### PR TITLE
[env] [neptune] re-enable pluto signal handler on neptune disable

### DIFF
--- a/tests/test_multinode.py
+++ b/tests/test_multinode.py
@@ -313,9 +313,9 @@ class TestMultiNodeUsagePatterns:
             run.finish()
 
         # All should have the same server ID
-        assert all(sid == server_ids[0] for sid in server_ids), (
-            f'All ranks should log to same run, got IDs: {server_ids}'
-        )
+        assert all(
+            sid == server_ids[0] for sid in server_ids
+        ), f'All ranks should log to same run, got IDs: {server_ids}'
 
         # First should not be resumed, rest should be
         assert resumed_flags[0] is False

--- a/tests/test_neptune_compat.py
+++ b/tests/test_neptune_compat.py
@@ -1135,21 +1135,21 @@ class TestNeptuneCompatSignalHandlingTransparency:
             run = Run(experiment_name='signal-test')
 
             # Verify x_disable_signal_handlers is True when Neptune is enabled
-            assert captured_settings.get('x_disable_signal_handlers') is True, (
-                'x_disable_signal_handlers must be True when Neptune is enabled'
-            )
+            assert (
+                captured_settings.get('x_disable_signal_handlers') is True
+            ), 'x_disable_signal_handlers must be True when Neptune is enabled'
 
             # Verify signal handlers were NOT changed by Pluto
             current_sigint = signal.getsignal(signal.SIGINT)
             current_sigterm = signal.getsignal(signal.SIGTERM)
 
             # The handlers should be the same as before (Pluto didn't register)
-            assert current_sigint == initial_sigint, (
-                'SIGINT handler should not be changed by Pluto compat layer'
-            )
-            assert current_sigterm == initial_sigterm, (
-                'SIGTERM handler should not be changed by Pluto compat layer'
-            )
+            assert (
+                current_sigint == initial_sigint
+            ), 'SIGINT handler should not be changed by Pluto compat layer'
+            assert (
+                current_sigterm == initial_sigterm
+            ), 'SIGTERM handler should not be changed by Pluto compat layer'
 
             run.close()
 
@@ -1187,9 +1187,9 @@ class TestNeptuneCompatSignalHandlingTransparency:
 
             # Verify x_disable_signal_handlers is False when Neptune is disabled
             # (Pluto should handle signals since Neptune won't)
-            assert captured_settings.get('x_disable_signal_handlers') is False, (
-                'x_disable_signal_handlers must be False when Neptune is disabled'
-            )
+            assert (
+                captured_settings.get('x_disable_signal_handlers') is False
+            ), 'x_disable_signal_handlers must be False when Neptune is disabled'
 
             run.close()
 
@@ -1265,9 +1265,9 @@ class TestNeptuneCompatSignalHandlingTransparency:
             elapsed = time.time() - start
 
             # Should complete within timeout + buffer (not hang for 100s)
-            assert elapsed < 10, (
-                f'close() took {elapsed}s, should be < 10s (timeout should work)'
-            )
+            assert (
+                elapsed < 10
+            ), f'close() took {elapsed}s, should be < 10s (timeout should work)'
 
     def test_pluto_cleanup_silent_on_error(
         self, mock_neptune_backend, pluto_config_env
@@ -1376,17 +1376,17 @@ class TestNeptuneCompatSignalHandlingTransparency:
                 run = Run(experiment_name='atexit-test')
 
                 # Verify an atexit handler was registered
-                assert len(registered_handlers) > 0, (
-                    'atexit handler should be registered'
-                )
+                assert (
+                    len(registered_handlers) > 0
+                ), 'atexit handler should be registered'
 
                 # The handler should be the wrapper's cleanup method
                 handler_names = [
                     h.__name__ for h in registered_handlers if hasattr(h, '__name__')
                 ]
-                assert '_atexit_cleanup_pluto' in handler_names, (
-                    'atexit handler should be _atexit_cleanup_pluto'
-                )
+                assert (
+                    '_atexit_cleanup_pluto' in handler_names
+                ), 'atexit handler should be _atexit_cleanup_pluto'
 
                 run.close()
 
@@ -1413,9 +1413,9 @@ class TestNeptuneCompatSignalHandlingTransparency:
             elapsed = time.time() - start
 
             # Should complete quickly due to timeout
-            assert elapsed < 10, (
-                f'Context manager exit took {elapsed}s, should be < 10s'
-            )
+            assert (
+                elapsed < 10
+            ), f'Context manager exit took {elapsed}s, should be < 10s'
 
     def test_wrapper_closed_flag_prevents_double_cleanup(
         self, mock_neptune_backend, pluto_config_env
@@ -1444,6 +1444,6 @@ class TestNeptuneCompatSignalHandlingTransparency:
             run.__exit__(None, None, None)
 
             # Pluto finish should only be called once
-            assert finish_call_count == 1, (
-                f'Pluto finish called {finish_call_count} times, should be 1'
-            )
+            assert (
+                finish_call_count == 1
+            ), f'Pluto finish called {finish_call_count} times, should be 1'

--- a/tests/test_sync_process.py
+++ b/tests/test_sync_process.py
@@ -356,9 +356,9 @@ class TestSyncProcessShutdown:
         assert 'test_metric_gamma' in run.settings.meta
 
         # Verify _iface exists and would have been used for metadata
-        assert run._iface is not None, (
-            'ServerInterface must exist to register metric names with server'
-        )
+        assert (
+            run._iface is not None
+        ), 'ServerInterface must exist to register metric names with server'
 
         run.finish()
 


### PR DESCRIPTION
With neptune, Pluto's signal handlers were unconditionally disabled. This meant no signal handling occurred at all since Neptune wasn't initialized either.

Now signal handlers are conditionally enabled based on Neptune's state:
- Neptune enabled: Pluto signal handlers disabled (Neptune handles signals)
- Neptune disabled: Pluto signal handlers enabled (Pluto handles signals)

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)