### PR TITLE
[bugfix] Initialize _tmp attribute in Artifact.__init__

### DIFF
--- a/pluto/file.py
+++ b/pluto/file.py
@@ -93,6 +93,7 @@ class Artifact(File):
         **kwargs: Any,
     ) -> None:
         self._tmp: Optional[str] = None
+        self._ext: str = ''
         self._name = caption + f'.{uuid.uuid4()}' if caption else f'{uuid.uuid4()}'
         self._id = f'{uuid.uuid4()}{uuid.uuid4()}'.replace('-', '')
 


### PR DESCRIPTION
The Artifact class was missing the _tmp attribute initialization, causing "'Artifact' object has no attribute '_tmp'" errors when the _mkcopy method was called. Other File subclasses (Text, Image, Audio, Video) set _tmp in their load() methods, but Artifact needs it initialized in __init__ since the parent File.__init__ is not called until load() time.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)