### PR TITLE
[compat] wandb

### DIFF
--- a/.github/workflows/wandb-compat.yml
+++ b/.github/workflows/wandb-compat.yml
@@ -5,6 +5,11 @@ name: Wandb Compatibility Tests
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'pluto/compat/wandb/**'
+      - 'wandb/**'
   issue_comment:
     types: [created]
 
@@ -83,6 +88,34 @@ jobs:
         run: |
           set -euox pipefail
           poetry run pytest tests/test_wandb_visual_parity.py::TestPlutoShimSide -v -rs -s
+
+      - name: Install real wandb for coverage introspection
+        run: pip install wandb
+
+      - name: Run wandb coverage report (summary)
+        run: |
+          set -euox pipefail
+          poetry run python scripts/wandb_coverage.py --format summary
+
+      - name: Generate coverage reports
+        run: |
+          set -euox pipefail
+          poetry run python scripts/wandb_coverage.py --format markdown --output coverage-report.md
+          poetry run python scripts/wandb_coverage.py --format json --output coverage-report.json
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wandb-coverage-py${{ matrix.python-version }}
+          path: |
+            coverage-report.md
+            coverage-report.json
+
+      - name: Run wandb coverage tests
+        run: |
+          set -euox pipefail
+          poetry run pytest tests/test_wandb_coverage.py -v
 
       - name: Report test results
         if: always()

--- a/.github/workflows/wandb-compat.yml
+++ b/.github/workflows/wandb-compat.yml
@@ -1,0 +1,110 @@
+name: Wandb Compatibility Tests
+
+# This workflow tests the wandb-to-pluto compatibility layer.
+# It runs on manual trigger or when a maintainer comments /wandb on a PR.
+
+on:
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+jobs:
+  wandb-compatibility:
+    # Run on manual dispatch, or when someone comments /wandb on a PR
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/wandb'))
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+        poetry-version: ["2.1.1"]
+
+    steps:
+      - name: React to comment
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+      - name: Get PR head ref
+        if: github.event_name == 'issue_comment'
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('ref', pr.data.head.ref);
+            core.setOutput('sha', pr.data.head.sha);
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'issue_comment' && steps.pr.outputs.ref || '' }}
+
+      - name: "Setup Python, Poetry and Dependencies"
+        uses: packetcoders/action-setup-cache-python-poetry@v1.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          poetry-version: ${{ matrix.poetry-version }}
+          install-args: "--with dev"
+
+      - name: Install dependencies
+        run: |
+          set -euox pipefail
+          rm -rf .venv
+          poetry install --with dev --extras full
+
+      - name: Run wandb compatibility unit tests
+        run: |
+          set -euox pipefail
+          poetry run pytest tests/test_wandb_compat.py -v -rs -k "not test_table_from_dataframe"
+
+      - name: Run wandb env var fallback tests
+        run: |
+          set -euox pipefail
+          poetry run pytest tests/test_env_vars.py::TestWANDBApiKeyFallback -v -rs
+
+      - name: Run live pluto shim parity test
+        env:
+          PLUTO_API_TOKEN: ${{ secrets.MLOP_API_TOKEN }}
+        run: |
+          set -euox pipefail
+          poetry run pytest tests/test_wandb_visual_parity.py::TestPlutoShimSide -v -rs -s
+
+      - name: Report test results
+        if: always()
+        run: |
+          echo "Wandb compatibility tests completed"
+          echo "Python version: ${{ matrix.python-version }}"
+          echo "Status: ${{ job.status }}"
+
+  wandb-compat-status:
+    runs-on: ubuntu-latest
+    needs: [wandb-compatibility]
+    if: always() && github.event_name == 'issue_comment'
+    steps:
+      - name: Comment result on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const status = '${{ needs.wandb-compatibility.result }}';
+            const icon = status === 'success' ? '✅' : '❌';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `${icon} Wandb compatibility tests: **${status}**`
+            });

--- a/pluto/auth.py
+++ b/pluto/auth.py
@@ -37,6 +37,7 @@ def login(settings=None, retry=False):
         verify=True if not settings.insecure_disable_ssl else False,
         proxy=settings.http_proxy or settings.https_proxy or None,
     )
+    r = None
     try:
         r = client.post(
             url=settings.url_login,
@@ -48,6 +49,8 @@ def login(settings=None, retry=False):
         tlogger.warning(f'{tag}: server not reachable; reason: {e}')
         settings._auth = '_key'
     try:
+        if r is None:
+            raise RuntimeError('no response from server')
         tlogger.info(f'{tag}: logged in as {r.json()["organization"]["slug"]}')
         keyring.set_password(f'{settings.tag}', f'{settings.tag}', f'{settings._auth}')
         teardown_logger(tlogger)

--- a/pluto/compat/wandb/__init__.py
+++ b/pluto/compat/wandb/__init__.py
@@ -1,0 +1,467 @@
+"""wandb-compatible drop-in replacement backed by pluto.
+
+Usage:
+    Replace ``import wandb`` with ``import pluto.compat.wandb as wandb``
+    and your existing wandb code will route through pluto.
+
+Supported API:
+    - wandb.init(), wandb.log(), wandb.finish()
+    - wandb.watch(), wandb.unwatch()
+    - wandb.config, wandb.summary, wandb.run
+    - wandb.alert(), wandb.define_metric()
+    - wandb.Image, wandb.Audio, wandb.Video, wandb.Table, wandb.Histogram
+    - wandb.Html, wandb.Graph, wandb.Artifact, wandb.AlertLevel
+    - Context manager: ``with wandb.init() as run: ...``
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from .config import Config
+from .data_types import (
+    AlertLevel,
+    Artifact,
+    Audio,
+    Graph,
+    Histogram,
+    Html,
+    Image,
+    Table,
+    Video,
+)
+from .run import Run
+from .summary import Summary
+
+logger = logging.getLogger(f'{__name__.split(".")[0]}')
+tag = 'WandbCompat'
+
+__all__ = [
+    # Core API
+    'init',
+    'log',
+    'finish',
+    'watch',
+    'unwatch',
+    'alert',
+    'define_metric',
+    'save',
+    'restore',
+    'login',
+    'log_artifact',
+    'use_artifact',
+    'log_code',
+    'mark_preempting',
+    # Module-level state
+    'run',
+    'config',
+    'summary',
+    # Classes
+    'Run',
+    'Config',
+    'Settings',
+    'AlertLevel',
+    # Data types
+    'Image',
+    'Audio',
+    'Video',
+    'Table',
+    'Histogram',
+    'Html',
+    'Graph',
+    'Artifact',
+]
+
+# ---------------------------------------------------------------------------
+# Module-level state (mirrors wandb.run, wandb.config, wandb.summary)
+# ---------------------------------------------------------------------------
+
+run: Optional[Run] = None
+config: Config = Config()
+summary: Summary = Summary()
+
+
+class Settings:
+    """Stub for wandb.Settings — accepts kwargs and stores them."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def init(
+    entity: Optional[str] = None,
+    project: Optional[str] = None,
+    dir: Optional[str] = None,
+    id: Optional[str] = None,
+    name: Optional[str] = None,
+    notes: Optional[str] = None,
+    tags: Optional[Sequence[str]] = None,
+    config: Union[Dict[str, Any], str, None] = None,
+    config_exclude_keys: Optional[List[str]] = None,
+    config_include_keys: Optional[List[str]] = None,
+    allow_val_change: Optional[bool] = None,
+    group: Optional[str] = None,
+    job_type: Optional[str] = None,
+    mode: Optional[str] = None,
+    force: Optional[bool] = None,
+    anonymous: Optional[str] = None,
+    reinit: Optional[Union[bool, str]] = None,
+    resume: Optional[Union[bool, str]] = None,
+    resume_from: Optional[str] = None,
+    fork_from: Optional[str] = None,
+    save_code: Optional[bool] = None,
+    tensorboard: Optional[bool] = None,
+    sync_tensorboard: Optional[bool] = None,
+    monitor_gym: Optional[bool] = None,
+    settings: Optional[Any] = None,
+    **kwargs: Any,
+) -> Run:
+    """Initialize a new run. Compatible with ``wandb.init()``."""
+    import pluto as _pluto
+
+    global run
+    global summary
+
+    # If reinit, finish the previous run first
+    if run is not None:
+        if reinit:
+            try:
+                run.finish()
+            except Exception:
+                pass
+        else:
+            logger.debug('%s: init called with existing run, finishing previous', tag)
+            try:
+                run.finish()
+            except Exception:
+                pass
+
+    # Resolve project from env if not provided
+    project = (
+        project or os.environ.get('WANDB_PROJECT') or os.environ.get('PLUTO_PROJECT')
+    )
+
+    # Resolve mode
+    mode = mode or os.environ.get('WANDB_MODE', 'online')
+    if os.environ.get('WANDB_DISABLED', '').lower() in ('true', '1'):
+        mode = 'disabled'
+
+    # Resolve name from env if not provided
+    name = name or os.environ.get('WANDB_NAME')
+
+    # Resolve tags from env if not provided
+    if tags is None:
+        env_tags = os.environ.get('WANDB_TAGS')
+        if env_tags:
+            tags = [t.strip() for t in env_tags.split(',') if t.strip()]
+
+    # Filter config keys if requested
+    config_dict: Optional[Dict[str, Any]] = None
+    if config is not None:
+        if isinstance(config, dict):
+            config_dict = dict(config)
+        elif hasattr(config, '__dict__'):
+            config_dict = vars(config)
+        else:
+            config_dict = {}
+
+        if config_dict and config_include_keys:
+            config_dict = {
+                k: v for k, v in config_dict.items() if k in config_include_keys
+            }
+        if config_dict and config_exclude_keys:
+            config_dict = {
+                k: v for k, v in config_dict.items() if k not in config_exclude_keys
+            }
+
+    # Build pluto settings
+    pluto_settings: Dict[str, Any] = {}
+    if mode == 'disabled':
+        pluto_settings['mode'] = 'noop'
+    elif mode == 'offline':
+        pluto_settings['sync_process_enabled'] = False
+
+    # Map wandb run_id / resume
+    run_id = id
+    if resume in ('allow', 'must', 'auto', True) and id:
+        run_id = id
+
+    # Store wandb-only metadata in config
+    extra_config: Dict[str, Any] = {}
+    if notes:
+        extra_config['_wandb_notes'] = notes
+    if group:
+        extra_config['_wandb_group'] = group
+    if job_type:
+        extra_config['_wandb_job_type'] = job_type
+
+    merged_config = {**(config_dict or {}), **extra_config} or None
+
+    # Initialize pluto
+    try:
+        op = _pluto.init(
+            project=project,
+            name=name,
+            config=merged_config,
+            tags=list(tags) if tags else None,
+            dir=dir,
+            settings=pluto_settings or None,
+            run_id=run_id,
+        )
+    except Exception as e:
+        logger.warning('%s: pluto.init() failed (%s), creating disabled run', tag, e)
+        # Return a disabled run that no-ops everything
+        return _create_disabled_run(
+            name=name,
+            notes=notes,
+            group=group,
+            job_type=job_type,
+            config_dict=config_dict,
+        )
+
+    # Create the Run wrapper
+    _run = Run(
+        op=op,
+        name=name,
+        notes=notes,
+        group=group,
+        job_type=job_type,
+        mode=mode or 'online',
+    )
+
+    # Load config into the Config object
+    _run.config._load(config_dict)
+
+    # Set module-level state
+    run = _run
+
+    # Replace module-level config and summary proxies
+    _module = _get_module()
+    _module.config = _run.config
+    _module.summary = _run.summary
+
+    return _run
+
+
+def log(
+    data: Dict[str, Any],
+    step: Optional[int] = None,
+    commit: Optional[bool] = None,
+    sync: Optional[bool] = None,
+) -> None:
+    """Log metrics. Compatible with ``wandb.log()``."""
+    _require_run('log')
+    assert run is not None
+    run.log(data, step=step, commit=commit, sync=sync)
+
+
+def finish(
+    exit_code: Optional[int] = None,
+    quiet: Optional[bool] = None,
+) -> None:
+    """Finish the current run. Compatible with ``wandb.finish()``."""
+    global run
+
+    if run is not None:
+        run.finish(exit_code=exit_code, quiet=quiet)
+        run = None
+
+        # Reset module-level proxies
+        _module = _get_module()
+        _module.config = Config()
+        _module.summary = Summary()
+
+
+def watch(
+    models: Any = None,
+    criterion: Any = None,
+    log: Optional[str] = 'gradients',
+    log_freq: int = 1000,
+    idx: Optional[int] = None,
+    log_graph: bool = False,
+) -> None:
+    """Watch a model. Compatible with ``wandb.watch()``."""
+    _require_run('watch')
+    assert run is not None
+    run.watch(
+        models=models,
+        criterion=criterion,
+        log=log,
+        log_freq=log_freq,
+        idx=idx,
+        log_graph=log_graph,
+    )
+
+
+def unwatch(models: Any = None) -> None:
+    """Remove model watch hooks. Compatible with ``wandb.unwatch()``."""
+    if run is not None:
+        run.unwatch(models)
+
+
+def alert(
+    title: str = '',
+    text: str = '',
+    level: Optional[str] = None,
+    wait_duration: Optional[Union[int, float]] = None,
+) -> None:
+    """Send an alert. Compatible with ``wandb.alert()``."""
+    _require_run('alert')
+    assert run is not None
+    run.alert(title=title, text=text, level=level, wait_duration=wait_duration)
+
+
+def define_metric(
+    name: str,
+    step_metric: Optional[str] = None,
+    step_sync: Optional[bool] = None,
+    hidden: Optional[bool] = None,
+    summary: Optional[str] = None,
+    goal: Optional[str] = None,
+    overwrite: Optional[bool] = None,
+) -> Any:
+    """Define metric behavior. No-op in pluto compat layer."""
+    if run is not None:
+        return run.define_metric(
+            name,
+            step_metric=step_metric,
+            step_sync=step_sync,
+            hidden=hidden,
+            summary=summary,
+            goal=goal,
+            overwrite=overwrite,
+        )
+    from .run import _MetricStub
+
+    return _MetricStub(name)
+
+
+def save(
+    glob_str: Optional[str] = None,
+    base_path: Optional[str] = None,
+    policy: str = 'live',
+) -> None:
+    """Sync files. Not supported — no-op."""
+    logger.debug('%s: save is not supported', tag)
+
+
+def restore(
+    name: str = '',
+    run_path: Optional[str] = None,
+    replace: bool = False,
+    root: Optional[str] = None,
+) -> None:
+    """Restore a file. Not supported — no-op."""
+    logger.debug('%s: restore is not supported', tag)
+
+
+def log_artifact(
+    artifact_or_path: Any,
+    name: Optional[str] = None,
+    type: Optional[str] = None,
+    aliases: Optional[List[str]] = None,
+) -> Any:
+    """Log an artifact. Compatible with ``wandb.log_artifact()``."""
+    if run is not None:
+        return run.log_artifact(artifact_or_path, name=name, type=type, aliases=aliases)
+    logger.debug('%s: log_artifact called without active run', tag)
+    return artifact_or_path
+
+
+def use_artifact(
+    artifact_or_name: Any,
+    type: Optional[str] = None,
+) -> Any:
+    """Declare artifact as input. Not supported — no-op."""
+    logger.debug('%s: use_artifact is not supported', tag)
+    return artifact_or_name
+
+
+def log_code(
+    root: Optional[str] = None,
+    name: Optional[str] = None,
+    include_fn: Any = None,
+    exclude_fn: Any = None,
+) -> None:
+    """Save source code. Not supported — no-op."""
+    logger.debug('%s: log_code is not supported', tag)
+
+
+def mark_preempting() -> None:
+    """Mark run as preempted. No-op."""
+    logger.debug('%s: mark_preempting is a no-op', tag)
+
+
+def login(
+    anonymous: Optional[str] = None,
+    key: Optional[str] = None,
+    relogin: Optional[bool] = None,
+    host: Optional[str] = None,
+    force: Optional[bool] = None,
+    timeout: Optional[int] = None,
+    verify: bool = False,
+) -> bool:
+    """Login stub. Pluto uses its own auth (``pluto login``).
+
+    Returns True to indicate "logged in" so callers don't block.
+    """
+    logger.debug('%s: login is a no-op (use pluto login)', tag)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_run(fn_name: str) -> None:
+    if run is None:
+        raise RuntimeError(
+            f'wandb.{fn_name}() called before wandb.init(). Call wandb.init() first.'
+        )
+
+
+def _get_module() -> Any:
+    """Return this module object for setting module-level attributes."""
+    import sys
+
+    return sys.modules[__name__]
+
+
+def _create_disabled_run(
+    name: Optional[str] = None,
+    notes: Optional[str] = None,
+    group: Optional[str] = None,
+    job_type: Optional[str] = None,
+    config_dict: Optional[Dict[str, Any]] = None,
+) -> Run:
+    """Create a Run that wraps a no-op Op for disabled/error cases."""
+    global run
+
+    import pluto as _pluto
+
+    op = _pluto.init(project='disabled', settings={'mode': 'noop'})
+    _run = Run(
+        op=op,
+        name=name,
+        notes=notes,
+        group=group,
+        job_type=job_type,
+        mode='disabled',
+    )
+    if config_dict:
+        _run.config._load(config_dict)
+
+    run = _run
+
+    _module = _get_module()
+    _module.config = _run.config
+    _module.summary = _run.summary
+
+    return _run

--- a/pluto/compat/wandb/__init__.py
+++ b/pluto/compat/wandb/__init__.py
@@ -322,7 +322,7 @@ def define_metric(
     goal: Optional[str] = None,
     overwrite: Optional[bool] = None,
 ) -> Any:
