### PR TITLE
[workflow] Add PyPI release workflow for pluto-ml

### DIFF
--- a/.github/workflows/pypi-publish-release.yml
+++ b/.github/workflows/pypi-publish-release.yml
@@ -1,0 +1,38 @@
+name: Publish Release to PyPI (pluto-ml)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  release-build-pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Get version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(awk -F '"' '/version =/ { print $2 }' pyproject.toml | head -n 1)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update version placeholders
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          sed -i "s/{{PLUTO_COMMIT_SHA}}/${{ github.sha }}/g" pluto/__init__.py
+          sed -i "s/__version__ = '.*'/__version__ = '${VERSION}'/g" pluto/__init__.py
+
+      - name: Build package
+        run: poetry build
+
+      - name: Publish to PyPI
+        run: poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary
- Add new GitHub workflow to publish release versions to PyPI as `pluto-ml`
- Uses version from `pyproject.toml` directly (no `.dev` suffix like nightly)
- Triggers on GitHub release publication or manual dispatch

## Test plan
- [ ] Verify workflow appears in GitHub Actions tab
- [ ] Test manual dispatch trigger
- [ ] Create a test release to verify end-to-end publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)