### PR TITLE
[ci] Add Python 3.13 to CI test matrix

### DIFF
--- a/.github/workflows/pytest-smoke.yml
+++ b/.github/workflows/pytest-smoke.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         poetry-version: ["2.1.1"]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Extend pytest-smoke workflow to include Python 3.13 in the test matrix, ensuring compatibility testing with the latest Python version.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)