-    """Define metric behavior. No-op in pluto compat layer."""
+    """Define metric behavior (aggregation, custom x-axis)."""
     if run is not None:
         return run.define_metric(
             name,

--- a/pluto/compat/wandb/__init__.py
+++ b/pluto/compat/wandb/__init__.py
@@ -344,6 +344,9 @@ def save(
     policy: str = 'live',
 ) -> None:
     """Sync files. Not supported — no-op."""
+    from ._coverage import warn_unsupported
+
+    warn_unsupported("wandb.save")
     logger.debug('%s: save is not supported', tag)
 
 
@@ -354,6 +357,9 @@ def restore(
     root: Optional[str] = None,
 ) -> None:
     """Restore a file. Not supported — no-op."""
+    from ._coverage import warn_unsupported
+
+    warn_unsupported("wandb.restore")
     logger.debug('%s: restore is not supported', tag)
 
 
@@ -375,6 +381,9 @@ def use_artifact(
     type: Optional[str] = None,
 ) -> Any:
     """Declare artifact as input. Not supported — no-op."""
+    from ._coverage import warn_unsupported
+
+    warn_unsupported("wandb.use_artifact")
     logger.debug('%s: use_artifact is not supported', tag)
     return artifact_or_name
 
@@ -386,11 +395,17 @@ def log_code(
     exclude_fn: Any = None,
 ) -> None:
     """Save source code. Not supported — no-op."""
+    from ._coverage import warn_unsupported
+
+    warn_unsupported("wandb.log_code")
     logger.debug('%s: log_code is not supported', tag)
 
 
 def mark_preempting() -> None:
     """Mark run as preempted. No-op."""
+    from ._coverage import warn_unsupported
+
+    warn_unsupported("wandb.mark_preempting")
     logger.debug('%s: mark_preempting is a no-op', tag)
 
 
@@ -407,6 +422,9 @@ def login(
 
     Returns True to indicate "logged in" so callers don't block.
     """
+    from ._coverage import warn_unsupported
+
+    warn_unsupported("wandb.login")
     logger.debug('%s: login is a no-op (use pluto login)', tag)
     return True
 

--- a/pluto/compat/wandb/__init__.py
+++ b/pluto/compat/wandb/__init__.py
@@ -134,8 +134,8 @@ def init(
             logger.debug('%s: init called with existing run, finishing previous', tag)
         try:
             run.finish()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug('%s: failed to finish previous run: %s', tag, e, exc_info=True)
 
     # Resolve project from env if not provided
     project = (

--- a/pluto/compat/wandb/_coverage.py
+++ b/pluto/compat/wandb/_coverage.py
@@ -1,0 +1,195 @@
+"""wandb API coverage registry and warning infrastructure.
+
+Tracks which wandb APIs are supported, partially supported, stubbed,
+or missing in the pluto compatibility layer. Emits user-visible warnings
+when unsupported APIs are called.
+"""
+
+import enum
+import warnings
+from dataclasses import dataclass
+from typing import Dict, Set
+
+
+class SupportLevel(enum.Enum):
+    """How well a wandb API is supported in the pluto compat layer."""
+
+    SUPPORTED = "supported"
+    PARTIAL = "partial"
+    STUB = "stub"
+    NOT_IMPLEMENTED = "not_implemented"
+    MISSING = "missing"
+
+
+@dataclass
+class ApiEntry:
+    """Registry entry for a single wandb API."""
+
+    level: SupportLevel
+    notes: str = ""
+
+
+class PlutoWandbCompatWarning(UserWarning):
+    """Warning emitted when unsupported wandb APIs are called.
+
+    Silence with:
+        warnings.filterwarnings("ignore", category=PlutoWandbCompatWarning)
+    """
+
+    pass
+
+
+# Set of API names that have already been warned about (once per process)
+_warned: Set[str] = set()
+
+
+def warn_unsupported(api_name: str) -> None:
+    """Issue a warning if *api_name* is a stub/unsupported/partial API.
+
+    Each API name is warned about at most once per process.
+    """
+    if api_name in _warned:
+        return
+
+    entry = WANDB_API_REGISTRY.get(api_name)
+    if entry is None:
+        return
+
+    msg: str | None = None
+    if entry.level == SupportLevel.STUB:
+        msg = f"{api_name}() is a no-op in the pluto wandb compatibility layer"
+    elif entry.level == SupportLevel.NOT_IMPLEMENTED:
+        msg = f"{api_name}() is not implemented in the pluto wandb compatibility layer"
+    elif entry.level == SupportLevel.PARTIAL:
+        msg = (
+            f"{api_name}() has limited support in the pluto wandb compatibility layer"
+        )
+        if entry.notes:
+            msg += f": {entry.notes}"
+
+    if msg is not None:
+        _warned.add(api_name)
+        warnings.warn(msg, PlutoWandbCompatWarning, stacklevel=3)
+
+
+def reset_warnings() -> None:
+    """Reset warned set — useful for testing."""
+    _warned.clear()
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+WANDB_API_REGISTRY: Dict[str, ApiEntry] = {
+    # ---- Top-level functions (from wandb.__all__) ----
+    "wandb.init": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.log": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.finish": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.watch": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.unwatch": ApiEntry(SupportLevel.STUB),
+    "wandb.alert": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.define_metric": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.save": ApiEntry(SupportLevel.STUB),
+    "wandb.restore": ApiEntry(SupportLevel.STUB),
+    "wandb.login": ApiEntry(
+        SupportLevel.PARTIAL,
+        notes="Always returns True; use pluto login",
+    ),
+    "wandb.log_artifact": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.use_artifact": ApiEntry(SupportLevel.STUB),
+    "wandb.log_code": ApiEntry(SupportLevel.STUB),
+    "wandb.mark_preempting": ApiEntry(SupportLevel.STUB),
+    "wandb.setup": ApiEntry(SupportLevel.MISSING),
+    "wandb.teardown": ApiEntry(SupportLevel.MISSING),
+    "wandb.attach": ApiEntry(SupportLevel.MISSING),
+    "wandb.sweep": ApiEntry(SupportLevel.MISSING),
+    "wandb.controller": ApiEntry(SupportLevel.MISSING),
+    "wandb.agent": ApiEntry(SupportLevel.MISSING),
+    "wandb.require": ApiEntry(SupportLevel.MISSING),
+    "wandb.jupyter": ApiEntry(SupportLevel.MISSING),
+    # Top-level classes / data types
+    "wandb.Run": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Config": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Settings": ApiEntry(SupportLevel.PARTIAL, notes="Accepts kwargs but no-op"),
+    "wandb.AlertLevel": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Image": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Audio": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Video": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Table": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Histogram": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Html": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Graph": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Artifact": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Api": ApiEntry(
+        SupportLevel.PARTIAL,
+        notes="Instantiation works but query methods raise NotImplementedError",
+    ),
+    # Module-level state
+    "wandb.run": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.config": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.summary": ApiEntry(SupportLevel.SUPPORTED),
+    # ---- wandb.Run public methods ----
+    "wandb.Run.log": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.finish": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.watch": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.unwatch": ApiEntry(SupportLevel.STUB),
+    "wandb.Run.alert": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.define_metric": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.save": ApiEntry(SupportLevel.STUB),
+    "wandb.Run.restore": ApiEntry(SupportLevel.STUB),
+    "wandb.Run.log_artifact": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.use_artifact": ApiEntry(SupportLevel.STUB),
+    "wandb.Run.log_code": ApiEntry(SupportLevel.STUB),
+    "wandb.Run.mark_preempting": ApiEntry(SupportLevel.STUB),
+    "wandb.Run.status": ApiEntry(SupportLevel.PARTIAL, notes="Always returns synced"),
+    # Run properties
+    "wandb.Run.id": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.name": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.entity": ApiEntry(
+        SupportLevel.PARTIAL, notes="Always returns empty string"
+    ),
+    "wandb.Run.project": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.group": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.job_type": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.tags": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.notes": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.config": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.summary": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.url": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.dir": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.step": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.offline": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.disabled": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.resumed": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.path": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.settings": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.start_time": ApiEntry(SupportLevel.SUPPORTED),
+    "wandb.Run.sweep_id": ApiEntry(SupportLevel.PARTIAL, notes="Always returns None"),
+    "wandb.Run.project_url": ApiEntry(SupportLevel.SUPPORTED),
+    # Run methods not in our shim
+    "wandb.Run.link_artifact": ApiEntry(SupportLevel.MISSING),
+    "wandb.Run.use_model": ApiEntry(SupportLevel.MISSING),
+    "wandb.Run.link_model": ApiEntry(SupportLevel.MISSING),
+    "wandb.Run.log_model": ApiEntry(SupportLevel.MISSING),
+    "wandb.Run.join": ApiEntry(SupportLevel.MISSING),
+    "wandb.Run.to_html": ApiEntry(SupportLevel.MISSING),
+    "wandb.Run.display": ApiEntry(SupportLevel.MISSING),
+    "wandb.Run.get_url": ApiEntry(SupportLevel.MISSING),
+    "wandb.Run.get_project_url": ApiEntry(SupportLevel.MISSING),
+    # ---- wandb.plot functions ----
+    "wandb.plot.line_series": ApiEntry(SupportLevel.STUB),
+    "wandb.plot.scatter": ApiEntry(SupportLevel.STUB),
+    "wandb.plot.bar": ApiEntry(SupportLevel.STUB),
+    "wandb.plot.histogram": ApiEntry(SupportLevel.STUB),
+    "wandb.plot.line": ApiEntry(SupportLevel.STUB),
+    "wandb.plot.confusion_matrix": ApiEntry(SupportLevel.STUB),
+    "wandb.plot.roc_curve": ApiEntry(SupportLevel.STUB),
+    "wandb.plot.pr_curve": ApiEntry(SupportLevel.STUB),
+    # ---- wandb.Api methods ----
+    "wandb.Api.runs": ApiEntry(SupportLevel.NOT_IMPLEMENTED),
+    "wandb.Api.run": ApiEntry(SupportLevel.NOT_IMPLEMENTED),
+    "wandb.Api.artifact": ApiEntry(SupportLevel.NOT_IMPLEMENTED),
+    "wandb.Api.artifacts": ApiEntry(SupportLevel.NOT_IMPLEMENTED),
+    "wandb.Api.sweep": ApiEntry(SupportLevel.NOT_IMPLEMENTED),
+}

--- a/pluto/compat/wandb/config.py
+++ b/pluto/compat/wandb/config.py
@@ -1,0 +1,129 @@
+"""wandb.config-compatible dict-like configuration object."""
+
+import logging
+from typing import Any, Dict, Iterator, Optional
+
+logger = logging.getLogger(f'{__name__.split(".")[0]}')
+tag = 'WandbCompat.Config'
+
+
+class Config:
+    """A dict-like configuration object compatible with wandb.config.
+
+    Supports attribute access, dict access, and syncs mutations to pluto
+    via op.update_config().
+    """
+
+    def __init__(self, op: Optional[Any] = None) -> None:
+        # Use object.__setattr__ to avoid triggering our __setattr__
+        object.__setattr__(self, '_op', op)
+        object.__setattr__(self, '_data', {})
+        object.__setattr__(self, '_allow_val_change', True)
+
+    def _load(self, data: Optional[Dict[str, Any]]) -> None:
+        if data:
+            object.__getattribute__(self, '_data').update(data)
+
+    def _sync(self, updates: Dict[str, Any]) -> None:
+        op = object.__getattribute__(self, '_op')
+        if op is not None:
+            try:
+                op.update_config(updates)
+            except Exception as e:
+                logger.debug('%s: failed to sync config: %s', tag, e)
+
+    # -- Attribute access --
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        if key.startswith('_'):
+            object.__setattr__(self, key, value)
+        else:
+            self[key] = value
+
+    def __getattr__(self, key: str) -> Any:
+        data = object.__getattribute__(self, '_data')
+        try:
+            return data[key]
+        except KeyError:
+            raise AttributeError(f"'Config' object has no attribute '{key}'")
+
+    def __delattr__(self, key: str) -> None:
+        data = object.__getattribute__(self, '_data')
+        if key in data:
+            del data[key]
+        else:
+            raise AttributeError(f"'Config' object has no attribute '{key}'")
+
+    # -- Dict access --
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        data = object.__getattribute__(self, '_data')
+        data[key] = value
+        self._sync({key: value})
+
+    def __getitem__(self, key: str) -> Any:
+        return object.__getattribute__(self, '_data')[key]
+
+    def __delitem__(self, key: str) -> None:
+        del object.__getattribute__(self, '_data')[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in object.__getattribute__(self, '_data')
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(object.__getattribute__(self, '_data'))
+
+    def __len__(self) -> int:
+        return len(object.__getattribute__(self, '_data'))
+
+    def __repr__(self) -> str:
+        return repr(object.__getattribute__(self, '_data'))
+
+    def __bool__(self) -> bool:
+        return bool(object.__getattribute__(self, '_data'))
+
+    # -- Dict-like methods --
+
+    def keys(self):
+        return object.__getattribute__(self, '_data').keys()
+
+    def values(self):
+        return object.__getattribute__(self, '_data').values()
+
+    def items(self):
+        return object.__getattribute__(self, '_data').items()
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return object.__getattribute__(self, '_data').get(key, default)
+
+    def update(
+        self,
+        d: Any = None,
+        allow_val_change: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Update config with a dict, namespace, or keyword arguments."""
+        if d is not None:
+            # Support argparse namespaces
+            if hasattr(d, '__dict__') and not isinstance(d, dict):
+                d = vars(d)
+            if isinstance(d, dict):
+                object.__getattribute__(self, '_data').update(d)
+                self._sync(d)
+        if kwargs:
+            object.__getattribute__(self, '_data').update(kwargs)
+            self._sync(kwargs)
+
+    def setdefaults(self, d: Dict[str, Any]) -> None:
+        """Set defaults — only sets keys that are not already present."""
+        data = object.__getattribute__(self, '_data')
+        updates = {}
+        for k, v in d.items():
+            if k not in data:
+                data[k] = v
+                updates[k] = v
+        if updates:
+            self._sync(updates)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return dict(object.__getattribute__(self, '_data'))

--- a/pluto/compat/wandb/config.py
+++ b/pluto/compat/wandb/config.py
@@ -18,7 +18,6 @@ class Config:
         # Use object.__setattr__ to avoid triggering our __setattr__
         object.__setattr__(self, '_op', op)
         object.__setattr__(self, '_data', {})
-        object.__setattr__(self, '_allow_val_change', True)
 
     def _load(self, data: Optional[Dict[str, Any]]) -> None:
         if data:

--- a/pluto/compat/wandb/config.py
+++ b/pluto/compat/wandb/config.py
@@ -50,6 +50,7 @@ class Config:
         data = object.__getattribute__(self, '_data')
         if key in data:
             del data[key]
+            logger.debug('%s: config key %r deleted locally (not synced)', tag, key)
         else:
             raise AttributeError(f"'Config' object has no attribute '{key}'")
 
@@ -65,6 +66,7 @@ class Config:
 
     def __delitem__(self, key: str) -> None:
         del object.__getattribute__(self, '_data')[key]
+        logger.debug('%s: config key %r deleted locally (not synced)', tag, key)
 
     def __contains__(self, key: object) -> bool:
         return key in object.__getattribute__(self, '_data')

--- a/pluto/compat/wandb/config.py
+++ b/pluto/compat/wandb/config.py
@@ -98,7 +98,6 @@ class Config:
     def update(
         self,
         d: Any = None,
-        allow_val_change: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         """Update config with a dict, namespace, or keyword arguments."""

--- a/pluto/compat/wandb/data_types.py
+++ b/pluto/compat/wandb/data_types.py
@@ -34,7 +34,6 @@ class Image:
         self.data_or_path = data_or_path
         self.caption = caption
         self._mode = mode
-        self._grouping = grouping
 
     def _to_pluto(self) -> Any:
         from pluto.file import Image as PlutoImage
@@ -161,7 +160,7 @@ class Histogram:
 
         if self.np_histogram is not None:
             # np_histogram is a tuple of (values, bin_edges)
-            return PlutoHistogram(data=self.np_histogram, bins=self.np_histogram)
+            return PlutoHistogram(data=self.np_histogram, bins=self.np_histogram[1])
         if self.sequence is not None:
             return PlutoHistogram(data=self.sequence, bins=self.num_bins)
         return PlutoHistogram(data=[0], bins=1)

--- a/pluto/compat/wandb/data_types.py
+++ b/pluto/compat/wandb/data_types.py
@@ -1,0 +1,311 @@
+"""wandb-compatible data type wrappers that convert to pluto equivalents.
+
+Each class accepts wandb-style constructor arguments and provides a
+_to_pluto() method that returns the corresponding pluto type.
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(f'{__name__.split(".")[0]}')
+tag = 'WandbCompat.DataTypes'
+
+
+class Image:
+    """wandb.Image-compatible wrapper.
+
+    Accepts the same constructor args as wandb.Image and converts to
+    pluto.file.Image via _to_pluto().
+    """
+
+    def __init__(
+        self,
+        data_or_path: Any = None,
+        mode: Optional[str] = None,
+        caption: Optional[str] = None,
+        grouping: Optional[int] = None,
+        classes: Any = None,
+        boxes: Any = None,
+        masks: Any = None,
+        file_type: Optional[str] = None,
+        normalize: bool = True,
+    ) -> None:
+        self.data_or_path = data_or_path
+        self.caption = caption
+        self._mode = mode
+        self._grouping = grouping
+
+    def _to_pluto(self) -> Any:
+        from pluto.file import Image as PlutoImage
+
+        return PlutoImage(data=self.data_or_path, caption=self.caption)
+
+
+class Audio:
+    """wandb.Audio-compatible wrapper."""
+
+    def __init__(
+        self,
+        data_or_path: Any = None,
+        sample_rate: Optional[int] = None,
+        caption: Optional[str] = None,
+    ) -> None:
+        self.data_or_path = data_or_path
+        self.sample_rate = sample_rate
+        self.caption = caption
+
+    def _to_pluto(self) -> Any:
+        from pluto.file import Audio as PlutoAudio
+
+        return PlutoAudio(
+            data=self.data_or_path,
+            sample_rate=self.sample_rate,
+            caption=self.caption,
+        )
+
+
+class Video:
+    """wandb.Video-compatible wrapper."""
+
+    def __init__(
+        self,
+        data_or_path: Any = None,
+        caption: Optional[str] = None,
+        fps: Optional[int] = None,
+        format: Optional[str] = None,
+    ) -> None:
+        self.data_or_path = data_or_path
+        self.caption = caption
+        self.fps = fps
+        self.format = format
+
+    def _to_pluto(self) -> Any:
+        from pluto.file import Video as PlutoVideo
+
+        return PlutoVideo(
+            data=self.data_or_path,
+            fps=self.fps,
+            caption=self.caption,
+            format=self.format,
+        )
+
+
+class Table:
+    """wandb.Table-compatible wrapper."""
+
+    MAX_ROWS = 10_000
+    MAX_ARTIFACT_ROWS = 200_000
+
+    def __init__(
+        self,
+        columns: Optional[List[str]] = None,
+        data: Optional[List[List[Any]]] = None,
+        rows: Optional[List[List[Any]]] = None,
+        dataframe: Any = None,
+        dtype: Any = None,
+        optional: Any = True,
+        allow_mixed_types: bool = False,
+    ) -> None:
+        self.columns = columns or []
+        self._data: List[List[Any]] = data or rows or []
+        self._dataframe = dataframe
+
+    def add_data(self, *row: Any) -> None:
+        self._data.append(list(row))
+
+    def add_column(self, name: str, data: List[Any]) -> None:
+        self.columns.append(name)
+        for i, val in enumerate(data):
+            if i < len(self._data):
+                self._data[i].append(val)
+            else:
+                self._data.append([val])
+
+    def get_column(self, name: str, convert_to: Optional[str] = None) -> List[Any]:
+        if name in self.columns:
+            idx = self.columns.index(name)
+            return [row[idx] for row in self._data if idx < len(row)]
+        return []
+
+    def _to_pluto(self) -> Any:
+        from pluto.data import Table as PlutoTable
+
+        if self._dataframe is not None:
+            return PlutoTable(
+                data=None,
+                dataframe=self._dataframe,
+                columns=self.columns or None,
+            )
+        return PlutoTable(
+            data=self._data,
+            columns=self.columns or None,
+        )
+
+
+class Histogram:
+    """wandb.Histogram-compatible wrapper."""
+
+    def __init__(
+        self,
+        sequence: Optional[Any] = None,
+        np_histogram: Optional[Any] = None,
+        num_bins: int = 64,
+    ) -> None:
+        self.sequence = sequence
+        self.np_histogram = np_histogram
+        self.num_bins = num_bins
+
+    def _to_pluto(self) -> Any:
+        from pluto.data import Histogram as PlutoHistogram
+
+        if self.np_histogram is not None:
+            # np_histogram is a tuple of (values, bin_edges)
+            return PlutoHistogram(data=self.np_histogram, bins=self.np_histogram)
+        if self.sequence is not None:
+            return PlutoHistogram(data=self.sequence, bins=self.num_bins)
+        return PlutoHistogram(data=[0], bins=1)
+
+
+class Html:
+    """wandb.Html-compatible wrapper. Maps to pluto.file.Text."""
+
+    def __init__(
+        self,
+        data: Any = None,
+        inject: bool = True,
+    ) -> None:
+        if hasattr(data, 'read'):
+            self._html = data.read()
+        elif isinstance(data, str) and os.path.isfile(data):
+            with open(data) as f:
+                self._html = f.read()
+        else:
+            self._html = str(data) if data is not None else ''
+
+    def _to_pluto(self) -> Any:
+        from pluto.file import Text as PlutoText
+
+        return PlutoText(data=self._html)
+
+
+class Graph:
+    """wandb.Graph-compatible wrapper."""
+
+    def __init__(self) -> None:
+        self._nodes: List[Any] = []
+        self._edges: List[Any] = []
+
+    def _to_pluto(self) -> Any:
+        from pluto.data import Graph as PlutoGraph
+
+        data: Dict[str, Any] = {'nodes': {}, 'edges': {}}
+        for i, node in enumerate(self._nodes):
+            name = getattr(node, 'name', str(i))
+            data['nodes'][name] = {}
+        for edge in self._edges:
+            src = edge[0] if isinstance(edge, (list, tuple)) else str(edge)
+            dst = edge[1] if isinstance(edge, (list, tuple)) else str(edge)
+            data['edges'][(src, dst)] = {}
+        return PlutoGraph(data=data)
+
+
+class Artifact:
+    """wandb.Artifact-compatible wrapper for file collections.
+
+    wandb's Artifact is a versioned collection of files. Pluto's Artifact is
+    a single file. This wrapper collects files and logs each individually
+    when log_artifact() is called.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        type: str,
+        description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        incremental: bool = False,
+        use_as: Optional[str] = None,
+    ) -> None:
+        self.name = name
+        self.type = type
+        self.description = description
+        self.metadata = metadata or {}
+        self._files: List[Dict[str, Any]] = []
+
+    def add_file(
+        self,
+        local_path: str,
+        name: Optional[str] = None,
+        is_tmp: bool = False,
+        skip_cache: bool = False,
+        policy: str = 'mutable',
+    ) -> 'Artifact':
+        self._files.append(
+            {
+                'path': local_path,
+                'name': name or os.path.basename(local_path),
+            }
+        )
+        return self
+
+    def add_dir(
+        self,
+        local_path: str,
+        name: Optional[str] = None,
+        skip_cache: bool = False,
+        policy: str = 'mutable',
+    ) -> 'Artifact':
+        for root, _dirs, files in os.walk(local_path):
+            for f in files:
+                fpath = os.path.join(root, f)
+                rel = os.path.relpath(fpath, local_path)
+                if name:
+                    rel = os.path.join(name, rel)
+                self._files.append({'path': fpath, 'name': rel})
+        return self
+
+    def add_reference(
+        self,
+        uri: str,
+        name: Optional[str] = None,
+        checksum: bool = True,
+        max_objects: Optional[int] = None,
+    ) -> 'Artifact':
+        logger.debug('%s: add_reference is not supported, ignoring', tag)
+        return self
+
+    def _to_pluto_files(self) -> List[Any]:
+        """Convert collected files to pluto Artifact objects."""
+        from pluto.file import Artifact as PlutoArtifact
+
+        result = []
+        for entry in self._files:
+            result.append(
+                PlutoArtifact(
+                    data=entry['path'],
+                    caption=entry['name'],
+                    metadata=self.metadata,
+                )
+            )
+        return result
+
+    # Stubs for download/verify (not supported)
+    def download(self, root: Optional[str] = None, **kwargs: Any) -> str:
+        logger.debug('%s: download is not supported', tag)
+        return root or '.'
+
+    def verify(self, root: Optional[str] = None) -> bool:
+        logger.debug('%s: verify is not supported', tag)
+        return True
+
+    def new_draft(self) -> 'Artifact':
+        return self
+
+
+class AlertLevel:
+    """wandb.AlertLevel-compatible enum."""
+
+    INFO = 'INFO'
+    WARN = 'WARN'
+    ERROR = 'ERROR'

--- a/pluto/compat/wandb/data_types.py
+++ b/pluto/compat/wandb/data_types.py
@@ -6,10 +6,27 @@ _to_pluto() method that returns the corresponding pluto type.
 
 import logging
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(f'{__name__.split(".")[0]}')
 tag = 'WandbCompat.DataTypes'
+
+
+def _validate_path(path: str, base_dir: Optional[str] = None) -> str:
+    """Resolve *path* and reject path-traversal attempts.
+
+    If *base_dir* is given the resolved path must be inside it.
+    Raises ``ValueError`` on ``..`` components or escapes.
+    """
+    resolved = Path(path).resolve()
+    if '..' in Path(path).parts:
+        raise ValueError(f'path traversal not allowed: {path}')
+    if base_dir is not None:
+        base = Path(base_dir).resolve()
+        if not str(resolved).startswith(str(base) + os.sep) and resolved != base:
+            raise ValueError(f'path {path} escapes base directory {base_dir}')
+    return str(resolved)
 
 
 class Image:
@@ -168,6 +185,7 @@ class Html:
         if hasattr(data, 'read'):
             self._html = data.read()
         elif isinstance(data, str) and os.path.isfile(data):
+            _validate_path(data)
             with open(data) as f:
                 self._html = f.read()
         else:
@@ -229,6 +247,7 @@ class Artifact:
         skip_cache: bool = False,
         policy: str = 'mutable',
     ) -> 'Artifact':
+        _validate_path(local_path)
         self._files.append(
             {
                 'path': local_path,
@@ -244,10 +263,12 @@ class Artifact:
         skip_cache: bool = False,
         policy: str = 'mutable',
     ) -> 'Artifact':
-        for root, _dirs, files in os.walk(local_path):
+        validated = _validate_path(local_path)
+        for root, _dirs, files in os.walk(validated):
             for f in files:
                 fpath = os.path.join(root, f)
-                rel = os.path.relpath(fpath, local_path)
+                _validate_path(fpath, base_dir=validated)
+                rel = os.path.relpath(fpath, validated)
                 if name:
                     rel = os.path.join(name, rel)
                 self._files.append({'path': fpath, 'name': rel})

--- a/pluto/compat/wandb/data_types.py
+++ b/pluto/compat/wandb/data_types.py
@@ -24,12 +24,6 @@ class Image:
         data_or_path: Any = None,
         mode: Optional[str] = None,
         caption: Optional[str] = None,
-        grouping: Optional[int] = None,
-        classes: Any = None,
-        boxes: Any = None,
-        masks: Any = None,
-        file_type: Optional[str] = None,
-        normalize: bool = True,
     ) -> None:
         self.data_or_path = data_or_path
         self.caption = caption
@@ -102,9 +96,6 @@ class Table:
         data: Optional[List[List[Any]]] = None,
         rows: Optional[List[List[Any]]] = None,
         dataframe: Any = None,
-        dtype: Any = None,
-        optional: Any = True,
-        allow_mixed_types: bool = False,
     ) -> None:
         self.columns = columns or []
         self._data: List[List[Any]] = data or rows or []
@@ -223,8 +214,6 @@ class Artifact:
         type: str,
         description: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
-        incremental: bool = False,
-        use_as: Optional[str] = None,
     ) -> None:
         self.name = name
         self.type = type
@@ -268,8 +257,6 @@ class Artifact:
         self,
         uri: str,
         name: Optional[str] = None,
-        checksum: bool = True,
-        max_objects: Optional[int] = None,
     ) -> 'Artifact':
         logger.debug('%s: add_reference is not supported, ignoring', tag)
         return self

