### PR TITLE
[sys][metrics] pluto network/IB metrics

### DIFF
--- a/pluto/sys.py
+++ b/pluto/sys.py
@@ -341,9 +341,7 @@ class System:
         ib_counters = self.get_infiniband_counters()
 
         # Combine all counters for rate calculation
-        all_counters: Dict[str, float] = {
-            k: float(v) for k, v in net_counters.items()
-        }
+        all_counters: Dict[str, float] = {k: float(v) for k, v in net_counters.items()}
         all_counters.update({k: float(v) for k, v in ib_counters.items()})
 
         # Calculate rates (bytes/sec, packets/sec)


### PR DESCRIPTION
Add rate calculation support for system metrics, similar to Prometheus rate() function:

- Add _calc_rate() helper to compute per-second rates between samples
- Add get_infiniband_counters() to read IB port counters from sysfs
- Emit rate metrics alongside raw counters in monitor():
  - sys/net.bytes_recv.rate, sys/net.bytes_sent.rate (bytes/sec)
  - sys/ib.<device>.<port>.rcv_bytes.rate (bytes/sec)
  - sys/ib.<device>.<port>.xmit_bytes.rate (bytes/sec)
  - sys/ib.<device>.<port>.rcv_packets.rate (packets/sec)
  - sys/ib.<device>.<port>.xmit_packets.rate (packets/sec)

This allows plotting instantaneous bandwidth similar to:
  rate(node_network_receive_bytes_total[5m]) in Prometheus

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)