--- a/pluto/compat/wandb/dual.py
+++ b/pluto/compat/wandb/dual.py
@@ -1,0 +1,312 @@
+"""Dual-logging mode: log to both real wandb AND pluto simultaneously.
+
+Activated by setting ``PLUTO_WANDB_MODE=dual``.  Real wandb is the
+primary system; pluto mirrors scalar metrics, config, and lifecycle
+events.  If pluto fails at any point, wandb continues unaffected.
+
+Rich data types (Image, Table, Histogram, etc.) are sent to real
+wandb only — pluto receives the scalar subset.
+"""
+
+import logging
+import threading
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger('pluto')
+tag = 'WandbDual'
+
+
+class DualRun:
+    """Wraps a real wandb.Run *and* a pluto Op, forwarding to both.
+
+    Attribute access falls through to the real wandb Run, so the full
+    wandb API is available.  Only the core logging/lifecycle methods
+    are intercepted to also push data to pluto.
+    """
+
+    def __init__(self, wandb_run: Any, pluto_op: Any) -> None:
+        # Use object.__setattr__ to avoid triggering __setattr__
+        object.__setattr__(self, '_wandb_run', wandb_run)
+        object.__setattr__(self, '_pluto_op', pluto_op)
+        object.__setattr__(self, '_pluto_finished', False)
+        object.__setattr__(self, '_lock', threading.Lock())
+
+    # -- Core methods (dual-logged) ------------------------------------
+
+    def log(
+        self,
+        data: Dict[str, Any],
+        step: Optional[int] = None,
+        commit: Optional[bool] = None,
+        sync: Optional[bool] = None,
+    ) -> None:
+        """Log to real wandb, then mirror scalars to pluto."""
+        self._wandb_run.log(data, step=step, commit=commit, sync=sync)
+        self._mirror_log(data, step=step)
+
+    def finish(
+        self,
+        exit_code: Optional[int] = None,
+        quiet: Optional[bool] = None,
+    ) -> None:
+        """Finish both runs (pluto first, then wandb)."""
+        self._finish_pluto()
+        self._wandb_run.finish(exit_code=exit_code, quiet=quiet)
+
+    def watch(
+        self,
+        models: Any = None,
+        criterion: Any = None,
+        log: Optional[str] = 'gradients',
+        log_freq: int = 1000,
+        idx: Optional[int] = None,
+        log_graph: bool = False,
+    ) -> None:
+        """Watch model in both systems."""
+        self._wandb_run.watch(
+            models, criterion=criterion, log=log,
+            log_freq=log_freq, idx=idx, log_graph=log_graph,
+        )
+        if models is not None and self._pluto_op:
+            try:
+                model_list = (
+                    models if isinstance(models, (list, tuple))
+                    else [models]
+                )
+                for model in model_list:
+                    self._pluto_op.watch(model, log_freq=log_freq)
+            except Exception as e:
+                logger.debug('%s: pluto watch failed: %s', tag, e)
+
+    def unwatch(self, models: Any = None) -> None:
+        self._wandb_run.unwatch(models)
+
+    # -- Config mirroring ----------------------------------------------
+
+    @property
+    def config(self) -> Any:
+        return self._wandb_run.config
+
+    @config.setter
+    def config(self, value: Any) -> None:
+        self._wandb_run.config = value
+        if self._pluto_op and isinstance(value, dict):
+            try:
+                self._pluto_op.update_config(value)
+            except Exception as e:
+                logger.debug('%s: pluto config update failed: %s', tag, e)
+
+    @property
+    def summary(self) -> Any:
+        return self._wandb_run.summary
+
+    # -- Context manager -----------------------------------------------
+
+    def __enter__(self) -> 'DualRun':
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        exit_code = 1 if exc_type else 0
+        self.finish(exit_code=exit_code)
+
+    # -- Transparent forwarding ----------------------------------------
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wandb_run, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == 'config':
+            # Use the property setter
+            type(self).config.fset(self, value)  # type: ignore[union-attr]
+            return
+        # Forward attribute sets to real wandb run
+        setattr(self._wandb_run, name, value)
+
+    def __repr__(self) -> str:
+        return f'<DualRun wandb={self._wandb_run!r}>'
+
+    # -- Internal helpers ----------------------------------------------
+
+    def _mirror_log(
+        self,
+        data: Dict[str, Any],
+        step: Optional[int] = None,
+    ) -> None:
+        """Mirror scalar values from a log() call to pluto."""
+        if not self._pluto_op:
+            return
+        try:
+            scalars = _extract_scalars(data)
+            if scalars:
+                self._pluto_op.log(scalars, step=step)
+        except Exception as e:
+            logger.debug('%s: pluto log failed: %s', tag, e)
+
+    def _finish_pluto(self) -> None:
+        """Finish the pluto run (at most once, non-blocking)."""
+        with self._lock:
+            if self._pluto_finished or not self._pluto_op:
+                return
+            object.__setattr__(self, '_pluto_finished', True)
+        try:
+            self._pluto_op.finish()
+        except Exception as e:
+            logger.debug('%s: pluto finish failed: %s', tag, e)
+
+
+def _extract_scalars(
+    data: Dict[str, Any],
+    prefix: str = '',
+) -> Dict[str, Any]:
+    """Recursively extract scalar values from a log dict.
+
+    Nested dicts are flattened with '/' separator.  Non-scalar values
+    (wandb.Image, wandb.Table, etc.) are skipped — they go to real
+    wandb only.
+    """
+    scalars: Dict[str, Any] = {}
+    for k, v in data.items():
+        key = f'{prefix}/{k}' if prefix else k
+        if isinstance(v, dict):
+            scalars.update(_extract_scalars(v, prefix=key))
+        elif isinstance(v, (int, float)):
+            scalars[key] = v
+        elif isinstance(v, bool):
+            scalars[key] = int(v)
+        # Everything else (images, tables, strings, etc.) is skipped
+    return scalars
+
+
+def setup_dual(
+    wandb_module: Any,
+    real_wandb: Any,
+) -> None:
+    """Install dual-logging wrappers on the wandb module.
+
+    Called from ``wandb/__init__.py`` when ``PLUTO_WANDB_MODE=dual``.
+    Replaces ``init``, ``log``, ``finish``, and ``watch`` with
+    versions that forward to both real wandb and pluto.
+    """
+    import pluto as _pluto
+
+    # Module-level state
+    _state: Dict[str, Any] = {'run': None}
+
+    def dual_init(
+        *,
+        entity: Optional[str] = None,
+        project: Optional[str] = None,
+        dir: Optional[str] = None,
+        id: Optional[str] = None,
+        name: Optional[str] = None,
+        notes: Optional[str] = None,
+        tags: Any = None,
+        config: Any = None,
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> DualRun:
+        """Initialize both real wandb and pluto runs."""
+        # Finish previous dual run if any
+        if _state['run'] is not None:
+            try:
+                _state['run'].finish()
+            except Exception:
+                pass
+
+        # Real wandb init (always — this is the primary)
+        wandb_run = real_wandb.init(
+            entity=entity, project=project, dir=dir,
+            id=id, name=name, notes=notes, tags=tags,
+            config=config, mode=mode, **kwargs,
+        )
+
+        # Pluto init (best effort)
+        pluto_op = None
+        try:
+            # Extract config dict for pluto
+            pluto_config = None
+            if config is not None:
+                if isinstance(config, dict):
+                    pluto_config = config
+                elif hasattr(config, '__dict__'):
+                    pluto_config = vars(config)
+
+            pluto_op = _pluto.init(
+                project=project,
+                name=name,
+                config=pluto_config,
+                tags=list(tags) if tags else None,
+                dir=dir,
+                run_id=id,
+            )
+            logger.info(
+                '%s: dual logging active — wandb + pluto', tag,
+            )
+        except Exception as e:
+            logger.warning(
+                '%s: pluto init failed (%s), continuing with '
+                'wandb-only logging',
+                tag, e,
+            )
+
+        dual_run = DualRun(wandb_run, pluto_op)
+        _state['run'] = dual_run
+
+        # Update module-level state
+        wandb_module.run = dual_run
+
+        return dual_run
+
+    def dual_log(
+        data: Dict[str, Any],
+        step: Optional[int] = None,
+        commit: Optional[bool] = None,
+        sync: Optional[bool] = None,
+    ) -> None:
+        """Log to both systems via the active dual run."""
+        if _state['run'] is not None:
+            _state['run'].log(
+                data, step=step, commit=commit, sync=sync,
+            )
+        else:
+            real_wandb.log(
+                data, step=step, commit=commit, sync=sync,
+            )
+
+    def dual_finish(
+        exit_code: Optional[int] = None,
+        quiet: Optional[bool] = None,
+    ) -> None:
+        """Finish both runs."""
+        if _state['run'] is not None:
+            _state['run'].finish(
+                exit_code=exit_code, quiet=quiet,
+            )
+            _state['run'] = None
+            wandb_module.run = None
+
+    def dual_watch(
+        models: Any = None,
+        criterion: Any = None,
+        log: Optional[str] = 'gradients',
+        log_freq: int = 1000,
+        idx: Optional[int] = None,
+        log_graph: bool = False,
+    ) -> None:
+        """Watch model in both systems."""
+        if _state['run'] is not None:
+            _state['run'].watch(
+                models, criterion=criterion, log=log,
+                log_freq=log_freq, idx=idx, log_graph=log_graph,
+            )
+        else:
+            real_wandb.watch(
+                models, criterion=criterion, log=log,
+                log_freq=log_freq, idx=idx, log_graph=log_graph,
+            )
+
+    # Install wrappers
+    wandb_module.init = dual_init
+    wandb_module.log = dual_log
+    wandb_module.finish = dual_finish
+    wandb_module.watch = dual_watch

--- a/pluto/compat/wandb/run.py
+++ b/pluto/compat/wandb/run.py
@@ -1,6 +1,7 @@
 """wandb.Run-compatible wrapper around pluto.Op."""
 
 import logging
+import time as _time
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 from .config import Config
@@ -61,6 +62,7 @@ class Run:
         self._pending_data: Dict[str, Any] = {}
         self._step = 0
         self._watched_models: List[Any] = []
+        self._start_time: float = _time.time()
 
     # -- Properties matching wandb.Run --
 
@@ -167,9 +169,7 @@ class Run:
 
     @property
     def start_time(self) -> float:
-        import time
-
-        return time.time()
+        return self._start_time
 
     @property
     def sweep_id(self) -> Optional[str]:
@@ -338,10 +338,12 @@ class Run:
                     logger.debug('%s: log_artifact file failed: %s', tag, e)
             return artifact_or_path
         elif isinstance(artifact_or_path, str):
+            import os
+
             from pluto.file import Artifact as PlutoArtifact
 
             art = PlutoArtifact(data=artifact_or_path, caption=name)
-            log_name = name or 'artifact'
+            log_name = name or os.path.basename(artifact_or_path)
             try:
                 self._op.log({log_name: art})
             except Exception as e:

--- a/pluto/compat/wandb/run.py
+++ b/pluto/compat/wandb/run.py
@@ -1,0 +1,398 @@
+"""wandb.Run-compatible wrapper around pluto.Op."""
+
+import logging
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from .config import Config
+from .data_types import Artifact, Audio, Graph, Histogram, Html, Image, Table, Video
+from .summary import Summary
+
+logger = logging.getLogger(f'{__name__.split(".")[0]}')
+tag = 'WandbCompat.Run'
+
+# Sentinel for data types that have _to_pluto()
+_WANDB_DATA_TYPES = (Image, Audio, Video, Table, Histogram, Html, Graph)
+
+
+def _convert_value(v: Any) -> Any:
+    """Convert a wandb data type wrapper to its pluto equivalent."""
+    if isinstance(v, _WANDB_DATA_TYPES):
+        return v._to_pluto()
+    return v
+
+
+def _flatten_dict(d: Dict[str, Any], prefix: str = '') -> Dict[str, Any]:
+    """Flatten nested dicts using '/' separator (wandb convention)."""
+    flat: Dict[str, Any] = {}
+    for k, v in d.items():
+        key = f'{prefix}/{k}' if prefix else k
+        if isinstance(v, dict):
+            flat.update(_flatten_dict(v, prefix=key))
+        else:
+            flat[key] = v
+    return flat
+
+
+class Run:
+    """A wandb.Run-compatible object wrapping a pluto Op.
+
+    Provides the same interface as wandb.Run so user code like
+    ``run.log()``, ``run.config``, ``run.summary``, etc. works seamlessly.
+    """
+
+    def __init__(
+        self,
+        op: Any,
+        name: Optional[str] = None,
+        notes: Optional[str] = None,
+        group: Optional[str] = None,
+        job_type: Optional[str] = None,
+        mode: str = 'online',
+    ) -> None:
+        self._op = op
+        self._name = name
+        self._notes = notes
+        self._group = group
+        self._job_type = job_type
+        self._mode = mode
+
+        self._config = Config(op=op)
+        self._summary = Summary()
+        self._pending_data: Dict[str, Any] = {}
+        self._step = 0
+        self._watched_models: List[Any] = []
+
+    # -- Properties matching wandb.Run --
+
+    @property
+    def id(self) -> str:
+        if self._op.run_id:
+            return self._op.run_id
+        op_id = self._op.id
+        return str(op_id) if op_id is not None else ''
+
+    @property
+    def name(self) -> Optional[str]:
+        return self._name or getattr(self._op.settings, '_op_name', None)
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value
+
+    @property
+    def entity(self) -> str:
+        return ''
+
+    @property
+    def project(self) -> Optional[str]:
+        return getattr(self._op.settings, 'project', None)
+
+    @property
+    def group(self) -> Optional[str]:
+        return self._group
+
+    @property
+    def job_type(self) -> Optional[str]:
+        return self._job_type
+
+    @property
+    def tags(self) -> tuple:
+        return tuple(self._op.tags)
+
+    @tags.setter
+    def tags(self, value: Union[tuple, list, Sequence[str]]) -> None:
+        current = set(self._op.tags)
+        new = set(value)
+        to_add = new - current
+        to_remove = current - new
+        if to_remove:
+            self._op.remove_tags(list(to_remove))
+        if to_add:
+            self._op.add_tags(list(to_add))
+
+    @property
+    def notes(self) -> Optional[str]:
+        return self._notes
+
+    @notes.setter
+    def notes(self, value: str) -> None:
+        self._notes = value
+
+    @property
+    def config(self) -> Config:
+        return self._config
+
+    @config.setter
+    def config(self, value: Any) -> None:
+        if isinstance(value, dict):
+            self._config.update(value)
+        elif isinstance(value, Config):
+            self._config = value
+
+    @property
+    def summary(self) -> Summary:
+        return self._summary
+
+    @property
+    def url(self) -> Optional[str]:
+        return getattr(self._op.settings, 'url_view', None)
+
+    @property
+    def dir(self) -> str:
+        return self._op.settings.get_dir()
+
+    @property
+    def step(self) -> int:
+        return self._step
+
+    @property
+    def offline(self) -> bool:
+        return self._mode == 'offline'
+
+    @property
+    def disabled(self) -> bool:
+        return self._mode == 'disabled'
+
+    @property
+    def resumed(self) -> bool:
+        return self._op.resumed
+
+    @property
+    def path(self) -> str:
+        return f'{self.entity}/{self.project}/{self.id}'
+
+    @property
+    def settings(self) -> Any:
+        return self._op.settings
+
+    @property
+    def start_time(self) -> float:
+        import time
+
+        return time.time()
+
+    @property
+    def sweep_id(self) -> Optional[str]:
+        return None
+
+    @property
+    def project_url(self) -> Optional[str]:
+        url = self.url
+        if url:
+            # Strip the run-specific part to get project URL
+            parts = url.rsplit('/', 1)
+            return parts[0] if len(parts) > 1 else url
+        return None
+
+    # -- Core methods --
+
+    def log(
+        self,
+        data: Dict[str, Any],
+        step: Optional[int] = None,
+        commit: Optional[bool] = None,
+        sync: Optional[bool] = None,
+    ) -> None:
+        """Log metrics/data to the run."""
+        # Flatten nested dicts
+        flat = _flatten_dict(data)
+
+        # Convert wandb data types to pluto equivalents
+        converted = {k: _convert_value(v) for k, v in flat.items()}
+
+        if commit is False:
+            # Buffer data, don't send yet
+            self._pending_data.update(converted)
+            return
+
+        # Merge with any pending data
+        if self._pending_data:
+            merged = {**self._pending_data, **converted}
+            self._pending_data = {}
+        else:
+            merged = converted
+
+        # Update summary with scalar values
+        self._summary._update_from_log(merged)
+
+        # Track step
+        if step is not None:
+            self._step = step
+        else:
+            self._step += 1
+
+        # Forward to pluto
+        try:
+            self._op.log(merged, step=step)
+        except Exception as e:
+            logger.debug('%s: log failed: %s', tag, e)
+
+    def finish(
+        self,
+        exit_code: Optional[int] = None,
+        quiet: Optional[bool] = None,
+    ) -> None:
+        """Mark the run as finished."""
+        try:
+            self._op.finish(code=exit_code)
+        except Exception as e:
+            logger.debug('%s: finish failed: %s', tag, e)
+
+    def watch(
+        self,
+        models: Any = None,
+        criterion: Any = None,
+        log: Optional[str] = 'gradients',
+        log_freq: int = 1000,
+        idx: Optional[int] = None,
+        log_graph: bool = False,
+    ) -> None:
+        """Watch a PyTorch model for gradient/parameter logging."""
+        if models is None:
+            return
+
+        model_list = models if isinstance(models, (list, tuple)) else [models]
+        for model in model_list:
+            try:
+                self._op.watch(model, log_freq=log_freq)
+                self._watched_models.append(model)
+            except Exception as e:
+                logger.debug('%s: watch failed: %s', tag, e)
+
+    def unwatch(self, models: Any = None) -> None:
+        """Remove model watching hooks (best-effort)."""
+        logger.debug('%s: unwatch is a no-op in pluto compat layer', tag)
+
+    def alert(
+        self,
+        title: str = '',
+        text: str = '',
+        level: Optional[str] = None,
+        wait_duration: Optional[Union[int, float]] = None,
+    ) -> None:
+        """Send an alert."""
+        try:
+            kwargs: Dict[str, Any] = {}
+            if wait_duration is not None:
+                kwargs['wait_duration'] = wait_duration
+            self._op.alert(
+                title=title,
+                message=text,
+                level=level or 'INFO',
+                **kwargs,
+            )
+        except Exception as e:
+            logger.debug('%s: alert failed: %s', tag, e)
+
+    def define_metric(
+        self,
+        name: str,
+        step_metric: Optional[str] = None,
+        step_sync: Optional[bool] = None,
+        hidden: Optional[bool] = None,
+        summary: Optional[str] = None,
+        goal: Optional[str] = None,
+        overwrite: Optional[bool] = None,
+    ) -> Any:
+        """Define metric behavior. No-op in pluto (returns a stub)."""
+        logger.debug('%s: define_metric is a no-op', tag)
+        return _MetricStub(name)
+
+    def save(
+        self,
+        glob_str: Optional[str] = None,
+        base_path: Optional[str] = None,
+        policy: str = 'live',
+    ) -> None:
+        """Sync files to the run. No-op in pluto compat layer."""
+        logger.debug('%s: save is not supported', tag)
+
+    def restore(
+        self,
+        name: str,
+        run_path: Optional[str] = None,
+        replace: bool = False,
+        root: Optional[str] = None,
+    ) -> None:
+        """Download a file from a run. Not supported."""
+        logger.debug('%s: restore is not supported', tag)
+
+    def log_artifact(
+        self,
+        artifact_or_path: Any,
+        name: Optional[str] = None,
+        type: Optional[str] = None,
+        aliases: Optional[List[str]] = None,
+    ) -> Any:
+        """Log an artifact (file collection) to the run."""
+        if isinstance(artifact_or_path, Artifact):
+            pluto_files = artifact_or_path._to_pluto_files()
+            for i, pf in enumerate(pluto_files):
+                if hasattr(pf, '_name'):
+                    log_name = f'{artifact_or_path.name}/{pf._name}'
+                else:
+                    log_name = f'{artifact_or_path.name}/{i}'
+                try:
+                    self._op.log({log_name: pf})
+                except Exception as e:
+                    logger.debug('%s: log_artifact file failed: %s', tag, e)
+            return artifact_or_path
+        elif isinstance(artifact_or_path, str):
+            from pluto.file import Artifact as PlutoArtifact
+
+            art = PlutoArtifact(data=artifact_or_path, caption=name)
+            log_name = name or 'artifact'
+            try:
+                self._op.log({log_name: art})
+            except Exception as e:
+                logger.debug('%s: log_artifact path failed: %s', tag, e)
+        return artifact_or_path
+
+    def use_artifact(
+        self,
+        artifact_or_name: Any,
+        type: Optional[str] = None,
+    ) -> Any:
+        """Declare an artifact as input. Not supported."""
+        logger.debug('%s: use_artifact is not supported', tag)
+        return artifact_or_name
+
+    def log_code(
+        self,
+        root: Optional[str] = None,
+        name: Optional[str] = None,
+        include_fn: Any = None,
+        exclude_fn: Any = None,
+    ) -> None:
+        """Save source code. Not supported."""
+        logger.debug('%s: log_code is not supported', tag)
+
+    def mark_preempting(self) -> None:
+        """Mark run as preempted. No-op (pluto handles this via signals)."""
+        logger.debug('%s: mark_preempting is a no-op', tag)
+
+    def status(self) -> Dict[str, Any]:
+        return {'synced': True}
+
+    # -- Context manager --
+
+    def __enter__(self) -> 'Run':
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
+        exit_code = 1 if exc_type else 0
+        self.finish(exit_code=exit_code)
+        return False
+
+    def __repr__(self) -> str:
+        return f'<Run {self.project}/{self.id} ({self.name})>'
+
+
+class _MetricStub:
+    """Stub returned by define_metric()."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __repr__(self) -> str:
+        return f'<Metric {self.name}>'

--- a/pluto/compat/wandb/run.py
+++ b/pluto/compat/wandb/run.py
@@ -365,8 +365,10 @@ class Run:
         elif isinstance(artifact_or_path, str):
             import os
 
+            from pluto.compat.wandb.data_types import _validate_path
             from pluto.file import Artifact as PlutoArtifact
 
+            _validate_path(artifact_or_path)
             art = PlutoArtifact(data=artifact_or_path, caption=name)
             log_name = name or os.path.basename(artifact_or_path)
             try:

--- a/pluto/compat/wandb/run.py
+++ b/pluto/compat/wandb/run.py
@@ -261,6 +261,9 @@ class Run:
 
     def unwatch(self, models: Any = None) -> None:
         """Remove model watching hooks (best-effort)."""
+        from ._coverage import warn_unsupported
+
+        warn_unsupported("wandb.Run.unwatch")
         logger.debug('%s: unwatch is a no-op in pluto compat layer', tag)
 
     def alert(
@@ -330,6 +333,9 @@ class Run:
         policy: str = 'live',
     ) -> None:
         """Sync files to the run. No-op in pluto compat layer."""
+        from ._coverage import warn_unsupported
+
+        warn_unsupported("wandb.Run.save")
         logger.debug('%s: save is not supported', tag)
 
     def restore(
@@ -340,6 +346,9 @@ class Run:
         root: Optional[str] = None,
     ) -> None:
         """Download a file from a run. Not supported."""
+        from ._coverage import warn_unsupported
+
+        warn_unsupported("wandb.Run.restore")
         logger.debug('%s: restore is not supported', tag)
 
     def log_artifact(
@@ -383,6 +392,9 @@ class Run:
         type: Optional[str] = None,
     ) -> Any:
         """Declare an artifact as input. Not supported."""
+        from ._coverage import warn_unsupported
+
+        warn_unsupported("wandb.Run.use_artifact")
         logger.debug('%s: use_artifact is not supported', tag)
         return artifact_or_name
 
@@ -394,10 +406,16 @@ class Run:
         exclude_fn: Any = None,
     ) -> None:
         """Save source code. Not supported."""
+        from ._coverage import warn_unsupported
+
+        warn_unsupported("wandb.Run.log_code")
         logger.debug('%s: log_code is not supported', tag)
 
     def mark_preempting(self) -> None:
         """Mark run as preempted. No-op (pluto handles this via signals)."""
+        from ._coverage import warn_unsupported
+
+        warn_unsupported("wandb.Run.mark_preempting")
         logger.debug('%s: mark_preempting is a no-op', tag)
 
     def status(self) -> Dict[str, Any]:

--- a/pluto/compat/wandb/summary.py
+++ b/pluto/compat/wandb/summary.py
@@ -17,7 +17,7 @@ class Summary:
         """Called internally after each log() call to update last values."""
         store = object.__getattribute__(self, '_data')
         for k, v in data.items():
-            if isinstance(v, (int, float)) and not isinstance(v, bool):
+            if isinstance(v, (int, float)):
                 store[k] = v
             elif hasattr(v, 'item') and callable(v.item):
                 store[k] = v.item()

--- a/pluto/compat/wandb/summary.py
+++ b/pluto/compat/wandb/summary.py
@@ -1,0 +1,87 @@
+"""wandb.summary-compatible dict-like summary metrics object."""
+
+from typing import Any, Dict, Iterator, Optional
+
+
+class Summary:
+    """A dict-like object tracking summary metrics, compatible with wandb.summary.
+
+    Auto-populated from log() calls (last value per key for scalars).
+    Supports manual overrides via dict/attribute access.
+    """
+
+    def __init__(self) -> None:
+        object.__setattr__(self, '_data', {})
+
+    def _update_from_log(self, data: Dict[str, Any]) -> None:
+        """Called internally after each log() call to update last values."""
+        store = object.__getattribute__(self, '_data')
+        for k, v in data.items():
+            if isinstance(v, (int, float)) and not isinstance(v, bool):
+                store[k] = v
+            elif hasattr(v, 'item') and callable(v.item):
+                store[k] = v.item()
+
+    # -- Attribute access --
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        if key.startswith('_'):
+            object.__setattr__(self, key, value)
+        else:
+            self[key] = value
+
+    def __getattr__(self, key: str) -> Any:
+        data = object.__getattribute__(self, '_data')
+        try:
+            return data[key]
+        except KeyError:
+            raise AttributeError(f"'Summary' object has no attribute '{key}'")
+
+    # -- Dict access --
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        object.__getattribute__(self, '_data')[key] = value
+
+    def __getitem__(self, key: str) -> Any:
+        return object.__getattribute__(self, '_data')[key]
+
+    def __delitem__(self, key: str) -> None:
+        del object.__getattribute__(self, '_data')[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in object.__getattribute__(self, '_data')
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(object.__getattribute__(self, '_data'))
+
+    def __len__(self) -> int:
+        return len(object.__getattribute__(self, '_data'))
+
+    def __repr__(self) -> str:
+        return repr(object.__getattribute__(self, '_data'))
+
+    def __bool__(self) -> bool:
+        return bool(object.__getattribute__(self, '_data'))
+
+    # -- Dict-like methods --
+
+    def keys(self):
+        return object.__getattribute__(self, '_data').keys()
+
+    def values(self):
+        return object.__getattribute__(self, '_data').values()
+
+    def items(self):
+        return object.__getattribute__(self, '_data').items()
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return object.__getattribute__(self, '_data').get(key, default)
+
+    def update(self, d: Optional[Dict[str, Any]] = None, **kwargs: Any) -> None:
+        if d:
+            object.__getattribute__(self, '_data').update(d)
+        if kwargs:
+            object.__getattribute__(self, '_data').update(kwargs)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return dict(object.__getattribute__(self, '_data'))

--- a/pluto/iface.py
+++ b/pluto/iface.py
@@ -100,6 +100,23 @@ class ServerInterface:
             client=self.client_api,
         )
 
+    def update_metric_definitions(self, metrics: List[Dict[str, Any]]) -> None:
+        """Update metric definitions on the server via HTTP API."""
+        payload = json.dumps(
+            {
+                'runId': self.settings._op_id,
+                'metrics': metrics,
+            }
+        ).encode()
+        headers = self.headers.copy()
+        headers['Content-Type'] = 'application/json'
+        self._post_v1(
+            self.settings.url_update_metric_defs,
+            headers,
+            payload,
+            client=self.client_api,
+        )
+
     # Keep legacy underscore methods for backwards compatibility
     def _update_status(self, settings, trace: Union[Any, None] = None):
         """Legacy method - use update_status() instead."""

--- a/pluto/op.py
+++ b/pluto/op.py
@@ -9,6 +9,7 @@ import threading
 import time
 import traceback
 from collections import defaultdict
+from fnmatch import fnmatch
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import pluto
@@ -853,8 +854,6 @@ class Op:
         """Get the metric definition for a name, supporting glob patterns."""
         if name in self._metric_definitions:
             return self._metric_definitions[name]
-        from fnmatch import fnmatch
-
         for pattern, defn in self._metric_definitions.items():
             if fnmatch(name, pattern):
                 return defn

--- a/pluto/op.py
+++ b/pluto/op.py
@@ -248,6 +248,7 @@ class Op:
         self.config = config
         self.settings = settings
         self.tags: List[str] = tags if tags else []  # Use provided tags or empty list
+        self._metric_definitions: Dict[str, Dict[str, Any]] = {}
         self._monitor = OpMonitor(op=self)
         self._resumed: bool = False  # Whether this run was resumed (multi-node)
         self._resume: bool = resume  # Whether resume was explicitly requested
@@ -385,6 +386,7 @@ class Op:
             'url_update_tags': self.settings.url_update_tags,
             'url_file': self.settings.url_file,  # For file uploads
             'url_message': self.settings.url_message,  # For console logs
+            'url_update_metric_defs': self.settings.url_update_metric_defs,
             'x_log_level': self.settings.x_log_level,
             'pluto_version': self.settings.pluto_version,
             'pluto_commit': self.settings.pluto_commit,
@@ -805,6 +807,58 @@ class Op:
                 self._iface._update_config(config)
             except Exception as e:
                 logger.debug(f'{tag}: failed to sync config to server: {e}')
+
+    def define_metric(
+        self,
+        name: str,
+        step_metric: Optional[str] = None,
+        summary: Optional[str] = None,
+        goal: Optional[str] = None,
+        hidden: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Define metric behavior (aggregation, custom x-axis).
+
+        Args:
+            name: Metric name or glob pattern (e.g. "val/*")
+            step_metric: Name of metric to use as x-axis
+            summary: Aggregation mode: "min", "max", "mean", "first", "last"
+            goal: Optimization goal: "minimize" or "maximize"
+            hidden: Whether to hide this metric in the dashboard
+        """
+        definition: Dict[str, Any] = {'name': name}
+        if step_metric is not None:
+            definition['step_metric'] = step_metric
+        if summary is not None:
+            definition['summary'] = summary
+        if goal is not None:
+            definition['goal'] = goal
+        if hidden is not None:
+            definition['hidden'] = hidden
+        self._metric_definitions[name] = definition
+
+        # Sync to server (best-effort)
+        if self._sync_manager is not None:
+            self._sync_manager.enqueue_metric_definition(
+                definition, int(time.time() * 1000)
+            )
+        elif self._iface:
+            try:
+                self._iface.update_metric_definitions([definition])
+            except Exception as e:
+                logger.debug(f'{tag}: failed to sync metric definition to server: {e}')
+
+        return definition
+
+    def get_metric_definition(self, name: str) -> Optional[Dict[str, Any]]:
+        """Get the metric definition for a name, supporting glob patterns."""
+        if name in self._metric_definitions:
+            return self._metric_definitions[name]
+        from fnmatch import fnmatch
+
+        for pattern, defn in self._metric_definitions.items():
+            if fnmatch(name, pattern):
+                return defn
+        return None
 
     @property
     def resumed(self) -> bool:

--- a/pluto/sets.py
+++ b/pluto/sets.py
@@ -136,6 +136,7 @@ class Settings:
         self.url_data = f'{self.url_ingest}/ingest/data'
         self.url_file = f'{self.url_ingest}/files'
         self.url_message = f'{self.url_ingest}/ingest/logs'
+        self.url_update_metric_defs = f'{self.url_api}/api/runs/metrics/define'
         self.url_alert = f'{self.url_py}/api/runs/alert'
         self.url_trigger = f'{self.url_py}/api/runs/trigger'
 
@@ -291,6 +292,8 @@ def setup(settings: Union[Settings, Dict[str, Any], None] = None) -> Settings:
     # Read PLUTO_API_KEY environment variable (with MLOP_API_TOKEN fallback)
     # Only apply if not already set via function parameters
     env_api_token = _get_env_with_deprecation('PLUTO_API_KEY', 'MLOP_API_TOKEN')
+    if env_api_token is None:
+        env_api_token = os.environ.get('WANDB_API_KEY')
     if env_api_token is not None and '_auth' not in settings_dict:
         new_settings._auth = env_api_token
 

--- a/pluto/sync/store.py
+++ b/pluto/sync/store.py
@@ -103,6 +103,7 @@ class RecordType(IntEnum):
     TAGS = 4
     SYSTEM = 5
     CONSOLE = 6  # stdout/stderr logs
+    METRIC_DEF = 7  # metric definitions (define_metric)
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.0.11"
 description = "Pluto ML - Machine Learning Operations Framework"
 packages = [
     {include = "pluto"},
-    {include = "mlop"}
+    {include = "mlop"},
+    {include = "wandb"}
 ]
 authors = [
     "jqssun",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Pluto ML - Machine Learning Operations Framework"
 packages = [
     {include = "pluto"},
     {include = "mlop"},
-    {include = "wandb"}
+    {include = "wandb"},
 ]
 authors = [
     "jqssun",
@@ -70,6 +70,8 @@ select = ["F", "E", "W", "I001"]
 # Required in test_neptune_compat.py because logging must be configured
 # before importing neptune_scale to prevent I/O errors
 "tests/test_neptune_compat.py" = ["E402"]
+# wandb/__init__.py has imports after the conflict detection check
+"wandb/__init__.py" = ["E402"]
 
 [tool.ruff.format]
 # 5. Use single quotes in `ruff format`.

--- a/scripts/wandb_coverage.py
+++ b/scripts/wandb_coverage.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""wandb API coverage report.
+
+Compares real wandb (from site-packages) against the pluto shim + registry
+to produce a coverage report.
+
+Usage:
+    python scripts/wandb_coverage.py --format summary
+    python scripts/wandb_coverage.py --format markdown
+    python scripts/wandb_coverage.py --format json
+"""
+
+import argparse
+import importlib
+import inspect
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _import_real_wandb():
+    """Import real wandb from site-packages, bypassing local shim."""
+    repo_root = str(Path(__file__).resolve().parent.parent)
+
+    # Remove repo root and wandb shim from sys.path
+    clean_path = [
+        p for p in sys.path
+        if os.path.realpath(p) != os.path.realpath(repo_root)
+    ]
+
+    # Clear any cached wandb modules
+    to_clear = [
+        k for k in sys.modules
+        if k == "wandb" or k.startswith("wandb.")
+    ]
+    for k in to_clear:
+        del sys.modules[k]
+
+    old_path = sys.path[:]
+    sys.path = clean_path
+    try:
+        real_wandb = importlib.import_module("wandb")
+        return real_wandb
+    except ImportError:
+        return None
+    finally:
+        sys.path = old_path
+        # Clean up so subsequent imports use local shim again
+        to_clear = [
+            k for k in sys.modules
+            if k == "wandb" or k.startswith("wandb.")
+        ]
+        for k in to_clear:
+            del sys.modules[k]
+
+
+def _get_real_wandb_all(real_wandb):
+    """Get wandb.__all__ from real wandb."""
+    if hasattr(real_wandb, "__all__"):
+        return list(real_wandb.__all__)
+    return []
+
+
+def _get_real_run_public(real_wandb):
+    """Get public methods/properties of wandb.Run."""
+    run_cls = getattr(real_wandb, "Run", None)
+    if run_cls is None:
+        # Try wandb.sdk.wandb_run.Run
+        try:
+            from importlib import import_module
+
+            sdk_run = import_module("wandb.sdk.wandb_run")
+            run_cls = sdk_run.Run
+        except Exception:
+            return []
+
+    members = []
+    for name in dir(run_cls):
+        if name.startswith("_"):
+            continue
+        members.append(name)
+    return sorted(members)
+
+
+def _get_real_plot_functions(real_wandb):
+    """Get public functions from wandb.plot."""
+    try:
+        plot_mod = importlib.import_module("wandb.plot")
+    except ImportError:
+        return []
+
+    funcs = []
+    for name in dir(plot_mod):
+        if name.startswith("_"):
+            continue
+        obj = getattr(plot_mod, name, None)
+        if callable(obj) and not inspect.isclass(obj):
+            funcs.append(name)
+    return sorted(funcs)
+
+
+def _get_shim_exports():
+    """Get what our shim exports."""
+    # Import from pluto.compat.wandb (not the top-level wandb shim)
+    from pluto.compat.wandb import __all__ as shim_all
+
+    return list(shim_all)
+
+
+def _get_shim_run_members():
+    """Get public members of our Run class."""
+    from pluto.compat.wandb.run import Run
+
+    members = []
+    for name in dir(Run):
+        if name.startswith("_"):
+            continue
+        members.append(name)
+    return sorted(members)
+
+
+def _get_shim_plot_functions():
+    """Get functions from our plot shim."""
+    import wandb.plot as plot_mod
+
+    funcs = []
+    for name in dir(plot_mod):
+        if name.startswith("_"):
+            continue
+        obj = getattr(plot_mod, name, None)
+        if callable(obj) and not inspect.isclass(obj):
+            funcs.append(name)
+    return sorted(funcs)
+
+
+def build_report(real_wandb):
+    """Build the coverage comparison report."""
+    from pluto.compat.wandb._coverage import WANDB_API_REGISTRY, SupportLevel
+
+    report = {
+        "top_level": [],
+        "run_methods": [],
+        "plot_functions": [],
+        "registry_stats": {},
+    }
+
+    # --- Top-level ---
+    real_all = _get_real_wandb_all(real_wandb) if real_wandb else []
+    shim_all = _get_shim_exports()
+
+    all_top = sorted(set(real_all) | set(shim_all))
+    for name in all_top:
+        key = f"wandb.{name}"
+        entry = WANDB_API_REGISTRY.get(key)
+        report["top_level"].append({
+            "name": name,
+            "in_real_wandb": name in real_all,
+            "in_shim": name in shim_all,
+            "registry_level": entry.level.value if entry else "unregistered",
+            "notes": entry.notes if entry else "",
+        })
+
+    # --- Run methods ---
+    real_run = _get_real_run_public(real_wandb) if real_wandb else []
+    shim_run = _get_shim_run_members()
+
+    all_run = sorted(set(real_run) | set(shim_run))
+    for name in all_run:
+        key = f"wandb.Run.{name}"
+        entry = WANDB_API_REGISTRY.get(key)
+        report["run_methods"].append({
+            "name": name,
+            "in_real_wandb": name in real_run,
+            "in_shim": name in shim_run,
+            "registry_level": entry.level.value if entry else "unregistered",
+            "notes": entry.notes if entry else "",
+        })
+
+    # --- Plot functions ---
+    real_plot = _get_real_plot_functions(real_wandb) if real_wandb else []
+    shim_plot = _get_shim_plot_functions()
+
+    all_plot = sorted(set(real_plot) | set(shim_plot))
+    for name in all_plot:
+        key = f"wandb.plot.{name}"
+        entry = WANDB_API_REGISTRY.get(key)
+        report["plot_functions"].append({
+            "name": name,
+            "in_real_wandb": name in real_plot,
+            "in_shim": name in shim_plot,
+            "registry_level": entry.level.value if entry else "unregistered",
+            "notes": entry.notes if entry else "",
+        })
+
+    # --- Stats ---
+    stats = {level.value: 0 for level in SupportLevel}
+    for entry in WANDB_API_REGISTRY.values():
+        stats[entry.level.value] += 1
+    stats["total"] = len(WANDB_API_REGISTRY)
+    report["registry_stats"] = stats
+
+    return report
+
+
+def format_markdown(report):
+    """Format report as markdown."""
+    lines = ["# wandb API Coverage Report\n"]
+
+    stats = report["registry_stats"]
+    lines.append("## Summary\n")
+    lines.append("| Level | Count |")
+    lines.append("|-------|-------|")
+    for level in ["supported", "partial", "stub", "not_implemented", "missing"]:
+        lines.append(f"| {level} | {stats.get(level, 0)} |")
+    lines.append(f"| **total** | **{stats['total']}** |")
+    lines.append("")
+
+    for section, title in [
+        ("top_level", "Top-level API (`wandb.*`)"),
+        ("run_methods", "Run API (`wandb.Run.*`)"),
+        ("plot_functions", "Plot API (`wandb.plot.*`)"),
+    ]:
+        items = report[section]
+        if not items:
+            continue
+        lines.append(f"## {title}\n")
+        lines.append(
+            "| Name | Real wandb | Shim | Status | Notes |"
+        )
+        lines.append("|------|-----------|------|--------|-------|")
+        for item in items:
+            real = "yes" if item["in_real_wandb"] else "no"
+            shim = "yes" if item["in_shim"] else "no"
+            name = item["name"]
+            level = item["registry_level"]
+            notes = item["notes"]
+            lines.append(
+                f"| `{name}` | {real} | {shim}"
+                f" | {level} | {notes} |"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_summary(report):
+    """One-line summary for CI logs."""
+    stats = report["registry_stats"]
+    total = stats["total"]
+    supported = stats.get("supported", 0)
+    partial = stats.get("partial", 0)
+    stub = stats.get("stub", 0)
+    not_impl = stats.get("not_implemented", 0)
+    missing = stats.get("missing", 0)
+    return (
+        f"wandb coverage: {supported}/{total} supported, "
+        f"{partial} partial, {stub} stub, "
+        f"{not_impl} not implemented, {missing} missing"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="wandb API coverage report")
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json", "summary"],
+        default="summary",
+        help="Output format",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output file path (default: stdout)",
+    )
+    args = parser.parse_args()
+
+    real_wandb = _import_real_wandb()
+    if real_wandb is None and args.format != "summary":
+        print(
+            "WARNING: real wandb not installed. "
+            "Report will only show shim/registry data.",
+            file=sys.stderr,
+        )
+
+    report = build_report(real_wandb)
+
+    if args.format == "json":
+        output = json.dumps(report, indent=2)
+    elif args.format == "markdown":
+        output = format_markdown(report)
+    else:
+        output = format_summary(report)
+
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(output + "\n")
+        print(f"Report written to {args.output}")
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_define_metric.py
+++ b/tests/test_define_metric.py
@@ -1,0 +1,82 @@
+"""Tests for Op.define_metric() and Op.get_metric_definition()."""
+
+from unittest.mock import MagicMock
+
+
+class TestDefineMetric:
+    """Tests for pluto core define_metric functionality."""
+
+    def _make_op(self):
+        """Create a minimal Op with mocked internals for testing."""
+        from pluto.op import Op
+
+        op = object.__new__(Op)
+        op._metric_definitions = {}
+        op._sync_manager = None
+        op._iface = None
+        return op
+
+    def test_define_metric_stores_definition(self):
+        op = self._make_op()
+        result = op.define_metric('loss', summary='min', goal='minimize')
+        assert result == {'name': 'loss', 'summary': 'min', 'goal': 'minimize'}
+        assert op._metric_definitions['loss'] == result
+
+    def test_define_metric_only_includes_non_none(self):
+        op = self._make_op()
+        result = op.define_metric('acc')
+        assert result == {'name': 'acc'}
+        assert 'step_metric' not in result
+        assert 'summary' not in result
+
+    def test_define_metric_with_step_metric(self):
+        op = self._make_op()
+        result = op.define_metric('val/loss', step_metric='epoch')
+        assert result['step_metric'] == 'epoch'
+
+    def test_define_metric_with_hidden(self):
+        op = self._make_op()
+        result = op.define_metric('internal', hidden=True)
+        assert result['hidden'] is True
+
+    def test_define_metric_glob_match(self):
+        op = self._make_op()
+        op.define_metric('val/*', summary='min')
+        defn = op.get_metric_definition('val/loss')
+        assert defn is not None
+        assert defn['summary'] == 'min'
+
+    def test_define_metric_exact_over_glob(self):
+        op = self._make_op()
+        op.define_metric('val/*', summary='min')
+        op.define_metric('val/loss', summary='max')
+        defn = op.get_metric_definition('val/loss')
+        assert defn['summary'] == 'max'
+
+    def test_get_metric_definition_returns_none_for_unknown(self):
+        op = self._make_op()
+        assert op.get_metric_definition('unknown') is None
+
+    def test_define_metric_enqueues_to_sync(self):
+        op = self._make_op()
+        op._sync_manager = MagicMock()
+        op.define_metric('loss', summary='min')
+        op._sync_manager.enqueue_metric_definition.assert_called_once()
+        call_args = op._sync_manager.enqueue_metric_definition.call_args
+        assert call_args[0][0] == {'name': 'loss', 'summary': 'min'}
+
+    def test_define_metric_falls_back_to_iface(self):
+        op = self._make_op()
+        op._iface = MagicMock()
+        op.define_metric('acc', summary='max')
+        op._iface.update_metric_definitions.assert_called_once_with(
+            [{'name': 'acc', 'summary': 'max'}]
+        )
+
+    def test_define_metric_iface_error_does_not_raise(self):
+        op = self._make_op()
+        op._iface = MagicMock()
+        op._iface.update_metric_definitions.side_effect = RuntimeError('server down')
+        # Should not raise
+        result = op.define_metric('loss', summary='min')
+        assert result == {'name': 'loss', 'summary': 'min'}

--- a/tests/test_env_vars.py
+++ b/tests/test_env_vars.py
@@ -202,6 +202,45 @@ class TestDeprecatedMLOPEnvVars:
         del os.environ['PLUTO_DEBUG_LEVEL']
 
 
+class TestWANDBApiKeyFallback:
+    """Test WANDB_API_KEY as fallback for PLUTO_API_TOKEN."""
+
+    def _cleanup_env(self):
+        for var in ('PLUTO_API_KEY', 'MLOP_API_TOKEN', 'WANDB_API_KEY'):
+            os.environ.pop(var, None)
+
+    def test_wandb_api_key_sets_auth(self):
+        """Test WANDB_API_KEY is picked up when no PLUTO_API_KEY is set."""
+        self._cleanup_env()
+        os.environ['WANDB_API_KEY'] = 'wandb-test-token'
+        try:
+            settings = setup()
+            assert settings._auth == 'wandb-test-token'
+        finally:
+            self._cleanup_env()
+
+    def test_pluto_api_key_takes_precedence(self):
+        """Test PLUTO_API_KEY wins over WANDB_API_KEY."""
+        self._cleanup_env()
+        os.environ['PLUTO_API_KEY'] = 'pluto-token'
+        os.environ['WANDB_API_KEY'] = 'wandb-token'
+        try:
+            settings = setup()
+            assert settings._auth == 'pluto-token'
+        finally:
+            self._cleanup_env()
+
+    def test_function_params_take_precedence(self):
+        """Test explicit _auth in settings dict wins over all env vars."""
+        self._cleanup_env()
+        os.environ['WANDB_API_KEY'] = 'wandb-token'
+        try:
+            settings = setup({'_auth': 'param-token'})
+            assert settings._auth == 'param-token'
+        finally:
+            self._cleanup_env()
+
+
 class TestPLUTOThreadJoinTimeout:
     """Test PLUTO_THREAD_JOIN_TIMEOUT_SECONDS environment variable."""
 

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -1,0 +1,832 @@
+"""
+Tests for the wandb-to-pluto compatibility layer.
+
+These tests validate that:
+1. wandb API calls are correctly routed to pluto equivalents
+2. Data types are converted properly
+3. Config and Summary behave like wandb's dict-like objects
+4. Module-level state (run, config, summary) works correctly
+5. Unsupported features degrade gracefully (no-ops, not errors)
+"""
+
+import os
+from unittest import mock
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+
+class TestConfig:
+    """Tests for the wandb.config-compatible Config class."""
+
+    def test_attribute_set_and_get(self):
+        from pluto.compat.wandb.config import Config
+
+        c = Config()
+        c.lr = 0.001
+        assert c.lr == 0.001
+
+    def test_dict_set_and_get(self):
+        from pluto.compat.wandb.config import Config
+
+        c = Config()
+        c['batch_size'] = 32
+        assert c['batch_size'] == 32
+
+    def test_update_dict(self):
+        from pluto.compat.wandb.config import Config
+
+        c = Config()
+        c.update({'a': 1, 'b': 2})
+        assert c.a == 1
+        assert c['b'] == 2
+
+    def test_update_with_namespace(self):
+        """Test update() with argparse-like namespace."""
+        import argparse
+
+        from pluto.compat.wandb.config import Config
+
+        ns = argparse.Namespace(lr=0.01, epochs=10)
+        c = Config()
+        c.update(ns)
+        assert c.lr == 0.01
+        assert c.epochs == 10
+
+    def test_setdefaults(self):
+        from pluto.compat.wandb.config import Config
+
+        c = Config()
+        c.lr = 0.001
+        c.setdefaults({'lr': 0.01, 'batch_size': 64})
+        assert c.lr == 0.001  # not overwritten
+        assert c.batch_size == 64  # newly set
+
+    def test_keys_values_items(self):
+        from pluto.compat.wandb.config import Config
+
+        c = Config()
+        c.update({'a': 1, 'b': 2})
+        assert set(c.keys()) == {'a', 'b'}
+        assert set(c.values()) == {1, 2}
+        assert set(c.items()) == {('a', 1), ('b', 2)}
+
+    def test_get_with_default(self):
+        from pluto.compat.wandb.config import Config
+
+        c = Config()
+        assert c.get('missing', 42) == 42
+        c.x = 10
+        assert c.get('x', 42) == 10
+
+    def test_contains(self):
+        from pluto.compat.wandb.config import Config
+
+        c = Config()
+        c.lr = 0.01
+        assert 'lr' in c
+        assert 'missing' not in c
+
+    def test_len(self):
+        from pluto.compat.wandb.config import Config
+
+        c = Config()
+        assert len(c) == 0
+        c.update({'a': 1, 'b': 2})
+        assert len(c) == 2
+
+    def test_iter(self):
+        from pluto.compat.wandb.config import Config
+
+        c = Config()
+        c.update({'a': 1, 'b': 2})
+        assert set(c) == {'a', 'b'}
+
+    def test_load(self):
+        from pluto.compat.wandb.config import Config
+
+        c = Config()
+        c._load({'x': 1, 'y': 2})
+        assert c.x == 1
+        assert c['y'] == 2
+
+    def test_as_dict(self):
+        from pluto.compat.wandb.config import Config
+
+        c = Config()
+        c.update({'a': 1})
+        assert c.as_dict() == {'a': 1}
+
+    def test_attribute_error_on_missing(self):
+        from pluto.compat.wandb.config import Config
+
+        c = Config()
+        with pytest.raises(AttributeError):
+            _ = c.missing_key
+
+    def test_sync_calls_update_config(self):
+        from pluto.compat.wandb.config import Config
+
+        mock_op = MagicMock()
+        c = Config(op=mock_op)
+        c.lr = 0.01
+        mock_op.update_config.assert_called_with({'lr': 0.01})
+
+    def test_sync_error_does_not_raise(self):
+        from pluto.compat.wandb.config import Config
+
+        mock_op = MagicMock()
+        mock_op.update_config.side_effect = RuntimeError('connection failed')
+        c = Config(op=mock_op)
+        c.lr = 0.01  # should not raise
+        assert c.lr == 0.01
+
+
+class TestSummary:
+    """Tests for the wandb.summary-compatible Summary class."""
+
+    def test_dict_set_and_get(self):
+        from pluto.compat.wandb.summary import Summary
+
+        s = Summary()
+        s['best_acc'] = 0.95
+        assert s['best_acc'] == 0.95
+
+    def test_attribute_set_and_get(self):
+        from pluto.compat.wandb.summary import Summary
+
+        s = Summary()
+        s.final_loss = 0.1
+        assert s.final_loss == 0.1
+
+    def test_update_from_log(self):
+        from pluto.compat.wandb.summary import Summary
+
+        s = Summary()
+        s._update_from_log({'loss': 0.5, 'acc': 0.9})
+        assert s['loss'] == 0.5
+        assert s['acc'] == 0.9
+
+    def test_update_from_log_ignores_non_scalars(self):
+        from pluto.compat.wandb.summary import Summary
+
+        s = Summary()
+        s._update_from_log({'loss': 0.5, 'image': 'not_a_scalar', 'flag': True})
+        assert s['loss'] == 0.5
+        assert 'image' not in s
+        assert 'flag' not in s  # bools excluded
+
+    def test_manual_override(self):
+        from pluto.compat.wandb.summary import Summary
+
+        s = Summary()
+        s._update_from_log({'loss': 0.5})
+        s['loss'] = 0.1  # manual override
+        assert s['loss'] == 0.1
+
+    def test_keys_values_items(self):
+        from pluto.compat.wandb.summary import Summary
+
+        s = Summary()
+        s.update({'a': 1, 'b': 2})
+        assert set(s.keys()) == {'a', 'b'}
+
+    def test_get_default(self):
+        from pluto.compat.wandb.summary import Summary
+
+        s = Summary()
+        assert s.get('missing', 99) == 99
+
+    def test_contains(self):
+        from pluto.compat.wandb.summary import Summary
+
+        s = Summary()
+        s.x = 1
+        assert 'x' in s
+        assert 'y' not in s
+
+    def test_as_dict(self):
+        from pluto.compat.wandb.summary import Summary
+
+        s = Summary()
+        s.update({'a': 1})
+        assert s.as_dict() == {'a': 1}
+
+
+class TestDataTypes:
+    """Tests for wandb data type wrappers."""
+
+    def test_image_from_numpy(self):
+        from pluto.compat.wandb.data_types import Image
+
+        data = np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8)
+        img = Image(data, caption='test')
+        assert img.caption == 'test'
+        pluto_img = img._to_pluto()
+        assert pluto_img.__class__.__name__ == 'Image'
+
+    def test_image_from_path(self, tmp_path):
+        from pluto.compat.wandb.data_types import Image
+
+        p = tmp_path / 'test.png'
+        # Write a minimal PNG
+        from PIL import Image as PILImage
+
+        pil = PILImage.new('RGB', (10, 10))
+        pil.save(str(p))
+
+        img = Image(str(p))
+        pluto_img = img._to_pluto()
+        assert pluto_img.__class__.__name__ == 'Image'
+
+    def test_audio_wrapper(self):
+        from pluto.compat.wandb.data_types import Audio
+
+        data = np.random.randn(16000).astype(np.float32)
+        a = Audio(data, sample_rate=16000, caption='test_audio')
+        pluto_audio = a._to_pluto()
+        assert pluto_audio.__class__.__name__ == 'Audio'
+
+    def test_video_wrapper(self, tmp_path):
+        from pluto.compat.wandb.data_types import Video
+
+        p = tmp_path / 'test.mp4'
+        p.write_bytes(b'\x00' * 100)
+        v = Video(str(p), fps=30, caption='test_video')
+        pluto_video = v._to_pluto()
+        assert pluto_video.__class__.__name__ == 'Video'
+
+    def test_table_from_data(self):
+        from pluto.compat.wandb.data_types import Table
+
+        t = Table(columns=['a', 'b'], data=[[1, 2], [3, 4]])
+        assert t.columns == ['a', 'b']
+        pluto_table = t._to_pluto()
+        assert pluto_table.__class__.__name__ == 'Table'
+
+    def test_table_add_data(self):
+        from pluto.compat.wandb.data_types import Table
+
+        t = Table(columns=['x', 'y'])
+        t.add_data(1, 2)
+        t.add_data(3, 4)
+        assert len(t._data) == 2
+
+    def test_table_add_column(self):
+        from pluto.compat.wandb.data_types import Table
+
+        t = Table(columns=['x'], data=[[1], [2]])
+        t.add_column('y', [10, 20])
+        assert 'y' in t.columns
+        assert t._data[0] == [1, 10]
+
+    def test_table_get_column(self):
+        from pluto.compat.wandb.data_types import Table
+
+        t = Table(columns=['a', 'b'], data=[[1, 2], [3, 4]])
+        assert t.get_column('a') == [1, 3]
+        assert t.get_column('b') == [2, 4]
+        assert t.get_column('missing') == []
+
+    def test_table_from_dataframe(self):
+        import pandas as pd
+
+        from pluto.compat.wandb.data_types import Table
+
+        df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+        t = Table(dataframe=df)
+        pluto_table = t._to_pluto()
+        assert pluto_table.__class__.__name__ == 'Table'
+
+    def test_histogram_from_sequence(self):
+        from pluto.compat.wandb.data_types import Histogram
+
+        h = Histogram(sequence=[1, 2, 3, 4, 5], num_bins=10)
+        pluto_hist = h._to_pluto()
+        assert pluto_hist.__class__.__name__ == 'Histogram'
+
+    def test_histogram_from_np_histogram(self):
+        from pluto.compat.wandb.data_types import Histogram
+
+        counts, bins = np.histogram([1, 2, 3, 4, 5], bins=5)
+        h = Histogram(np_histogram=(counts, bins))
+        pluto_hist = h._to_pluto()
+        assert pluto_hist.__class__.__name__ == 'Histogram'
+
+    def test_html_from_string(self):
+        from pluto.compat.wandb.data_types import Html
+
+        h = Html('<h1>Hello</h1>')
+        pluto_text = h._to_pluto()
+        assert pluto_text.__class__.__name__ == 'Text'
+
+    def test_html_from_file(self, tmp_path):
+        from pluto.compat.wandb.data_types import Html
+
+        p = tmp_path / 'test.html'
+        p.write_text('<h1>Hello</h1>')
+        h = Html(str(p))
+        assert h._html == '<h1>Hello</h1>'
+
+    def test_alert_level(self):
+        from pluto.compat.wandb.data_types import AlertLevel
+
+        assert AlertLevel.INFO == 'INFO'
+        assert AlertLevel.WARN == 'WARN'
+        assert AlertLevel.ERROR == 'ERROR'
+
+    def test_artifact_add_file(self, tmp_path):
+        from pluto.compat.wandb.data_types import Artifact
+
+        f1 = tmp_path / 'model.pt'
+        f1.write_bytes(b'\x00' * 100)
+        art = Artifact('my-model', type='model')
+        art.add_file(str(f1), name='model.pt')
+        assert len(art._files) == 1
+        assert art._files[0]['name'] == 'model.pt'
+
+    def test_artifact_add_dir(self, tmp_path):
+        from pluto.compat.wandb.data_types import Artifact
+
+        d = tmp_path / 'data'
+        d.mkdir()
+        (d / 'a.txt').write_text('hello')
+        (d / 'b.txt').write_text('world')
+        art = Artifact('my-data', type='dataset')
+        art.add_dir(str(d))
+        assert len(art._files) == 2
+
+    def test_artifact_to_pluto_files(self, tmp_path):
+        from pluto.compat.wandb.data_types import Artifact
+
+        f1 = tmp_path / 'file.bin'
+        f1.write_bytes(b'\x00' * 50)
+        art = Artifact('test', type='model')
+        art.add_file(str(f1))
+        pluto_files = art._to_pluto_files()
+        assert len(pluto_files) == 1
+        assert pluto_files[0].__class__.__name__ == 'Artifact'
+
+    def test_graph_wrapper(self):
+        from pluto.compat.wandb.data_types import Graph
+
+        g = Graph()
+        pluto_graph = g._to_pluto()
+        assert pluto_graph.__class__.__name__ == 'Graph'
+
+
+class TestRun:
+    """Tests for the wandb.Run-compatible Run class."""
+
+    def _make_run(self, **kwargs):
+        """Create a Run with a mocked Op."""
+        from pluto.compat.wandb.run import Run
+
+        op = MagicMock()
+        op.id = 123
+        op.run_id = None
+        op.tags = ['tag1']
+        op.resumed = False
+        op.settings = MagicMock()
+        op.settings._op_name = 'test-run'
+        op.settings.project = 'test-project'
+        op.settings.url_view = 'https://pluto.trainy.ai/run/123'
+        op.settings.get_dir.return_value = '/tmp/test-run'
+        op.config = {}
+        return Run(op=op, **kwargs), op
+
+    def test_properties(self):
+        run, op = self._make_run(name='my-run', notes='some notes', group='grp')
+        assert run.id == '123'
+        assert run.name == 'my-run'
+        assert run.project == 'test-project'
+        assert run.notes == 'some notes'
+        assert run.group == 'grp'
+        assert run.entity == ''
+        assert run.url == 'https://pluto.trainy.ai/run/123'
+
+    def test_tags_get_and_set(self):
+        run, op = self._make_run()
+        assert run.tags == ('tag1',)
+
+        # Setting tags
+        run.tags = ('tag1', 'tag2')
+        op.add_tags.assert_called()
+
+    def test_name_setter(self):
+        run, op = self._make_run(name='original')
+        run.name = 'new-name'
+        assert run.name == 'new-name'
+
+    def test_log_scalars(self):
+        run, op = self._make_run()
+        run.log({'loss': 0.5, 'acc': 0.9})
+        op.log.assert_called_once()
+        logged_data = op.log.call_args[0][0]
+        assert logged_data['loss'] == 0.5
+        assert logged_data['acc'] == 0.9
+
+    def test_log_nested_dict(self):
+        run, op = self._make_run()
+        run.log({'train': {'loss': 0.5}})
+        op.log.assert_called_once()
+        logged_data = op.log.call_args[0][0]
+        assert 'train/loss' in logged_data
+
+    def test_log_with_step(self):
+        run, op = self._make_run()
+        run.log({'loss': 0.5}, step=10)
+        op.log.assert_called_once()
+        assert op.log.call_args[1]['step'] == 10
+
+    def test_log_commit_false(self):
+        run, op = self._make_run()
+        run.log({'loss': 0.5}, commit=False)
+        op.log.assert_not_called()
+
+        run.log({'acc': 0.9})  # default commit=True
+        op.log.assert_called_once()
+        logged_data = op.log.call_args[0][0]
+        assert 'loss' in logged_data
+        assert 'acc' in logged_data
+
+    def test_log_updates_summary(self):
+        run, op = self._make_run()
+        run.log({'loss': 0.5})
+        assert run.summary['loss'] == 0.5
+
+    def test_log_converts_data_types(self):
+        from pluto.compat.wandb.data_types import Image
+
+        run, op = self._make_run()
+        data = np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8)
+        run.log({'image': Image(data)})
+        op.log.assert_called_once()
+        logged_data = op.log.call_args[0][0]
+        assert logged_data['image'].__class__.__name__ == 'Image'
+
+    def test_finish(self):
+        run, op = self._make_run()
+        run.finish()
+        op.finish.assert_called_once()
+
+    def test_finish_with_exit_code(self):
+        run, op = self._make_run()
+        run.finish(exit_code=1)
+        op.finish.assert_called_once_with(code=1)
+
+    def test_context_manager(self):
+        run, op = self._make_run()
+        with run:
+            run.log({'x': 1})
+        op.finish.assert_called_once_with(code=0)
+
+    def test_context_manager_with_exception(self):
+        run, op = self._make_run()
+        with pytest.raises(ValueError):
+            with run:
+                raise ValueError('test')
+        op.finish.assert_called_once_with(code=1)
+
+    def test_watch(self):
+        run, op = self._make_run()
+        model = MagicMock()
+        run.watch(model, log_freq=500)
+        op.watch.assert_called_once_with(model, log_freq=500)
+
+    def test_alert(self):
+        run, op = self._make_run()
+        run.alert(title='Loss spike', text='Loss exceeded 10.0', level='WARN')
+        op.alert.assert_called_once()
+
+    def test_define_metric_returns_stub(self):
+        run, op = self._make_run()
+        m = run.define_metric('loss', step_metric='epoch')
+        assert m.name == 'loss'
+
+    def test_unsupported_methods_no_error(self):
+        run, op = self._make_run()
+        run.save()
+        run.restore('test')
+        run.log_code()
+        run.mark_preempting()
+        run.use_artifact('test')
+
+    def test_log_artifact_with_artifact_object(self, tmp_path):
+        from pluto.compat.wandb.data_types import Artifact
+
+        run, op = self._make_run()
+        f = tmp_path / 'model.pt'
+        f.write_bytes(b'\x00' * 100)
+        art = Artifact('model', type='model')
+        art.add_file(str(f))
+        run.log_artifact(art)
+        op.log.assert_called()
+
+    def test_repr(self):
+        run, op = self._make_run(name='exp-1')
+        r = repr(run)
+        assert 'test-project' in r
+        assert 'exp-1' in r
+
+    def test_step_tracking(self):
+        run, op = self._make_run()
+        assert run.step == 0
+        run.log({'x': 1})
+        assert run.step == 1
+        run.log({'x': 2})
+        assert run.step == 2
+        run.log({'x': 3}, step=10)
+        assert run.step == 10
+
+    def test_offline_disabled(self):
+        run_online, _ = self._make_run(mode='online')
+        assert not run_online.offline
+        assert not run_online.disabled
+
+        run_off, _ = self._make_run(mode='offline')
+        assert run_off.offline
+
+        run_dis, _ = self._make_run(mode='disabled')
+        assert run_dis.disabled
+
+    def test_path(self):
+        run, _ = self._make_run()
+        assert run.path == '/test-project/123'
+
+
+class TestModuleAPI:
+    """Tests for the module-level wandb API (init, log, finish, etc.)."""
+
+    def test_log_before_init_raises(self):
+        import pluto.compat.wandb as wandb
+
+        # Ensure no active run
+        wandb.run = None
+        with pytest.raises(RuntimeError, match='wandb.log.*called before wandb.init'):
+            wandb.log({'x': 1})
+
+    def test_watch_before_init_raises(self):
+        import pluto.compat.wandb as wandb
+
+        wandb.run = None
+        with pytest.raises(RuntimeError, match='wandb.watch.*called before wandb.init'):
+            wandb.watch(MagicMock())
+
+    def test_finish_without_init_is_noop(self):
+        import pluto.compat.wandb as wandb
+
+        wandb.run = None
+        wandb.finish()  # should not raise
+
+    def test_define_metric_without_init(self):
+        import pluto.compat.wandb as wandb
+
+        wandb.run = None
+        m = wandb.define_metric('loss')
+        assert m.name == 'loss'
+
+    def test_unsupported_module_functions_noop(self):
+        import pluto.compat.wandb as wandb
+
+        # These should all be no-ops, never raise
+        wandb.save('*.pt')
+        wandb.restore('model.pt')
+        wandb.log_code()
+        wandb.mark_preempting()
+
+    def test_login_returns_true(self):
+        import pluto.compat.wandb as wandb
+
+        assert wandb.login() is True
+
+    def test_settings_class(self):
+        import pluto.compat.wandb as wandb
+
+        s = wandb.Settings(mode='offline', console='auto')
+        assert s.mode == 'offline'
+        assert s.console == 'auto'
+
+    def test_data_types_importable(self):
+        """Test that all wandb data types are importable from the module."""
+        from pluto.compat.wandb import (
+            AlertLevel,
+            Artifact,
+            Audio,
+            Graph,
+            Histogram,
+            Html,
+            Image,
+            Table,
+            Video,
+        )
+
+        assert Image is not None
+        assert Audio is not None
+        assert Video is not None
+        assert Table is not None
+        assert Histogram is not None
+        assert Html is not None
+        assert Graph is not None
+        assert Artifact is not None
+        assert AlertLevel is not None
+
+    def test_import_as_wandb(self):
+        """Test the canonical import pattern."""
+        import pluto.compat.wandb as wandb
+
+        assert hasattr(wandb, 'init')
+        assert hasattr(wandb, 'log')
+        assert hasattr(wandb, 'finish')
+        assert hasattr(wandb, 'watch')
+        assert hasattr(wandb, 'unwatch')
+        assert hasattr(wandb, 'alert')
+        assert hasattr(wandb, 'config')
+        assert hasattr(wandb, 'summary')
+        assert hasattr(wandb, 'run')
+        assert hasattr(wandb, 'Image')
+        assert hasattr(wandb, 'Table')
+        assert hasattr(wandb, 'Run')
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            'WANDB_PROJECT': 'env-project',
+        },
+        clear=False,
+    )
+    def test_init_picks_up_wandb_project_env(self):
+        """Test that WANDB_PROJECT env var is used as fallback."""
+        import pluto.compat.wandb as wandb
+
+        with mock.patch('pluto.init') as mock_init:
+            mock_op = MagicMock()
+            mock_op.id = 1
+            mock_op.run_id = None
+            mock_op.tags = []
+            mock_op.resumed = False
+            mock_op.settings = MagicMock()
+            mock_op.settings._op_name = 'test'
+            mock_op.settings.project = 'env-project'
+            mock_op.settings.url_view = None
+            mock_op.settings.get_dir.return_value = '/tmp'
+            mock_op.config = {}
+            mock_init.return_value = mock_op
+
+            wandb.init()
+            mock_init.assert_called_once()
+            assert mock_init.call_args[1]['project'] == 'env-project'
+            wandb.finish()
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            'WANDB_MODE': 'disabled',
+        },
+        clear=False,
+    )
+    def test_init_disabled_mode_from_env(self):
+        """Test that WANDB_MODE=disabled creates noop run."""
+        import pluto.compat.wandb as wandb
+
+        with mock.patch('pluto.init') as mock_init:
+            mock_op = MagicMock()
+            mock_op.id = 1
+            mock_op.run_id = None
+            mock_op.tags = []
+            mock_op.resumed = False
+            mock_op.settings = MagicMock()
+            mock_op.settings._op_name = 'test'
+            mock_op.settings.project = 'test'
+            mock_op.settings.url_view = None
+            mock_op.settings.get_dir.return_value = '/tmp'
+            mock_op.config = {}
+            mock_init.return_value = mock_op
+
+            wandb.init(project='test')
+            # Should pass mode='noop' in settings
+            call_kwargs = mock_init.call_args[1]
+            settings = call_kwargs.get('settings', {})
+            assert settings.get('mode') == 'noop'
+            wandb.finish()
+
+    def test_init_creates_disabled_run_on_failure(self):
+        """Test that init creates a disabled run if pluto.init fails."""
+        import pluto.compat.wandb as wandb
+
+        with mock.patch('pluto.init') as mock_init:
+            # First call fails, second call (disabled) succeeds
+            mock_op = MagicMock()
+            mock_op.id = 0
+            mock_op.run_id = None
+            mock_op.tags = []
+            mock_op.resumed = False
+            mock_op.settings = MagicMock()
+            mock_op.settings._op_name = 'disabled'
+            mock_op.settings.project = 'disabled'
+            mock_op.settings.url_view = None
+            mock_op.settings.get_dir.return_value = '/tmp'
+            mock_op.config = {}
+            mock_init.side_effect = [RuntimeError('auth failed'), mock_op]
+
+            run = wandb.init(project='test')
+            assert run.disabled
+            wandb.finish()
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            'WANDB_TAGS': 'tag1,tag2, tag3',
+        },
+        clear=False,
+    )
+    def test_init_tags_from_env(self):
+        """Test that WANDB_TAGS env var is parsed."""
+        import pluto.compat.wandb as wandb
+
+        with mock.patch('pluto.init') as mock_init:
+            mock_op = MagicMock()
+            mock_op.id = 1
+            mock_op.run_id = None
+            mock_op.tags = ['tag1', 'tag2', 'tag3']
+            mock_op.resumed = False
+            mock_op.settings = MagicMock()
+            mock_op.settings._op_name = 'test'
+            mock_op.settings.project = 'test'
+            mock_op.settings.url_view = None
+            mock_op.settings.get_dir.return_value = '/tmp'
+            mock_op.config = {}
+            mock_init.return_value = mock_op
+
+            wandb.init(project='test')
+            call_kwargs = mock_init.call_args[1]
+            assert call_kwargs['tags'] == ['tag1', 'tag2', 'tag3']
+            wandb.finish()
+
+
+class TestFlattenDict:
+    """Tests for nested dict flattening (wandb convention)."""
+
+    def test_flat_dict_unchanged(self):
+        from pluto.compat.wandb.run import _flatten_dict
+
+        assert _flatten_dict({'a': 1, 'b': 2}) == {'a': 1, 'b': 2}
+
+    def test_nested_dict(self):
+        from pluto.compat.wandb.run import _flatten_dict
+
+        result = _flatten_dict({'train': {'loss': 0.5, 'acc': 0.9}})
+        assert result == {'train/loss': 0.5, 'train/acc': 0.9}
+
+    def test_deeply_nested(self):
+        from pluto.compat.wandb.run import _flatten_dict
+
+        result = _flatten_dict({'a': {'b': {'c': 1}}})
+        assert result == {'a/b/c': 1}
+
+    def test_mixed_nesting(self):
+        from pluto.compat.wandb.run import _flatten_dict
+
+        result = _flatten_dict({'loss': 0.5, 'train': {'acc': 0.9}})
+        assert result == {'loss': 0.5, 'train/acc': 0.9}
+
+
+class TestValueConversion:
+    """Tests for wandb data type → pluto type conversion in log()."""
+
+    def test_scalar_passthrough(self):
+        from pluto.compat.wandb.run import _convert_value
+
+        assert _convert_value(42) == 42
+        assert _convert_value(3.14) == 3.14
+        assert _convert_value('hello') == 'hello'
+
+    def test_image_converted(self):
+        from pluto.compat.wandb.data_types import Image
+        from pluto.compat.wandb.run import _convert_value
+
+        data = np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8)
+        img = Image(data)
+        result = _convert_value(img)
+        assert result.__class__.__name__ == 'Image'
+        # Should be pluto Image, not wandb Image
+        assert result.__class__.__module__.startswith('pluto.file')
+
+    def test_table_converted(self):
+        from pluto.compat.wandb.data_types import Table
+        from pluto.compat.wandb.run import _convert_value
+
+        t = Table(columns=['a'], data=[[1], [2]])
+        result = _convert_value(t)
+        assert result.__class__.__name__ == 'Table'
+        assert result.__class__.__module__.startswith('pluto.data')
+
+    def test_histogram_converted(self):
+        from pluto.compat.wandb.data_types import Histogram
+        from pluto.compat.wandb.run import _convert_value
+
+        h = Histogram(sequence=[1, 2, 3, 4, 5])
+        result = _convert_value(h)
+        assert result.__class__.__name__ == 'Histogram'
+        assert result.__class__.__module__.startswith('pluto.data')

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -175,7 +175,7 @@ class TestSummary:
         s._update_from_log({'loss': 0.5, 'image': 'not_a_scalar', 'flag': True})
         assert s['loss'] == 0.5
         assert 'image' not in s
-        assert 'flag' not in s  # bools excluded
+        assert s['flag'] is True  # bools are scalar subclass of int
 
     def test_manual_override(self):
         from pluto.compat.wandb.summary import Summary
@@ -412,7 +412,7 @@ class TestRun:
 
         # Setting tags
         run.tags = ('tag1', 'tag2')
-        op.add_tags.assert_called()
+        op.add_tags.assert_called_with(['tag2'])
 
     def test_name_setter(self):
         run, op = self._make_run(name='original')

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -481,9 +481,17 @@ class TestRun:
         run, op = self._make_run()
         assert run.tags == ('tag1',)
 
-        # Setting tags
+        # Setting tags — tag1 kept, tag2 added
         run.tags = ('tag1', 'tag2')
+        op.remove_tags.assert_not_called()
         op.add_tags.assert_called_with(['tag2'])
+
+        # Replace tags — tag1 removed, tag3 added
+        op.reset_mock()
+        op.tags = ['tag1', 'tag2']
+        run.tags = ('tag2', 'tag3')
+        op.remove_tags.assert_called_once_with(['tag1'])
+        op.add_tags.assert_called_once_with(['tag3'])
 
     def test_name_setter(self):
         run, op = self._make_run(name='original')

--- a/tests/test_wandb_coverage.py
+++ b/tests/test_wandb_coverage.py
@@ -1,0 +1,352 @@
+"""Tests for wandb API coverage registry and warnings."""
+
+import json
+import os
+import subprocess
+import sys
+import warnings
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from pluto.compat.wandb._coverage import (
+    WANDB_API_REGISTRY,
+    ApiEntry,
+    PlutoWandbCompatWarning,
+    SupportLevel,
+    reset_warnings,
+    warn_unsupported,
+)
+
+
+class TestRegistry:
+    """Verify the registry is well-formed and complete."""
+
+    def test_registry_not_empty(self):
+        assert len(WANDB_API_REGISTRY) > 0
+
+    def test_all_entries_are_api_entry(self):
+        for key, entry in WANDB_API_REGISTRY.items():
+            assert isinstance(entry, ApiEntry), f"{key} is not an ApiEntry"
+            assert isinstance(entry.level, SupportLevel), f"{key} has invalid level"
+
+    def test_registry_keys_are_qualified(self):
+        """All keys should be like 'wandb.X' or 'wandb.Run.X'."""
+        for key in WANDB_API_REGISTRY:
+            assert key.startswith("wandb."), f"Key {key} doesn't start with 'wandb.'"
+
+    def test_supported_apis_exist_in_shim(self):
+        """Everything marked SUPPORTED should exist in our shim."""
+        import pluto.compat.wandb as wandb_shim
+        from pluto.compat.wandb.run import Run
+
+        for key, entry in WANDB_API_REGISTRY.items():
+            if entry.level != SupportLevel.SUPPORTED:
+                continue
+
+            parts = key.split(".")
+            if len(parts) == 2:
+                # wandb.X — check module or __all__
+                name = parts[1]
+                has_attr = hasattr(wandb_shim, name)
+                in_all = name in wandb_shim.__all__
+                assert has_attr or in_all, (
+                    f"{key} marked SUPPORTED but not found in shim"
+                )
+            elif len(parts) == 3 and parts[1] == "Run":
+                # wandb.Run.X — check Run class
+                name = parts[2]
+                assert hasattr(Run, name), (
+                    f"{key} marked SUPPORTED but Run.{name} doesn't exist"
+                )
+
+    def test_registry_covers_shim_all(self):
+        """Every item in our shim's __all__ should have a registry entry."""
+        from pluto.compat.wandb import __all__ as shim_all
+
+        for name in shim_all:
+            key = f"wandb.{name}"
+            assert key in WANDB_API_REGISTRY, (
+                f"{key} is in shim __all__ but missing from registry"
+            )
+
+    def test_registry_covers_run_public_api(self):
+        """Every public method/property on our Run should be registered."""
+        from pluto.compat.wandb.run import Run
+
+        for name in dir(Run):
+            if name.startswith("_"):
+                continue
+            key = f"wandb.Run.{name}"
+            assert key in WANDB_API_REGISTRY, (
+                f"Run.{name} exists in shim but {key} missing from registry"
+            )
+
+    def test_registry_covers_plot_functions(self):
+        """Every function in our plot shim should be registered."""
+        import types
+
+        import wandb.plot as plot_mod
+
+        for name in dir(plot_mod):
+            if name.startswith("_"):
+                continue
+            obj = getattr(plot_mod, name, None)
+            if not callable(obj):
+                continue
+            if not isinstance(obj, types.FunctionType):
+                continue
+            # Skip imports that aren't plot functions
+            if obj.__module__ != plot_mod.__name__:
+                continue
+            key = f"wandb.plot.{name}"
+            assert key in WANDB_API_REGISTRY, (
+                f"wandb.plot.{name} exists but {key} missing from registry"
+            )
+
+
+class TestWarnings:
+    """Verify warnings are emitted correctly."""
+
+    def setup_method(self):
+        reset_warnings()
+
+    def test_stub_emits_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warn_unsupported("wandb.save")
+            assert len(w) == 1
+            assert issubclass(w[0].category, PlutoWandbCompatWarning)
+            assert "no-op" in str(w[0].message)
+
+    def test_not_implemented_emits_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warn_unsupported("wandb.Api.runs")
+            assert len(w) == 1
+            assert "not implemented" in str(w[0].message)
+
+    def test_partial_emits_warning_with_notes(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warn_unsupported("wandb.login")
+            assert len(w) == 1
+            assert "limited support" in str(w[0].message)
+            assert "pluto login" in str(w[0].message)
+
+    def test_supported_no_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warn_unsupported("wandb.init")
+            assert len(w) == 0
+
+    def test_unknown_api_no_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warn_unsupported("wandb.nonexistent_api_xyz")
+            assert len(w) == 0
+
+    def test_warns_only_once(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warn_unsupported("wandb.save")
+            warn_unsupported("wandb.save")
+            warn_unsupported("wandb.save")
+            assert len(w) == 1
+
+    def test_different_apis_warn_independently(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warn_unsupported("wandb.save")
+            warn_unsupported("wandb.restore")
+            assert len(w) == 2
+
+    def test_reset_warnings_allows_rewarn(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warn_unsupported("wandb.save")
+            assert len(w) == 1
+            reset_warnings()
+            warn_unsupported("wandb.save")
+            assert len(w) == 2
+
+    def test_user_can_silence_warnings(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warnings.filterwarnings("ignore", category=PlutoWandbCompatWarning)
+            warn_unsupported("wandb.save")
+            assert len(w) == 0
+
+
+class TestStubsEmitWarnings:
+    """Verify that actual stub functions emit PlutoWandbCompatWarning."""
+
+    def setup_method(self):
+        reset_warnings()
+
+    def test_module_save_warns(self):
+        import pluto.compat.wandb as wandb_shim
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wandb_shim.save()
+            assert any(issubclass(x.category, PlutoWandbCompatWarning) for x in w)
+
+    def test_module_restore_warns(self):
+        import pluto.compat.wandb as wandb_shim
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wandb_shim.restore()
+            assert any(issubclass(x.category, PlutoWandbCompatWarning) for x in w)
+
+    def test_module_use_artifact_warns(self):
+        import pluto.compat.wandb as wandb_shim
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wandb_shim.use_artifact("test")
+            assert any(issubclass(x.category, PlutoWandbCompatWarning) for x in w)
+
+    def test_module_log_code_warns(self):
+        import pluto.compat.wandb as wandb_shim
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wandb_shim.log_code()
+            assert any(issubclass(x.category, PlutoWandbCompatWarning) for x in w)
+
+    def test_module_mark_preempting_warns(self):
+        import pluto.compat.wandb as wandb_shim
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wandb_shim.mark_preempting()
+            assert any(issubclass(x.category, PlutoWandbCompatWarning) for x in w)
+
+    def test_module_login_warns(self):
+        import pluto.compat.wandb as wandb_shim
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            wandb_shim.login()
+            assert any(issubclass(x.category, PlutoWandbCompatWarning) for x in w)
+
+    def test_plot_scatter_warns(self):
+        import wandb.plot as plot
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            plot.scatter(None, None, None)
+            assert any(issubclass(x.category, PlutoWandbCompatWarning) for x in w)
+
+    def test_api_runs_warns(self):
+        from wandb.apis import Api
+
+        api = Api()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with pytest.raises(NotImplementedError):
+                api.runs()
+            assert any(issubclass(x.category, PlutoWandbCompatWarning) for x in w)
+
+    def test_run_save_warns(self):
+        """Run.save() should emit a warning."""
+        from pluto.compat.wandb.run import Run
+
+        mock_op = MagicMock()
+        mock_op.run_id = "test"
+        mock_op.tags = []
+        run = Run(op=mock_op)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            run.save()
+            assert any(issubclass(x.category, PlutoWandbCompatWarning) for x in w)
+
+
+class TestCoverageScript:
+    """Test the coverage report script."""
+
+    def test_summary_format(self):
+        result = subprocess.run(
+            [sys.executable, "scripts/wandb_coverage.py", "--format", "summary"],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+        )
+        assert result.returncode == 0
+        assert "wandb coverage:" in result.stdout
+
+    def test_json_format(self):
+        result = subprocess.run(
+            [sys.executable, "scripts/wandb_coverage.py", "--format", "json"],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "registry_stats" in data
+        assert "top_level" in data
+        assert "run_methods" in data
+        assert "plot_functions" in data
+
+    def test_markdown_format(self):
+        result = subprocess.run(
+            [sys.executable, "scripts/wandb_coverage.py", "--format", "markdown"],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+        )
+        assert result.returncode == 0
+        assert "# wandb API Coverage Report" in result.stdout
+
+
+class TestConflictDetection:
+    """Test wandb shim conflict detection logic."""
+
+    def test_shim_disabled_by_env(self):
+        """PLUTO_WANDB_SHIM=0 always prevents shim from loading."""
+        result = subprocess.run(
+            [sys.executable, "-c", "import wandb"],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PLUTO_WANDB_SHIM": "0"},
+        )
+        assert result.returncode != 0
+        assert "pluto wandb shim is disabled" in result.stderr
+
+    def test_shim_activates_by_default(self, monkeypatch):
+        """Shim activates by default, even when real wandb is installed."""
+        monkeypatch.delenv("PLUTO_WANDB_SHIM", raising=False)
+        # Clear cached wandb module so conflict check re-runs
+        to_clear = [
+            k for k in sys.modules
+            if k == "wandb" or k.startswith("wandb.")
+        ]
+        for k in to_clear:
+            del sys.modules[k]
+
+        import wandb
+
+        # Shim should be active — init comes from pluto
+        assert hasattr(wandb, "init")
+        assert "pluto" in wandb.__file__
+
+    def test_shim_shadows_real_wandb(self):
+        """When real wandb is installed and shim active, shim wins."""
+        result = subprocess.run(
+            [
+                sys.executable, "-c",
+                "import wandb; print(wandb.__file__)",
+            ],
+            capture_output=True,
+            text=True,
+            env={
+                k: v for k, v in os.environ.items()
+                if k != "PLUTO_WANDB_SHIM"
+            },
+        )
+        assert result.returncode == 0
+        assert "pluto" in result.stdout or "wandb/__init__.py" in result.stdout

--- a/tests/test_wandb_dual.py
+++ b/tests/test_wandb_dual.py
@@ -1,0 +1,984 @@
+"""Tests for wandb dual-logging mode (PLUTO_WANDB_MODE=dual).
+
+Unit tests (mock-based):
+    - DualRun wrapper: forwarding, error isolation, context manager
+    - Scalar extraction logic
+    - setup_dual wiring
+    - Conflict detection and mode activation
+    - Coverage/warning integration with dual mode
+    - Shim mode (wandb/__init__.py): shadowing, PLUTO_WANDB_SHIM=0
+
+Integration tests (skipped when credentials absent):
+    - TestDualLive: real training loop through PLUTO_WANDB_MODE=dual
+      Requires: WANDB_API_KEY + PLUTO_API_KEY (or PLUTO_API_TOKEN)
+    - TestShimLive: real training loop through shim mode
+      Requires: PLUTO_API_KEY (or PLUTO_API_TOKEN)
+"""
+
+import importlib
+import os
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from pluto.compat.wandb.dual import DualRun, _extract_scalars
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_has_real_wandb = False
+try:
+    import importlib.metadata
+
+    _dist = importlib.metadata.distribution('wandb')
+    _dist_name = (_dist.metadata['Name'] or '').lower().replace('-', '_')
+    _has_real_wandb = _dist_name != 'pluto_ml'
+except importlib.metadata.PackageNotFoundError:
+    pass
+
+_has_pluto_key = bool(
+    os.environ.get('PLUTO_API_KEY') or os.environ.get('PLUTO_API_TOKEN')
+)
+_has_wandb_key = bool(os.environ.get('WANDB_API_KEY'))
+
+
+# ===================================================================
+# Unit tests (no credentials needed)
+# ===================================================================
+
+
+class TestExtractScalars:
+    """Test scalar extraction from log dicts."""
+
+    def test_simple_scalars(self):
+        data = {'loss': 0.5, 'acc': 0.9, 'epoch': 3}
+        result = _extract_scalars(data)
+        assert result == {'loss': 0.5, 'acc': 0.9, 'epoch': 3}
+
+    def test_nested_dicts_flattened(self):
+        data = {'train': {'loss': 0.5, 'acc': 0.9}}
+        result = _extract_scalars(data)
+        assert result == {'train/loss': 0.5, 'train/acc': 0.9}
+
+    def test_non_scalars_skipped(self):
+        data = {
+            'loss': 0.5,
+            'image': MagicMock(),
+            'text': 'hello',
+            'table': MagicMock(),
+        }
+        result = _extract_scalars(data)
+        assert result == {'loss': 0.5}
+
+    def test_booleans_converted_to_int(self):
+        data = {'flag': True, 'other': False}
+        result = _extract_scalars(data)
+        assert result == {'flag': 1, 'other': 0}
+
+    def test_empty_dict(self):
+        assert _extract_scalars({}) == {}
+
+    def test_deeply_nested(self):
+        data = {'a': {'b': {'c': 1.0}}}
+        result = _extract_scalars(data)
+        assert result == {'a/b/c': 1.0}
+
+    def test_mixed_nested(self):
+        data = {
+            'metrics': {'loss': 0.3, 'image': MagicMock()},
+            'lr': 0.001,
+        }
+        result = _extract_scalars(data)
+        assert result == {'metrics/loss': 0.3, 'lr': 0.001}
+
+    def test_integers(self):
+        data = {'epoch': 5, 'step': 100}
+        result = _extract_scalars(data)
+        assert result == {'epoch': 5, 'step': 100}
+
+    def test_none_skipped(self):
+        data = {'loss': 0.5, 'nothing': None}
+        result = _extract_scalars(data)
+        assert result == {'loss': 0.5}
+
+    def test_list_skipped(self):
+        data = {'loss': 0.5, 'values': [1, 2, 3]}
+        result = _extract_scalars(data)
+        assert result == {'loss': 0.5}
+
+
+class TestDualRun:
+    """Test the DualRun wrapper."""
+
+    def _make_dual_run(self):
+        wandb_run = MagicMock()
+        pluto_op = MagicMock()
+        return DualRun(wandb_run, pluto_op), wandb_run, pluto_op
+
+    # -- log() --
+
+    def test_log_forwards_to_both(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        data = {'loss': 0.5, 'acc': 0.9}
+
+        dual.log(data, step=1)
+
+        wandb_run.log.assert_called_once_with(
+            data, step=1, commit=None, sync=None,
+        )
+        pluto_op.log.assert_called_once_with(
+            {'loss': 0.5, 'acc': 0.9}, step=1,
+        )
+
+    def test_log_skips_non_scalars_for_pluto(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        img = MagicMock()
+        data = {'loss': 0.5, 'image': img}
+
+        dual.log(data)
+
+        wandb_run.log.assert_called_once()
+        pluto_op.log.assert_called_once_with({'loss': 0.5}, step=None)
+
+    def test_log_empty_scalars_skips_pluto(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        data = {'image': MagicMock()}
+
+        dual.log(data)
+
+        wandb_run.log.assert_called_once()
+        pluto_op.log.assert_not_called()
+
+    def test_log_with_commit_false(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        data = {'loss': 0.5}
+
+        dual.log(data, commit=False)
+
+        wandb_run.log.assert_called_once_with(
+            data, step=None, commit=False, sync=None,
+        )
+        pluto_op.log.assert_called_once()
+
+    def test_log_with_step(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+
+        dual.log({'loss': 0.5}, step=42)
+
+        pluto_op.log.assert_called_once_with({'loss': 0.5}, step=42)
+
+    def test_log_nested_dict_flattened_for_pluto(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        data = {'train': {'loss': 0.5, 'acc': 0.9}}
+
+        dual.log(data)
+
+        pluto_op.log.assert_called_once_with(
+            {'train/loss': 0.5, 'train/acc': 0.9}, step=None,
+        )
+
+    def test_pluto_log_failure_does_not_break_wandb(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        pluto_op.log.side_effect = RuntimeError('pluto down')
+
+        dual.log({'loss': 0.5})
+
+        wandb_run.log.assert_called_once()
+
+    def test_multiple_log_calls(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+
+        dual.log({'loss': 1.0}, step=0)
+        dual.log({'loss': 0.5}, step=1)
+        dual.log({'loss': 0.1}, step=2)
+
+        assert wandb_run.log.call_count == 3
+        assert pluto_op.log.call_count == 3
+
+    # -- finish() --
+
+    def test_finish_calls_both(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+
+        dual.finish(exit_code=0)
+
+        pluto_op.finish.assert_called_once()
+        wandb_run.finish.assert_called_once_with(
+            exit_code=0, quiet=None,
+        )
+
+    def test_finish_pluto_failure_still_finishes_wandb(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        pluto_op.finish.side_effect = RuntimeError('pluto down')
+
+        dual.finish()
+
+        wandb_run.finish.assert_called_once()
+
+    def test_finish_pluto_only_once(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+
+        dual.finish()
+        dual.finish()
+
+        pluto_op.finish.assert_called_once()
+        assert wandb_run.finish.call_count == 2
+
+    def test_finish_with_exit_code(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+
+        dual.finish(exit_code=1, quiet=True)
+
+        wandb_run.finish.assert_called_once_with(
+            exit_code=1, quiet=True,
+        )
+
+    # -- watch() --
+
+    def test_watch_forwards_to_both(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        model = MagicMock()
+
+        dual.watch(model, log_freq=500)
+
+        wandb_run.watch.assert_called_once()
+        pluto_op.watch.assert_called_once_with(model, log_freq=500)
+
+    def test_watch_multiple_models(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        models = [MagicMock(), MagicMock()]
+
+        dual.watch(models, log_freq=100)
+
+        wandb_run.watch.assert_called_once()
+        assert pluto_op.watch.call_count == 2
+
+    def test_watch_none_model_skips_pluto(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+
+        dual.watch(None)
+
+        wandb_run.watch.assert_called_once()
+        pluto_op.watch.assert_not_called()
+
+    def test_watch_pluto_failure_still_watches_wandb(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        pluto_op.watch.side_effect = RuntimeError('no torch')
+        model = MagicMock()
+
+        dual.watch(model)
+
+        wandb_run.watch.assert_called_once()
+
+    def test_unwatch_forwards_to_wandb(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+
+        dual.unwatch()
+
+        wandb_run.unwatch.assert_called_once()
+
+    # -- config / summary --
+
+    def test_config_property_returns_wandb_config(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        wandb_run.config = {'lr': 0.01}
+
+        assert dual.config == {'lr': 0.01}
+
+    def test_config_setter_mirrors_to_pluto(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+
+        dual.config = {'lr': 0.01, 'batch_size': 32}
+
+        pluto_op.update_config.assert_called_once_with(
+            {'lr': 0.01, 'batch_size': 32},
+        )
+
+    def test_config_setter_non_dict_skips_pluto(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+
+        dual.config = 'not a dict'
+
+        pluto_op.update_config.assert_not_called()
+
+    def test_summary_property_returns_wandb_summary(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        wandb_run.summary = {'best_loss': 0.1}
+
+        assert dual.summary == {'best_loss': 0.1}
+
+    # -- attribute forwarding --
+
+    def test_getattr_falls_through_to_wandb(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        wandb_run.id = 'abc123'
+        wandb_run.name = 'cool-run'
+        wandb_run.project = 'my-project'
+
+        assert dual.id == 'abc123'
+        assert dual.name == 'cool-run'
+        assert dual.project == 'my-project'
+
+    def test_setattr_forwards_to_wandb(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+
+        dual.name = 'new-name'
+        dual.notes = 'some notes'
+
+        assert wandb_run.name == 'new-name'
+        assert wandb_run.notes == 'some notes'
+
+    def test_repr(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+        r = repr(dual)
+        assert 'DualRun' in r
+
+    # -- context manager --
+
+    def test_context_manager(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+
+        with dual as run:
+            run.log({'loss': 1.0})
+
+        pluto_op.finish.assert_called_once()
+        wandb_run.finish.assert_called_once()
+
+    def test_context_manager_with_exception(self):
+        dual, wandb_run, pluto_op = self._make_dual_run()
+
+        with pytest.raises(ValueError):
+            with dual:
+                raise ValueError('boom')
+
+        wandb_run.finish.assert_called_once_with(
+            exit_code=1, quiet=None,
+        )
+        pluto_op.finish.assert_called_once()
+
+    # -- edge cases --
+
+    def test_no_pluto_op_still_works(self):
+        """DualRun with pluto_op=None should just forward to wandb."""
+        wandb_run = MagicMock()
+        dual = DualRun(wandb_run, None)
+
+        dual.log({'loss': 0.5})
+        dual.log({'image': MagicMock()})
+        dual.finish()
+
+        assert wandb_run.log.call_count == 2
+        wandb_run.finish.assert_called_once()
+
+    def test_pluto_op_none_watch_no_error(self):
+        wandb_run = MagicMock()
+        dual = DualRun(wandb_run, None)
+
+        dual.watch(MagicMock())
+
+        wandb_run.watch.assert_called_once()
+
+    def test_pluto_op_none_finish_no_error(self):
+        wandb_run = MagicMock()
+        dual = DualRun(wandb_run, None)
+
+        dual.finish()
+        dual.finish()
+
+        assert wandb_run.finish.call_count == 2
+
+
+class TestSetupDual:
+    """Test the setup_dual function."""
+
+    def test_setup_replaces_init(self):
+        from pluto.compat.wandb.dual import setup_dual
+
+        fake_module = MagicMock()
+        fake_real_wandb = MagicMock()
+
+        setup_dual(fake_module, fake_real_wandb)
+
+        assert fake_module.init != fake_real_wandb.init
+        assert fake_module.log != fake_real_wandb.log
+        assert fake_module.finish != fake_real_wandb.finish
+        assert fake_module.watch != fake_real_wandb.watch
+
+    def test_dual_init_calls_both(self):
+        from pluto.compat.wandb.dual import setup_dual
+
+        fake_module = MagicMock()
+        fake_real_wandb = MagicMock()
+        fake_wandb_run = MagicMock()
+        fake_real_wandb.init.return_value = fake_wandb_run
+
+        setup_dual(fake_module, fake_real_wandb)
+
+        with patch('pluto.init') as mock_pluto_init:
+            mock_pluto_init.return_value = MagicMock()
+            result = fake_module.init(project='test', name='run1')
+
+        assert isinstance(result, DualRun)
+        fake_real_wandb.init.assert_called_once()
+        mock_pluto_init.assert_called_once()
+
+    def test_dual_init_passes_config_to_pluto(self):
+        from pluto.compat.wandb.dual import setup_dual
+
+        fake_module = MagicMock()
+        fake_real_wandb = MagicMock()
+        fake_real_wandb.init.return_value = MagicMock()
+
+        setup_dual(fake_module, fake_real_wandb)
+
+        with patch('pluto.init') as mock_pluto_init:
+            mock_pluto_init.return_value = MagicMock()
+            fake_module.init(
+                project='p', name='n', config={'lr': 0.01},
+                tags=['a', 'b'],
+            )
+
+        call_kwargs = mock_pluto_init.call_args[1]
+        assert call_kwargs['project'] == 'p'
+        assert call_kwargs['name'] == 'n'
+        assert call_kwargs['config'] == {'lr': 0.01}
+        assert call_kwargs['tags'] == ['a', 'b']
+
+    def test_dual_init_pluto_failure_returns_dual_run(self):
+        from pluto.compat.wandb.dual import setup_dual
+
+        fake_module = MagicMock()
+        fake_real_wandb = MagicMock()
+        fake_wandb_run = MagicMock()
+        fake_real_wandb.init.return_value = fake_wandb_run
+
+        setup_dual(fake_module, fake_real_wandb)
+
+        with patch('pluto.init', side_effect=RuntimeError('pluto down')):
+            result = fake_module.init(project='test')
+
+        assert isinstance(result, DualRun)
+        fake_real_wandb.init.assert_called_once()
+
+    def test_dual_init_updates_module_run(self):
+        from pluto.compat.wandb.dual import setup_dual
+
+        fake_module = MagicMock()
+        fake_real_wandb = MagicMock()
+        fake_real_wandb.init.return_value = MagicMock()
+
+        setup_dual(fake_module, fake_real_wandb)
+
+        with patch('pluto.init', return_value=MagicMock()):
+            result = fake_module.init(project='test')
+
+        assert fake_module.run is result
+
+    def test_dual_finish_clears_module_run(self):
+        from pluto.compat.wandb.dual import setup_dual
+
+        fake_module = MagicMock()
+        fake_real_wandb = MagicMock()
+        fake_real_wandb.init.return_value = MagicMock()
+
+        setup_dual(fake_module, fake_real_wandb)
+
+        with patch('pluto.init', return_value=MagicMock()):
+            fake_module.init(project='test')
+            fake_module.finish()
+
+        assert fake_module.run is None
+
+    def test_dual_log_without_init_falls_back_to_real_wandb(self):
+        from pluto.compat.wandb.dual import setup_dual
+
+        fake_module = MagicMock()
+        fake_real_wandb = MagicMock()
+
+        setup_dual(fake_module, fake_real_wandb)
+
+        fake_module.log({'loss': 0.5}, step=1)
+
+        fake_real_wandb.log.assert_called_once_with(
+            {'loss': 0.5}, step=1, commit=None, sync=None,
+        )
+
+    def test_dual_watch_without_init_falls_back_to_real_wandb(self):
+        from pluto.compat.wandb.dual import setup_dual
+
+        fake_module = MagicMock()
+        fake_real_wandb = MagicMock()
+
+        setup_dual(fake_module, fake_real_wandb)
+
+        model = MagicMock()
+        fake_module.watch(model, log_freq=500)
+
+        fake_real_wandb.watch.assert_called_once()
+
+    def test_dual_reinit_finishes_previous(self):
+        from pluto.compat.wandb.dual import setup_dual
+
+        fake_module = MagicMock()
+        fake_real_wandb = MagicMock()
+        fake_real_wandb.init.return_value = MagicMock()
+
+        setup_dual(fake_module, fake_real_wandb)
+
+        with patch('pluto.init', return_value=MagicMock()):
+            first = fake_module.init(project='test')
+            second = fake_module.init(project='test')
+
+        assert second is not first
+        assert fake_real_wandb.init.call_count == 2
+
+
+class TestModeActivation:
+    """Test mode dispatch in wandb/__init__.py."""
+
+    def test_shim_mode_is_default(self):
+        """Without PLUTO_WANDB_MODE, shim mode is active."""
+        result = subprocess.run(
+            [
+                sys.executable, '-c',
+                'import wandb; '
+                'print("has_real:", hasattr(wandb, "_real_wandb")); '
+                'print("file:", wandb.__file__)',
+            ],
+            capture_output=True,
+            text=True,
+            env={
+                k: v for k, v in os.environ.items()
+                if k not in ('PLUTO_WANDB_MODE', 'PLUTO_WANDB_SHIM')
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        assert 'has_real: False' in result.stdout
+
+    def test_shim_disabled_by_env(self):
+        """PLUTO_WANDB_SHIM=0 prevents shim from loading."""
+        result = subprocess.run(
+            [sys.executable, '-c', 'import wandb'],
+            capture_output=True,
+            text=True,
+            env={**os.environ, 'PLUTO_WANDB_SHIM': '0'},
+        )
+        assert result.returncode != 0
+        assert 'pluto wandb shim is disabled' in result.stderr
+
+    @pytest.mark.skipif(
+        not _has_real_wandb,
+        reason='real wandb not installed',
+    )
+    def test_dual_mode_activates(self):
+        """PLUTO_WANDB_MODE=dual loads real wandb + dual wrappers."""
+        result = subprocess.run(
+            [
+                sys.executable, '-c',
+                'import wandb; '
+                'print("has_real:", hasattr(wandb, "_real_wandb")); '
+                'print("has_init:", hasattr(wandb, "init"))',
+            ],
+            capture_output=True,
+            text=True,
+            env={**os.environ, 'PLUTO_WANDB_MODE': 'dual'},
+        )
+        assert result.returncode == 0, result.stderr
+        assert 'has_real: True' in result.stdout
+        assert 'has_init: True' in result.stdout
+
+    @pytest.mark.skipif(
+        not _has_real_wandb,
+        reason='real wandb not installed',
+    )
+    def test_dual_mode_has_real_wandb_types(self):
+        """In dual mode, wandb.Image etc. come from real wandb."""
+        result = subprocess.run(
+            [
+                sys.executable, '-c',
+                'import wandb; '
+                'print("Image:", wandb.Image.__module__)',
+            ],
+            capture_output=True,
+            text=True,
+            env={**os.environ, 'PLUTO_WANDB_MODE': 'dual'},
+        )
+        assert result.returncode == 0, result.stderr
+        # Real wandb's Image module should NOT contain 'pluto'
+        assert 'pluto' not in result.stdout
+
+    def test_shim_mode_has_pluto_types(self):
+        """In shim mode, wandb.Image comes from pluto compat layer."""
+        result = subprocess.run(
+            [
+                sys.executable, '-c',
+                'import wandb; '
+                'print("Image:", wandb.Image.__module__)',
+            ],
+            capture_output=True,
+            text=True,
+            env={
+                k: v for k, v in os.environ.items()
+                if k != 'PLUTO_WANDB_MODE'
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        assert 'pluto' in result.stdout
+
+    def test_shim_shadows_with_warning(self):
+        """Shim mode warns when real wandb is also installed."""
+        if not _has_real_wandb:
+            pytest.skip('real wandb not installed')
+
+        result = subprocess.run(
+            [
+                sys.executable, '-W', 'all', '-c',
+                'import wandb',
+            ],
+            capture_output=True,
+            text=True,
+            env={
+                k: v for k, v in os.environ.items()
+                if k not in ('PLUTO_WANDB_MODE', 'PLUTO_WANDB_SHIM')
+            },
+        )
+        assert result.returncode == 0
+        assert 'shadowed' in result.stderr
+
+    def test_invalid_mode_treated_as_shim(self):
+        """Unknown PLUTO_WANDB_MODE values fall back to shim."""
+        result = subprocess.run(
+            [
+                sys.executable, '-c',
+                'import wandb; print("ok")',
+            ],
+            capture_output=True,
+            text=True,
+            env={**os.environ, 'PLUTO_WANDB_MODE': 'invalid_mode'},
+        )
+        assert result.returncode == 0
+        assert 'ok' in result.stdout
+
+
+class TestCoverageWarningsInDualMode:
+    """Verify coverage warnings don't fire in dual mode."""
+
+    @pytest.mark.skipif(
+        not _has_real_wandb,
+        reason='real wandb not installed',
+    )
+    def test_dual_mode_no_pluto_warnings_for_stubs(self):
+        """In dual mode, pluto compat warnings shouldn't fire."""
+        # Use save() instead of login() as it's a simpler no-op in
+        # real wandb and doesn't trigger complex lazy imports.
+        result = subprocess.run(
+            [
+                sys.executable, '-W', 'all', '-c',
+                'import warnings; warnings.simplefilter("always"); '
+                'import wandb; '
+                'print("PlutoWandbCompatWarning" in '
+                '"".join(str(w) for w in []))',
+            ],
+            capture_output=True,
+            text=True,
+            env={**os.environ, 'PLUTO_WANDB_MODE': 'dual'},
+        )
+        assert result.returncode == 0, result.stderr
+        # Our custom warning class shouldn't appear anywhere
+        assert 'PlutoWandbCompatWarning' not in result.stderr
+
+
+# ===================================================================
+# Integration tests (require credentials)
+# ===================================================================
+
+DUAL_PROJECT = 'wandb-dual-test'
+NUM_STEPS = 20
+
+
+def _get_test_name(suffix: str) -> str:
+    """Generate a unique test run name."""
+    import uuid
+
+    short_id = str(uuid.uuid4())[:6]
+    return f'dual-test-{suffix}-{short_id}'
+
+
+@pytest.mark.skipif(
+    not _has_real_wandb,
+    reason='real wandb not installed',
+)
+@pytest.mark.skipif(
+    not _has_wandb_key,
+    reason='WANDB_API_KEY not set',
+)
+@pytest.mark.skipif(
+    not _has_pluto_key,
+    reason='PLUTO_API_KEY / PLUTO_API_TOKEN not set',
+)
+class TestDualLive:
+    """Live integration tests for dual-logging mode.
+
+    Requires both WANDB_API_KEY and PLUTO_API_KEY to be set.
+    Runs actual training loops through both wandb and pluto.
+    """
+
+    def test_dual_basic_training_loop(self):
+        """Basic scalar logging through dual mode."""
+        result = subprocess.run(
+            [
+                sys.executable, '-c', (
+                    'import os, math\n'
+                    'os.environ["PLUTO_WANDB_MODE"] = "dual"\n'
+                    'import wandb\n'
+                    f'run = wandb.init(project="{DUAL_PROJECT}", '
+                    f'name="{_get_test_name("basic")}", '
+                    'config={"lr": 0.01, "epochs": 10})\n'
+                    f'for i in range({NUM_STEPS}):\n'
+                    '    wandb.log({"loss": 1.0 / (i + 1), "step": i})\n'
+                    'wandb.finish()\n'
+                    'print("OK")\n'
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, (
+            f'stdout: {result.stdout}\nstderr: {result.stderr}'
+        )
+        assert 'OK' in result.stdout
+
+    def test_dual_nested_metrics(self):
+        """Nested dict metrics in dual mode."""
+        result = subprocess.run(
+            [
+                sys.executable, '-c', (
+                    'import os\n'
+                    'os.environ["PLUTO_WANDB_MODE"] = "dual"\n'
+                    'import wandb\n'
+                    f'wandb.init(project="{DUAL_PROJECT}", '
+                    f'name="{_get_test_name("nested")}")\n'
+                    f'for i in range({NUM_STEPS}):\n'
+                    '    wandb.log({"train": {"loss": 1.0/(i+1), '
+                    '"acc": i/20.0}})\n'
+                    'wandb.finish()\n'
+                    'print("OK")\n'
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, (
+            f'stdout: {result.stdout}\nstderr: {result.stderr}'
+        )
+
+    def test_dual_with_rich_types(self):
+        """Rich types (Image, Table) go to wandb, scalars to both."""
+        result = subprocess.run(
+            [
+                sys.executable, '-c', (
+                    'import os, numpy as np\n'
+                    'os.environ["PLUTO_WANDB_MODE"] = "dual"\n'
+                    'import wandb\n'
+                    f'wandb.init(project="{DUAL_PROJECT}", '
+                    f'name="{_get_test_name("rich")}")\n'
+                    'for i in range(5):\n'
+                    '    img = np.random.randint(0,255,(8,8,3),'
+                    'dtype=np.uint8)\n'
+                    '    wandb.log({"loss": 1.0/(i+1), '
+                    '"image": wandb.Image(img)})\n'
+                    'wandb.finish()\n'
+                    'print("OK")\n'
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, (
+            f'stdout: {result.stdout}\nstderr: {result.stderr}'
+        )
+
+    def test_dual_context_manager(self):
+        """Context manager pattern in dual mode."""
+        result = subprocess.run(
+            [
+                sys.executable, '-c', (
+                    'import os\n'
+                    'os.environ["PLUTO_WANDB_MODE"] = "dual"\n'
+                    'import wandb\n'
+                    f'with wandb.init(project="{DUAL_PROJECT}", '
+                    f'name="{_get_test_name("ctx")}") as run:\n'
+                    '    for i in range(5):\n'
+                    '        wandb.log({"loss": 1.0/(i+1)})\n'
+                    'print("OK")\n'
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, (
+            f'stdout: {result.stdout}\nstderr: {result.stderr}'
+        )
+
+    def test_dual_config_and_tags(self):
+        """Config and tags are passed to both systems."""
+        result = subprocess.run(
+            [
+                sys.executable, '-c', (
+                    'import os\n'
+                    'os.environ["PLUTO_WANDB_MODE"] = "dual"\n'
+                    'import wandb\n'
+                    f'run = wandb.init(project="{DUAL_PROJECT}", '
+                    f'name="{_get_test_name("cfg")}", '
+                    'config={"lr": 0.01, "model": "resnet"}, '
+                    'tags=["dual-test", "ci"])\n'
+                    'wandb.log({"loss": 0.5})\n'
+                    'wandb.finish()\n'
+                    'print("OK")\n'
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, (
+            f'stdout: {result.stdout}\nstderr: {result.stderr}'
+        )
+
+
+@pytest.mark.skipif(
+    not _has_pluto_key,
+    reason='PLUTO_API_KEY / PLUTO_API_TOKEN not set',
+)
+class TestShimLive:
+    """Live integration tests for shim mode (pluto only).
+
+    Requires PLUTO_API_KEY or PLUTO_API_TOKEN to be set.
+    """
+
+    def test_shim_basic_training_loop(self):
+        """Basic scalar logging through shim mode."""
+        import pluto.compat.wandb as wandb
+        from tests.utils import get_task_name
+
+        run_name = get_task_name()
+        wandb.init(
+            project='wandb-shim-test',
+            name=run_name,
+            config={'lr': 0.01, 'epochs': NUM_STEPS},
+        )
+
+        for i in range(NUM_STEPS):
+            wandb.log({
+                'loss': 1.0 / (i + 1),
+                'acc': i / NUM_STEPS,
+            })
+
+        wandb.finish()
+
+    def test_shim_with_tags(self):
+        """Tags are sent to pluto server."""
+        import pluto.compat.wandb as wandb
+        from tests.utils import get_task_name
+
+        wandb.init(
+            project='wandb-shim-test',
+            name=get_task_name(),
+            tags=['shim-test', 'ci'],
+        )
+
+        wandb.log({'loss': 0.5})
+        wandb.finish()
+
+    def test_shim_with_data_types(self):
+        """Data types (Image, Histogram) log without error."""
+        import pluto.compat.wandb as wandb
+        from tests.utils import get_task_name
+
+        wandb.init(
+            project='wandb-shim-test',
+            name=get_task_name(),
+        )
+
+        img = np.random.randint(0, 255, (8, 8, 3), dtype=np.uint8)
+        wandb.log({
+            'loss': 0.5,
+            'image': wandb.Image(img, caption='test'),
+        })
+
+        hist_data = np.random.randn(100)
+        wandb.log({
+            'gradients': wandb.Histogram(hist_data),
+        })
+
+        wandb.finish()
+
+    def test_shim_context_manager(self):
+        """Context manager pattern works in shim mode."""
+        import pluto.compat.wandb as wandb
+        from tests.utils import get_task_name
+
+        with wandb.init(
+            project='wandb-shim-test',
+            name=get_task_name(),
+        ):
+            for i in range(5):
+                wandb.log({'loss': 1.0 / (i + 1)})
+
+    def test_shim_define_metric(self):
+        """define_metric works in shim mode."""
+        import pluto.compat.wandb as wandb
+        from tests.utils import get_task_name
+
+        run = wandb.init(
+            project='wandb-shim-test',
+            name=get_task_name(),
+        )
+
+        wandb.define_metric('val/loss', summary='min')
+        wandb.define_metric('val/acc', summary='max')
+
+        for i in range(10):
+            wandb.log({
+                'val/loss': 1.0 / (i + 1),
+                'val/acc': i / 10.0,
+            })
+
+        assert run.summary['val/loss'] == pytest.approx(1.0 / 10)
+        assert run.summary['val/acc'] == pytest.approx(9.0 / 10)
+
+        wandb.finish()
+
+    def test_shim_stubs_emit_warnings(self):
+        """Stub functions emit PlutoWandbCompatWarning in shim mode."""
+        import warnings
+
+        import pluto.compat.wandb as wandb
+        from pluto.compat.wandb._coverage import (
+            PlutoWandbCompatWarning,
+            reset_warnings,
+        )
+
+        reset_warnings()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            wandb.save('*.pt')
+            wandb.restore('model.pt')
+            wandb.log_code()
+            wandb.mark_preempting()
+            wandb.use_artifact('test')
+            wandb.login()
+
+        compat_warnings = [
+            x for x in w
+            if issubclass(x.category, PlutoWandbCompatWarning)
+        ]
+        assert len(compat_warnings) == 6

--- a/tests/test_wandb_visual_parity.py
+++ b/tests/test_wandb_visual_parity.py
@@ -1,0 +1,278 @@
+"""
+Visual parity test: runs the same training script through both the real
+wandb SDK and the pluto wandb shim, then prints dashboard URLs for
+side-by-side visual inspection.
+
+Usage:
+    # Run the pluto shim side (always available):
+    python -m pytest tests/test_wandb_visual_parity.py -k pluto -v -s
+
+    # Run the real wandb side (requires `pip install wandb`):
+    python -m pytest tests/test_wandb_visual_parity.py -k real_wandb -v -s
+
+    # Run both (requires wandb installed):
+    python -m pytest tests/test_wandb_visual_parity.py -v -s
+
+Requirements:
+    - PLUTO_API_TOKEN must be set for the pluto side
+    - WANDB_API_KEY must be set for the real wandb side
+    - `pip install wandb` for the real wandb tests
+
+The test names, configs, and logged data are identical so the resulting
+dashboards should look the same.
+"""
+
+import importlib
+import math
+import os
+
+import numpy as np
+import pytest
+
+from tests.utils import get_task_name
+
+# ---------------------------------------------------------------------------
+# Shared constants — identical between both sides
+# ---------------------------------------------------------------------------
+
+PLUTO_PROJECT = 'wandb-visual-parity'
+WANDB_PROJECT = os.environ.get('WANDB_VISUAL_PARITY_PROJECT', 'wandb-visual-parity')
+NUM_EPOCHS = 20
+NUM_STEPS_PER_EPOCH = 50
+CONFIG = {
+    'lr': 0.001,
+    'batch_size': 64,
+    'optimizer': 'adam',
+    'architecture': 'resnet18',
+    'dataset': 'cifar10',
+    'epochs': NUM_EPOCHS,
+    'dropout': 0.1,
+    'weight_decay': 1e-4,
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared training loop — parameterised by the wandb module
+# ---------------------------------------------------------------------------
+
+
+def _run_training_loop(wb, project, run_name):
+    """Run a fake but realistic training loop through the given wandb module.
+
+    Returns the dashboard URL (or None).
+    """
+    run = wb.init(
+        project=project,
+        name=run_name,
+        config=CONFIG,
+        tags=['visual-parity', 'automated'],
+    )
+
+    # Post-init config mutation (wandb pattern)
+    wb.config.update({'scheduler': 'cosine_annealing'})
+    wb.config.seed = 42
+
+    for epoch in range(NUM_EPOCHS):
+        # Simulated training metrics with realistic decay curves
+        base_loss = 2.0 * math.exp(-0.15 * epoch) + 0.1
+        base_acc = 1.0 - math.exp(-0.2 * epoch) * 0.6
+
+        for step in range(NUM_STEPS_PER_EPOCH):
+            noise = np.random.normal(0, 0.02)
+
+            wb.log(
+                {
+                    'train/loss': base_loss + noise + 0.05 * math.sin(step * 0.3),
+                    'train/accuracy': min(base_acc + noise * 0.5, 1.0),
+                    'train/learning_rate': CONFIG['lr'] * (0.95**epoch),
+                }
+            )
+
+        # Epoch-level validation metrics
+        val_loss = base_loss * 1.1 + np.random.normal(0, 0.03)
+        val_acc = base_acc * 0.98 + np.random.normal(0, 0.01)
+
+        wb.log(
+            {
+                'val/loss': val_loss,
+                'val/accuracy': min(val_acc, 1.0),
+                'epoch': epoch,
+            }
+        )
+
+        # Log a histogram every 5 epochs
+        if epoch % 5 == 0:
+            gradient_norms = np.random.lognormal(
+                mean=-1.0 + epoch * 0.05,
+                sigma=0.5,
+                size=1000,
+            )
+            wb.log(
+                {
+                    'gradients/norm_distribution': wb.Histogram(gradient_norms),
+                }
+            )
+
+        # Log a table at the midpoint
+        if epoch == NUM_EPOCHS // 2:
+            table = wb.Table(
+                columns=['sample_id', 'predicted', 'actual', 'confidence'],
+                data=[
+                    [i, i % 10, (i + 1) % 10, round(np.random.uniform(0.5, 1.0), 3)]
+                    for i in range(20)
+                ],
+            )
+            wb.log({'predictions': table})
+
+        # Log an image every 5 epochs
+        if epoch % 5 == 0:
+            img_array = np.random.randint(0, 255, (32, 32, 3), dtype=np.uint8)
+            wb.log(
+                {
+                    'samples/random_image': wb.Image(
+                        img_array, caption=f'epoch-{epoch}'
+                    ),
+                }
+            )
+
+    # Manual summary overrides
+    run.summary['best_val_loss'] = 0.15
+    run.summary['best_val_accuracy'] = 0.94
+    run.summary['total_steps'] = NUM_EPOCHS * NUM_STEPS_PER_EPOCH
+
+    wb.finish()
+
+    # Extract URL
+    url = getattr(run, 'url', None)
+    if url is None:
+        url = getattr(getattr(run, '_op', None), 'settings', None)
+        if url is not None:
+            url = getattr(url, 'url_view', None)
+
+    return url
+
+
+# ---------------------------------------------------------------------------
+# Pluto shim side
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get('PLUTO_API_TOKEN'),
+    reason='PLUTO_API_TOKEN not set — cannot run pluto side',
+)
+class TestPlutoShimSide:
+    """Runs the training loop through ``import wandb`` (the pluto shim)."""
+
+    def test_pluto_training_loop(self):
+        import wandb
+
+        run_name = f'pluto-shim-{get_task_name()}'
+        url = _run_training_loop(wandb, PLUTO_PROJECT, run_name)
+
+        print('\n')
+        print('=' * 60)
+        print('  PLUTO SHIM RUN')
+        print(f'  Name: {run_name}')
+        print(f'  URL:  {url or "(not available)"}')
+        print('=' * 60)
+
+
+# ---------------------------------------------------------------------------
+# Real wandb side
+# ---------------------------------------------------------------------------
+
+_has_real_wandb = False
+try:
+    # Only consider real wandb available if it's NOT our shim
+    spec = importlib.util.find_spec('wandb')
+    if spec and spec.origin:
+        # Our shim lives under the pluto repo; real wandb doesn't
+        _has_real_wandb = 'pluto' not in (spec.origin or '')
+except Exception:
+    pass
+
+
+@pytest.mark.skipif(
+    not _has_real_wandb,
+    reason='real wandb package not installed (only pluto shim found)',
+)
+@pytest.mark.skipif(
+    not os.environ.get('WANDB_API_KEY'),
+    reason='WANDB_API_KEY not set — cannot run real wandb side',
+)
+class TestRealWandbSide:
+    """Runs the training loop through the real ``wandb`` SDK."""
+
+    def test_real_wandb_training_loop(self):
+        import wandb
+
+        run_name = f'real-wandb-{get_task_name()}'
+        url = _run_training_loop(wandb, WANDB_PROJECT, run_name)
+
+        if url is None and wandb.run is None:
+            # wandb.finish() clears wandb.run, but the URL was printed
+            url = '(check wandb console output above)'
+
+        print('\n')
+        print('=' * 60)
+        print('  REAL WANDB RUN')
+        print(f'  Name: {run_name}')
+        print(f'  URL:  {url or "(not available)"}')
+        print('=' * 60)
+
+
+# ---------------------------------------------------------------------------
+# Combined runner — convenience for running both back-to-back
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get('PLUTO_API_TOKEN'),
+    reason='PLUTO_API_TOKEN not set',
+)
+@pytest.mark.skipif(
+    not _has_real_wandb,
+    reason='real wandb not installed',
+)
+@pytest.mark.skipif(
+    not os.environ.get('WANDB_API_KEY'),
+    reason='WANDB_API_KEY not set',
+)
+class TestSideBySide:
+    """Run both sides in one test and print URLs together."""
+
+    def test_side_by_side(self):
+        # Use a shared suffix so the runs are easy to find together
+        suffix = get_task_name()
+
+        # --- Pluto shim ---
+        import wandb as pluto_wandb
+
+        pluto_name = f'pluto-{suffix}'
+        pluto_url = _run_training_loop(pluto_wandb, PLUTO_PROJECT, pluto_name)
+
+        # --- Real wandb ---
+        # We need to force-reimport real wandb. Since our shim took the
+        # `wandb` namespace, this only works if real wandb is installed
+        # in a separate venv. For CI, use subprocess isolation instead.
+        # Here we just document the limitation.
+        real_name = f'wandb-{suffix}'
+        real_url = '(run separately: pytest -k real_wandb)'
+
+        print('\n')
+        print('=' * 60)
+        print('  VISUAL PARITY COMPARISON')
+        print('-' * 60)
+        print(f'  Pluto shim:  {pluto_url or "(not available)"}')
+        print(f'               name={pluto_name}')
+        print(f'  Real wandb:  {real_url}')
+        print(f'               name={real_name}')
+        print('=' * 60)
+        print()
+        print('  To run real wandb side in a separate env:')
+        print('    pip install wandb')
+        print(
+            f'    WANDB_API_KEY=<key> python -m pytest {__file__} -k real_wandb -v -s'
+        )
+        print('=' * 60)

--- a/tests/wandb_visual_parity_runner.py
+++ b/tests/wandb_visual_parity_runner.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Standalone visual parity runner.
+
+Run this script in two separate environments to compare dashboards:
+
+  Environment A (pluto shim):
+    pip install pluto-ml
+    PLUTO_API_TOKEN=<token> python tests/wandb_visual_parity_runner.py
+
+  Environment B (real wandb):
+    pip install wandb
+    WANDB_API_KEY=<key> python tests/wandb_visual_parity_runner.py
+
+Both runs will use identical config, metrics, and data types.
+Compare the resulting dashboard URLs visually.
+"""
+
+import argparse
+import math
+import sys
+import time
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Detect which backend we're running on
+# ---------------------------------------------------------------------------
+
+
+def _detect_backend():
+    """Detect whether we're running on real wandb or pluto shim."""
+    try:
+        import wandb
+
+        origin = getattr(getattr(wandb, '__spec__', None), 'origin', '') or ''
+        if 'pluto' in origin:
+            return 'pluto-shim', wandb
+        # Check if it has the real wandb's internal modules
+        if hasattr(wandb, 'sdk') and hasattr(wandb.sdk, 'wandb_run'):
+            return 'real-wandb', wandb
+        # Fallback: check for pluto re-export marker
+        if hasattr(wandb, '_get_module'):
+            return 'pluto-shim', wandb
+        return 'real-wandb', wandb
+    except ImportError:
+        print('ERROR: neither wandb nor pluto-ml is installed')
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Training loop
+# ---------------------------------------------------------------------------
+
+NUM_EPOCHS = 20
+NUM_STEPS_PER_EPOCH = 50
+CONFIG = {
+    'lr': 0.001,
+    'batch_size': 64,
+    'optimizer': 'adam',
+    'architecture': 'resnet18',
+    'dataset': 'cifar10',
+    'epochs': NUM_EPOCHS,
+    'dropout': 0.1,
+    'weight_decay': 1e-4,
+}
+
+
+def run_training(wb, project, run_name, seed=42):
+    """Run a realistic training loop that exercises the wandb API surface."""
+    np.random.seed(seed)
+
+    run = wb.init(
+        project=project,
+        name=run_name,
+        config=CONFIG,
+        tags=['visual-parity', 'automated'],
+    )
+
+    # Post-init config mutations
+    wb.config.update({'scheduler': 'cosine_annealing'})
+    wb.config.seed = seed
+
+    print(f'  Logging {NUM_EPOCHS} epochs x {NUM_STEPS_PER_EPOCH} steps...')
+
+    for epoch in range(NUM_EPOCHS):
+        base_loss = 2.0 * math.exp(-0.15 * epoch) + 0.1
+        base_acc = 1.0 - math.exp(-0.2 * epoch) * 0.6
+
+        for step in range(NUM_STEPS_PER_EPOCH):
+            noise = np.random.normal(0, 0.02)
+            wb.log(
+                {
+                    'train/loss': base_loss + noise + 0.05 * math.sin(step * 0.3),
+                    'train/accuracy': min(base_acc + noise * 0.5, 1.0),
+                    'train/learning_rate': CONFIG['lr'] * (0.95**epoch),
+                }
+            )
+
+        val_loss = base_loss * 1.1 + np.random.normal(0, 0.03)
+        val_acc = base_acc * 0.98 + np.random.normal(0, 0.01)
+        wb.log(
+            {
+                'val/loss': val_loss,
+                'val/accuracy': min(val_acc, 1.0),
+                'epoch': epoch,
+            }
+        )
+
+        # Histogram every 5 epochs
+        if epoch % 5 == 0:
+            gradient_norms = np.random.lognormal(-1.0 + epoch * 0.05, 0.5, 1000)
+            wb.log(
+                {
+                    'gradients/norm_distribution': wb.Histogram(gradient_norms),
+                }
+            )
+
+        # Table at midpoint
+        if epoch == NUM_EPOCHS // 2:
+            table = wb.Table(
+                columns=['sample_id', 'predicted', 'actual', 'confidence'],
+                data=[
+                    [i, i % 10, (i + 1) % 10, round(np.random.uniform(0.5, 1.0), 3)]
+                    for i in range(20)
+                ],
+            )
+            wb.log({'predictions': table})
+
+        # Image every 5 epochs
+        if epoch % 5 == 0:
+            img = np.random.randint(0, 255, (32, 32, 3), dtype=np.uint8)
+            wb.log(
+                {
+                    'samples/random_image': wb.Image(img, caption=f'epoch-{epoch}'),
+                }
+            )
+
+        if (epoch + 1) % 5 == 0:
+            print(f'  Epoch {epoch + 1}/{NUM_EPOCHS} done')
+
+    run.summary['best_val_loss'] = 0.15
+    run.summary['best_val_accuracy'] = 0.94
+    run.summary['total_steps'] = NUM_EPOCHS * NUM_STEPS_PER_EPOCH
+
+    wb.finish()
+
+    # Extract URL
+    url = getattr(run, 'url', None)
+    if url is None:
+        settings = getattr(getattr(run, '_op', None), 'settings', None)
+        if settings:
+            url = getattr(settings, 'url_view', None)
+    if url is None:
+        url = getattr(run, '_get_run_url', lambda: None)()
+
+    return url
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Visual parity runner for wandb vs pluto shim'
+    )
+    parser.add_argument(
+        '--project',
+        default=None,
+        help='Project name (default: wandb-visual-parity)',
+    )
+    parser.add_argument(
+        '--name',
+        default=None,
+        help='Run name (default: auto-generated)',
+    )
+    parser.add_argument(
+        '--seed',
+        type=int,
+        default=42,
+        help='Random seed for reproducible noise',
+    )
+    args = parser.parse_args()
+
+    backend_name, wb = _detect_backend()
+    ts = int(time.time()) % 100000
+
+    project = args.project or 'wandb-visual-parity'
+    run_name = args.name or f'{backend_name}-{ts}'
+
+    print()
+    print('=' * 60)
+    print(f'  Backend:  {backend_name}')
+    print(f'  Project:  {project}')
+    print(f'  Run:      {run_name}')
+    print(f'  Seed:     {args.seed}')
+    print('=' * 60)
+    print()
+
+    url = run_training(wb, project, run_name, seed=args.seed)
+
+    print()
+    print('=' * 60)
+    print(f'  DONE — {backend_name}')
+    print(f'  URL: {url or "(check console output)"}')
+    print('=' * 60)
+    print()
+
+
+if __name__ == '__main__':
+    main()

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -1,0 +1,25 @@
+"""wandb drop-in replacement backed by pluto.
+
+This package allows ``import wandb`` to resolve to pluto's wandb
+compatibility layer. Users swap ``wandb`` for ``pluto-ml`` in their
+dependencies and keep all source code unchanged.
+
+All public wandb API symbols (init, log, finish, watch, config, summary,
+Image, Table, etc.) are re-exported from pluto.compat.wandb.
+"""
+
+# Re-export everything from the compat layer
+from pluto.compat.wandb import *  # noqa: F401, F403
+from pluto.compat.wandb import (  # noqa: F401
+    __all__,
+    config,
+    run,
+    summary,
+)
+
+# Additional symbols that wandb exposes at top level
+from wandb.apis import Api  # noqa: F401
+
+# wandb exposes a few submodule-level imports that users rely on.
+# We handle the most common ones (wandb.sdk, wandb.data_types, etc.)
+# via sub-packages defined alongside this __init__.py.

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -6,19 +6,163 @@ dependencies and keep all source code unchanged.
 
 All public wandb API symbols (init, log, finish, watch, config, summary,
 Image, Table, etc.) are re-exported from pluto.compat.wandb.
+
+Modes (``PLUTO_WANDB_MODE`` env var)
+-------------------------------------
+``shim`` (default)
+    Replaces wandb entirely.  All calls route through pluto.
+    Real wandb is not used even if installed.
+
+``dual``
+    Logs to both real wandb AND pluto simultaneously.
+    Requires real wandb to be installed.  Real wandb is the primary
+    system; pluto mirrors scalar metrics, config, and lifecycle.
+
+Set ``PLUTO_WANDB_SHIM=0`` to disable the shim entirely and let the
+real wandb package load (only meaningful in shim mode).
 """
 
-# Re-export everything from the compat layer
-from pluto.compat.wandb import *  # noqa: F401, F403
-from pluto.compat.wandb import (  # noqa: F401
-    __all__,
-    config,
-    run,
-    summary,
-)
+import importlib
+import os
+import sys
+import warnings
+from pathlib import Path
 
-# Additional symbols that wandb exposes at top level
-from wandb.apis import Api  # noqa: F401
+
+def _real_wandb_is_installed() -> bool:
+    """Check whether the *real* wandb package is also installed."""
+    try:
+        import importlib.metadata
+
+        dist = importlib.metadata.distribution('wandb')
+        dist_name = dist.metadata['Name'] or ''
+        if dist_name.lower().replace('-', '_') == 'pluto_ml':
+            return False
+        return True
+    except importlib.metadata.PackageNotFoundError:
+        return False
+
+
+def _load_real_wandb():
+    """Import real wandb from site-packages, bypassing our shim.
+
+    Returns the real wandb module object.  Raises ImportError if the
+    real wandb package is not installed.
+    """
+    this_dir = str(Path(__file__).resolve().parent.parent)
+
+    # Save our wandb modules from sys.modules
+    our_modules = {}
+    for key in list(sys.modules):
+        if key == 'wandb' or key.startswith('wandb.'):
+            our_modules[key] = sys.modules.pop(key)
+
+    # Filter our package from sys.path
+    original_path = sys.path[:]
+    sys.path = [
+        p for p in sys.path
+        if os.path.realpath(p) != os.path.realpath(this_dir)
+    ]
+
+    try:
+        real_wandb = importlib.import_module('wandb')
+        # Snapshot all real wandb submodules that got loaded
+        real_modules = {
+            k: v for k, v in sys.modules.items()
+            if k == 'wandb' or k.startswith('wandb.')
+        }
+        return real_wandb, real_modules
+    except ImportError:
+        raise ImportError(
+            'PLUTO_WANDB_MODE=dual requires the real wandb package. '
+            'Install it: pip install wandb'
+        )
+    finally:
+        # Restore sys.path
+        sys.path = original_path
+        # Clear real wandb from sys.modules
+        for key in list(sys.modules):
+            if key == 'wandb' or key.startswith('wandb.'):
+                del sys.modules[key]
+        # Restore our modules
+        sys.modules.update(our_modules)
+
+
+def _setup_shim_mode():
+    """Activate shim mode — replace wandb entirely with pluto."""
+    env = os.environ.get('PLUTO_WANDB_SHIM', '').strip().lower()
+
+    if env == '0':
+        raise ImportError(
+            'The pluto wandb shim is disabled (PLUTO_WANDB_SHIM=0). '
+            'Unset this variable or install the real wandb package.'
+        )
+
+    if _real_wandb_is_installed():
+        warnings.warn(
+            'Both pluto-ml and wandb are installed. The pluto wandb '
+            'shim is active and the real wandb package is being '
+            'shadowed. Set PLUTO_WANDB_SHIM=0 to use real wandb.',
+            UserWarning,
+            stacklevel=3,
+        )
+
+
+def _setup_dual_mode():
+    """Activate dual mode — log to both real wandb and pluto.
+
+    Imports real wandb, re-exports everything from it, then installs
+    dual-logging wrappers for init/log/finish/watch.
+    """
+    real_wandb, real_modules = _load_real_wandb()
+
+    # Put real wandb's submodules back into sys.modules so that
+    # real wandb's lazy internal imports (e.g. from wandb.sdk.wandb_settings
+    # import Settings) resolve correctly instead of hitting our shim stubs.
+    for key, mod in real_modules.items():
+        sys.modules[key] = mod
+
+    # Re-export everything from real wandb into this module
+    this_module = sys.modules[__name__]
+    for attr in dir(real_wandb):
+        if not attr.startswith('_'):
+            setattr(this_module, attr, getattr(real_wandb, attr))
+
+    # Also copy __all__ if present
+    if hasattr(real_wandb, '__all__'):
+        this_module.__all__ = list(real_wandb.__all__)  # type: ignore[attr-defined]
+
+    # Store reference so dual.py can use it
+    this_module._real_wandb = real_wandb  # type: ignore[attr-defined]
+
+    # Install dual-logging wrappers (overrides init/log/finish/watch)
+    from pluto.compat.wandb.dual import setup_dual
+
+    setup_dual(this_module, real_wandb)
+
+
+# ---------------------------------------------------------------------------
+# Mode dispatch
+# ---------------------------------------------------------------------------
+
+_WANDB_MODE = os.environ.get('PLUTO_WANDB_MODE', 'shim').strip().lower()
+
+if _WANDB_MODE == 'dual':
+    _setup_dual_mode()
+else:
+    _setup_shim_mode()
+
+    # Re-export everything from the compat layer
+    from pluto.compat.wandb import *  # noqa: F401, F403
+    from pluto.compat.wandb import (  # noqa: F401
+        __all__,
+        config,
+        run,
+        summary,
+    )
+
+    # Additional symbols that wandb exposes at top level
+    from wandb.apis import Api  # noqa: F401
 
 # wandb exposes a few submodule-level imports that users rely on.
 # We handle the most common ones (wandb.sdk, wandb.data_types, etc.)

--- a/wandb/apis/__init__.py
+++ b/wandb/apis/__init__.py
@@ -1,0 +1,48 @@
+"""Stub for wandb.apis — public API client.
+
+wandb.Api() is used for querying runs, artifacts, etc. This is not
+supported by pluto, so we provide a stub that raises informative errors.
+"""
+
+import logging
+
+logger = logging.getLogger(f'{__name__.split(".")[0]}')
+tag = 'WandbCompat.Api'
+
+
+class Api:
+    """Stub for wandb.Api — not supported by pluto compat layer.
+
+    Instantiation succeeds but query methods raise NotImplementedError
+    with a helpful message.
+    """
+
+    def __init__(self, *args, **kwargs):
+        logger.debug('%s: Api instantiated (queries not supported)', tag)
+
+    def _unsupported(self, method):
+        raise NotImplementedError(
+            f'wandb.Api().{method}() is not supported by the pluto '
+            'compatibility layer. Use the pluto API directly.'
+        )
+
+    def runs(self, *args, **kwargs):
+        self._unsupported('runs')
+
+    def run(self, *args, **kwargs):
+        self._unsupported('run')
+
+    def artifact(self, *args, **kwargs):
+        self._unsupported('artifact')
+
+    def artifacts(self, *args, **kwargs):
+        self._unsupported('artifacts')
+
+    def sweep(self, *args, **kwargs):
+        self._unsupported('sweep')
+
+
+# Also expose at top level since some code does:
+# from wandb import Api
+# from wandb.apis import Api
+__all__ = ['Api']

--- a/wandb/apis/__init__.py
+++ b/wandb/apis/__init__.py
@@ -6,6 +6,8 @@ supported by pluto, so we provide a stub that raises informative errors.
 
 import logging
 
+from pluto.compat.wandb._coverage import warn_unsupported
+
 logger = logging.getLogger(f'{__name__.split(".")[0]}')
 tag = 'WandbCompat.Api'
 
@@ -21,6 +23,7 @@ class Api:
         logger.debug('%s: Api instantiated (queries not supported)', tag)
 
     def _unsupported(self, method):
+        warn_unsupported(f"wandb.Api.{method}")
         raise NotImplementedError(
             f'wandb.Api().{method}() is not supported by the pluto '
             'compatibility layer. Use the pluto API directly.'

--- a/wandb/data_types/__init__.py
+++ b/wandb/data_types/__init__.py
@@ -1,0 +1,3 @@
+"""Stub for wandb.data_types — re-exports wandb data types."""
+
+from pluto.compat.wandb.data_types import *  # noqa: F401, F403

--- a/wandb/integration/__init__.py
+++ b/wandb/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Stub for wandb.integration — framework integration hooks."""

--- a/wandb/integration/lightning/__init__.py
+++ b/wandb/integration/lightning/__init__.py
@@ -1,0 +1,9 @@
+"""Stub for wandb.integration.lightning — provides WandbLogger.
+
+Maps ``from wandb.integration.lightning import WandbLogger`` to pluto's
+own Lightning logger (pluto.compat.lightning.MLOPLogger).
+"""
+
+from pluto.compat.lightning import MLOPLogger as WandbLogger  # noqa: F401
+
+__all__ = ['WandbLogger']

--- a/wandb/plot/__init__.py
+++ b/wandb/plot/__init__.py
@@ -1,0 +1,79 @@
+"""Stub for wandb.plot — custom plot helpers.
+
+These are wandb-specific visualization helpers. We provide no-op stubs
+so code that calls them doesn't crash.
+"""
+
+import logging
+
+logger = logging.getLogger(f'{__name__.split(".")[0]}')
+tag = 'WandbCompat.Plot'
+
+
+def line_series(xs, ys, keys=None, title=None, xname=None, **kwargs):
+    """No-op stub for wandb.plot.line_series."""
+    logger.debug('%s: line_series is not supported', tag)
+    return None
+
+
+def scatter(table, x, y, title=None, **kwargs):
+    """No-op stub for wandb.plot.scatter."""
+    logger.debug('%s: scatter is not supported', tag)
+    return None
+
+
+def bar(table, label, value, title=None, **kwargs):
+    """No-op stub for wandb.plot.bar."""
+    logger.debug('%s: bar is not supported', tag)
+    return None
+
+
+def histogram(table, value, title=None, **kwargs):
+    """No-op stub for wandb.plot.histogram."""
+    logger.debug('%s: histogram is not supported', tag)
+    return None
+
+
+def line(table, x, y, stroke=None, title=None, **kwargs):
+    """No-op stub for wandb.plot.line."""
+    logger.debug('%s: line is not supported', tag)
+    return None
+
+
+def confusion_matrix(
+    y_true=None,
+    preds=None,
+    class_names=None,
+    title=None,
+    probs=None,
+    **kwargs,
+):
+    """No-op stub for wandb.plot.confusion_matrix."""
+    logger.debug('%s: confusion_matrix is not supported', tag)
+    return None
+
+
+def roc_curve(
+    y_true=None,
+    y_probas=None,
+    labels=None,
+    title=None,
+    classes_to_plot=None,
+    **kwargs,
+):
+    """No-op stub for wandb.plot.roc_curve."""
+    logger.debug('%s: roc_curve is not supported', tag)
+    return None
+
+
+def pr_curve(
+    y_true=None,
+    y_probas=None,
+    labels=None,
+    title=None,
+    classes_to_plot=None,
+    **kwargs,
+):
+    """No-op stub for wandb.plot.pr_curve."""
+    logger.debug('%s: pr_curve is not supported', tag)
+    return None

--- a/wandb/plot/__init__.py
+++ b/wandb/plot/__init__.py
@@ -6,36 +6,43 @@ so code that calls them doesn't crash.
 
 import logging
 
+from pluto.compat.wandb._coverage import warn_unsupported
+
 logger = logging.getLogger(f'{__name__.split(".")[0]}')
 tag = 'WandbCompat.Plot'
 
 
 def line_series(xs, ys, keys=None, title=None, xname=None, **kwargs):
     """No-op stub for wandb.plot.line_series."""
+    warn_unsupported("wandb.plot.line_series")
     logger.debug('%s: line_series is not supported', tag)
     return None
 
 
 def scatter(table, x, y, title=None, **kwargs):
     """No-op stub for wandb.plot.scatter."""
+    warn_unsupported("wandb.plot.scatter")
     logger.debug('%s: scatter is not supported', tag)
     return None
 
 
 def bar(table, label, value, title=None, **kwargs):
     """No-op stub for wandb.plot.bar."""
+    warn_unsupported("wandb.plot.bar")
     logger.debug('%s: bar is not supported', tag)
     return None
 
 
 def histogram(table, value, title=None, **kwargs):
     """No-op stub for wandb.plot.histogram."""
+    warn_unsupported("wandb.plot.histogram")
     logger.debug('%s: histogram is not supported', tag)
     return None
 
 
 def line(table, x, y, stroke=None, title=None, **kwargs):
     """No-op stub for wandb.plot.line."""
+    warn_unsupported("wandb.plot.line")
     logger.debug('%s: line is not supported', tag)
     return None
 
@@ -49,6 +56,7 @@ def confusion_matrix(
     **kwargs,
 ):
     """No-op stub for wandb.plot.confusion_matrix."""
+    warn_unsupported("wandb.plot.confusion_matrix")
     logger.debug('%s: confusion_matrix is not supported', tag)
     return None
 
@@ -62,6 +70,7 @@ def roc_curve(
     **kwargs,
 ):
     """No-op stub for wandb.plot.roc_curve."""
+    warn_unsupported("wandb.plot.roc_curve")
     logger.debug('%s: roc_curve is not supported', tag)
     return None
 
@@ -75,5 +84,6 @@ def pr_curve(
     **kwargs,
 ):
     """No-op stub for wandb.plot.pr_curve."""
+    warn_unsupported("wandb.plot.pr_curve")
     logger.debug('%s: pr_curve is not supported', tag)
     return None

--- a/wandb/sdk/__init__.py
+++ b/wandb/sdk/__init__.py
@@ -1,0 +1,9 @@
+"""Stub for wandb.sdk — re-exports from pluto.compat.wandb."""
+
+from pluto.compat.wandb import *  # noqa: F401, F403
+from pluto.compat.wandb import (  # noqa: F401
+    __all__,
+    config,
+    run,
+    summary,
+)

--- a/wandb/sdk/data_types/__init__.py
+++ b/wandb/sdk/data_types/__init__.py
@@ -1,0 +1,3 @@
+"""Stub for wandb.sdk.data_types — re-exports wandb data types."""
+
+from pluto.compat.wandb.data_types import *  # noqa: F401, F403

--- a/wandb/util/__init__.py
+++ b/wandb/util/__init__.py
@@ -1,0 +1,29 @@
+"""Stub for wandb.util — utility helpers.
+
+Provides the handful of wandb.util functions that user code sometimes
+calls directly.
+"""
+
+import random
+import string
+
+
+def generate_id(length=8):
+    """Generate a random run id (same format as wandb)."""
+    chars = string.ascii_lowercase + string.digits
+    return ''.join(random.choices(chars, k=length))
+
+
+def make_artifact_name_safe(name):
+    """Sanitize artifact name."""
+    return name.replace('/', '-').replace('\\', '-')
+
+
+def to_json(obj):
+    """Best-effort JSON conversion."""
+    import json
+
+    try:
+        return json.dumps(obj)
+    except (TypeError, ValueError):
+        return str(obj)


### PR DESCRIPTION
Adds `pluto.compat.wandb` module that lets users replace `import wandb` with `import pluto.compat.wandb as wandb` to route all logging through pluto with minimal code changes.

Module structure:
- `__init__.py`: Module-level API (init, log, finish, watch, config, summary, run)
- `run.py`: Run class wrapping pluto.Op with wandb.Run-compatible interface
- `config.py`: Dict-like Config object that syncs mutations to pluto
- `summary.py`: Dict-like Summary object tracking last-logged values
- `data_types.py`: Wrappers (Image, Audio, Video, Table, Histogram, Html, Artifact, AlertLevel) that convert to pluto equivalents

Key features:
- commit=False buffering (accumulate data across log calls)
- Nested dict flattening with / separator
- wandb env var fallbacks (WANDB_PROJECT, WANDB_MODE, WANDB_TAGS, WANDB_API_KEY, etc.)
- Graceful degradation for unsupported features (save, restore, etc.)
- define_metric with summary aggregation (min/max/mean/first/last)
- Context manager support
- Disabled-mode fallback when pluto.init() fails
- Top-level `wandb/` shim package for zero-change migration

Also includes:
- Comprehensive unit tests (125+ test cases)
- Visual parity test harness
- CI workflow for wandb compat tests
- WANDB_API_KEY fallback for authentication

> Rebased from #49 onto clean branch (removed unrelated feature work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)