### PR TITLE
Add run forking support to pluto.init()

### DIFF
--- a/.github/workflows/pytest-smoke.yml
+++ b/.github/workflows/pytest-smoke.yml
@@ -57,6 +57,48 @@ jobs:
           github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
           file: coverage.lcov
 
+  fork-e2e:
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        poetry-version: ["2.1.1"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: "Setup Python, Poetry and Dependencies"
+        uses: packetcoders/action-setup-cache-python-poetry@v1.2.0
+        with:
+          python-version: ${{matrix.python-version}}
+          poetry-version: ${{matrix.poetry-version}}
+          install-args: "--with dev"
+
+      - name: Install deps and login
+        run: |
+          set -euox pipefail
+          rm -rf .venv
+          poetry install --with dev --extras full
+          pip install -e ".[dev,full]"
+          pluto login ${{ secrets.MLOP_API_TOKEN }}
+
+      - name: Run fork E2E tests
+        timeout-minutes: 5
+        env:
+          PLUTO_API_KEY: ${{ secrets.MLOP_API_TOKEN }}
+        run: |
+          set -euox pipefail
+          poetry run pytest tests/test_fork_e2e.py -rs -v 2>&1 | tee fork_e2e.log
+
+      - name: Upload fork E2E logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fork-e2e-logs
+          path: fork_e2e.log
+          retention-days: 7
+
   distributed-tests:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest-smoke.yml
+++ b/.github/workflows/pytest-smoke.yml
@@ -91,6 +91,14 @@ jobs:
           set -euox pipefail
           poetry run python tests/fork_integration_test.py 2>&1 | tee fork_integration.log
 
+      - name: Run fork chain test
+        timeout-minutes: 10
+        env:
+          PLUTO_API_KEY: ${{ secrets.MLOP_API_TOKEN }}
+        run: |
+          set -euox pipefail
+          poetry run python tests/manual_fork_chain.py 2>&1 | tee fork_chain.log
+
       - name: Run fork E2E tests
         timeout-minutes: 5
         env:
@@ -106,6 +114,7 @@ jobs:
           name: fork-e2e-logs
           path: |
             fork_integration.log
+            fork_chain.log
             fork_e2e.log
           retention-days: 7
 

--- a/.github/workflows/pytest-smoke.yml
+++ b/.github/workflows/pytest-smoke.yml
@@ -83,6 +83,14 @@ jobs:
           pip install -e ".[dev,full]"
           pluto login ${{ secrets.MLOP_API_TOKEN }}
 
+      - name: Run fork integration test
+        timeout-minutes: 5
+        env:
+          PLUTO_API_KEY: ${{ secrets.MLOP_API_TOKEN }}
+        run: |
+          set -euox pipefail
+          poetry run python tests/fork_integration_test.py 2>&1 | tee fork_integration.log
+
       - name: Run fork E2E tests
         timeout-minutes: 5
         env:
@@ -91,12 +99,14 @@ jobs:
           set -euox pipefail
           poetry run pytest tests/test_fork_e2e.py -rs -v 2>&1 | tee fork_e2e.log
 
-      - name: Upload fork E2E logs
+      - name: Upload fork logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: fork-e2e-logs
-          path: fork_e2e.log
+          path: |
+            fork_integration.log
+            fork_e2e.log
           retention-days: 7
 
   distributed-tests:

--- a/pluto/api.py
+++ b/pluto/api.py
@@ -35,20 +35,30 @@ def make_compat_trigger_v1(settings):
 
 
 def make_compat_start_v1(config, settings, info, tags=None):
-    return json.dumps(
-        {
-            # "runId": settings._op_id,
-            'runName': settings._op_name,
-            'projectName': settings.project,
-            'externalId': settings._external_id,  # User-provided run ID for multi-node
-            'config': json.dumps(config) if config is not None else None,
-            'loggerSettings': json.dumps(clean_dict(settings.to_dict())),
-            'systemMetadata': json.dumps(info) if info is not None else None,
-            'tags': tags if tags else None,
-            'createdAt': settings.compat.get('createdAt'),
-            'updatedAt': settings.compat.get('updatedAt'),
-        }
-    ).encode()
+    payload = {
+        # "runId": settings._op_id,
+        'runName': settings._op_name,
+        'projectName': settings.project,
+        'externalId': settings._external_id,  # User-provided run ID for multi-node
+        'config': json.dumps(config) if config is not None else None,
+        'loggerSettings': json.dumps(clean_dict(settings.to_dict())),
+        'systemMetadata': json.dumps(info) if info is not None else None,
+        'tags': tags if tags else None,
+        'createdAt': settings.compat.get('createdAt'),
+        'updatedAt': settings.compat.get('updatedAt'),
+    }
+
+    # Fork parameters (only include when set)
+    if settings._fork_run_id is not None:
+        payload['forkRunId'] = settings._fork_run_id
+    if settings._fork_step is not None:
+        payload['forkStep'] = settings._fork_step
+    if settings._inherit_config is not None:
+        payload['inheritConfig'] = settings._inherit_config
+    if settings._inherit_tags is not None:
+        payload['inheritTags'] = settings._inherit_tags
+
+    return json.dumps(payload).encode()
 
 
 def make_compat_resume_v1(settings):

--- a/pluto/init.py
+++ b/pluto/init.py
@@ -6,11 +6,34 @@ import pluto
 
 from . import sentry as _sentry
 from .op import Op
-from .sets import Settings, _classify_run_id, setup
+from .sets import Settings, _classify_run_id, _is_display_id, setup
 from .util import gen_id, get_char
 
 logger = logging.getLogger(f'{__name__.split(".")[0]}')
 tag = 'Init'
+
+
+def _resolve_fork_run_id(fork_run_id: Union[int, str], project: str) -> int:
+    """Resolve fork_run_id to a numeric run ID.
+
+    Accepts:
+        - int: used as-is
+        - numeric string (e.g. "12345"): cast to int
+        - display ID (e.g. "T0-123"): resolved via query API
+    """
+    if isinstance(fork_run_id, int):
+        return fork_run_id
+    if isinstance(fork_run_id, str) and fork_run_id.isdigit():
+        return int(fork_run_id)
+    if isinstance(fork_run_id, str) and _is_display_id(fork_run_id):
+        import pluto.query as pq
+
+        run = pq.get_run(project, fork_run_id)
+        return run['id']
+    raise ValueError(
+        f'fork_run_id must be a numeric run ID or display ID '
+        f'(e.g. "T0-123"), got: {fork_run_id!r}'
+    )
 
 
 class OpInit:
@@ -44,7 +67,7 @@ def init(
     tags: Union[str, list[str], None] = None,
     run_id: Optional[str] = None,
     resume: bool = False,
-    fork_run_id: Optional[int] = None,
+    fork_run_id: Optional[Union[int, str]] = None,
     fork_step: Optional[int] = None,
     inherit_config: Optional[bool] = None,
     inherit_tags: Optional[bool] = None,
@@ -71,8 +94,9 @@ def init(
                 same externalId already exists (prevents accidental data
                 collision). Runs created via PLUTO_RUN_ID env var are always
                 allowed to resume regardless of this flag.
-        fork_run_id: Numeric run ID of the parent run to fork from.
-            Must be used together with fork_step.
+        fork_run_id: Parent run to fork from. Accepts a numeric run ID
+            (int), a display ID string (e.g. ``"T0-123"``), or a numeric
+            string (e.g. ``"12345"``). Must be used together with fork_step.
         fork_step: Step number to fork at.
             Must be used together with fork_run_id.
         inherit_config: Whether to inherit config from the parent run
@@ -95,10 +119,10 @@ def init(
             run = pluto.init(
                 project="my-project",
                 name="lr-tuned",
-                fork_run_id=12345,
+                fork_run_id="T0-123",   # display ID from the UI
                 fork_step=500,
                 inherit_config=True,
-                config={"lr": 0.01},  # overrides inherited config keys
+                config={"lr": 0.01},    # overrides inherited config keys
             )
 
         Multi-node distributed training::
@@ -159,7 +183,7 @@ def init(
 
     # Set fork parameters on settings
     if fork_run_id is not None:
-        settings._fork_run_id = fork_run_id
+        settings._fork_run_id = _resolve_fork_run_id(fork_run_id, settings.project)
         settings._fork_step = fork_step
     if inherit_config is not None:
         settings._inherit_config = inherit_config

--- a/pluto/init.py
+++ b/pluto/init.py
@@ -44,6 +44,10 @@ def init(
     tags: Union[str, list[str], None] = None,
     run_id: Optional[str] = None,
     resume: bool = False,
+    fork_run_id: Optional[int] = None,
+    fork_step: Optional[int] = None,
+    inherit_config: Optional[bool] = None,
+    inherit_tags: Optional[bool] = None,
     **kwargs,
 ) -> Op:
     """
@@ -67,6 +71,14 @@ def init(
                 same externalId already exists (prevents accidental data
                 collision). Runs created via PLUTO_RUN_ID env var are always
                 allowed to resume regardless of this flag.
+        fork_run_id: Numeric run ID of the parent run to fork from.
+            Must be used together with fork_step.
+        fork_step: Step number to fork at.
+            Must be used together with fork_run_id.
+        inherit_config: Whether to inherit config from the parent run
+            (default: True on server).
+        inherit_tags: Whether to inherit tags from the parent run
+            (default: False on server).
 
     Returns:
         Op: The initialized run operation
@@ -77,6 +89,17 @@ def init(
             run = pluto.init(project="my-project", name="experiment-1")
             run.log({"loss": 0.5})
             run.finish()
+
+        Fork from an existing run::
+
+            run = pluto.init(
+                project="my-project",
+                name="lr-tuned",
+                fork_run_id=12345,
+                fork_step=500,
+                inherit_config=True,
+                config={"lr": 0.01},  # overrides inherited config keys
+            )
 
         Multi-node distributed training::
 
@@ -103,6 +126,12 @@ def init(
         processes that resume the run will use the original name. For clarity,
         use the same ``name`` value across all ranks.
     """
+    # Validate fork parameters
+    if fork_run_id is not None and fork_step is None:
+        raise ValueError('fork_step is required when fork_run_id is provided')
+    if fork_step is not None and fork_run_id is None:
+        raise ValueError('fork_run_id is required when fork_step is provided')
+
     # TODO: remove legacy compat
     dir = kwargs.get('save_dir', dir)
 
@@ -129,6 +158,15 @@ def init(
     # Auto-add 'konduktor' tag when running inside a Konduktor job
     if os.environ.get('KONDUKTOR_JOB_NAME') and 'konduktor' not in normalized_tags:
         normalized_tags.append('konduktor')
+
+    # Set fork parameters on settings
+    if fork_run_id is not None:
+        settings._fork_run_id = fork_run_id
+        settings._fork_step = fork_step
+    if inherit_config is not None:
+        settings._inherit_config = inherit_config
+    if inherit_tags is not None:
+        settings._inherit_tags = inherit_tags
 
     try:
         op_init = OpInit(config=config, tags=normalized_tags or None, resume=resume)

--- a/pluto/init.py
+++ b/pluto/init.py
@@ -127,10 +127,8 @@ def init(
         use the same ``name`` value across all ranks.
     """
     # Validate fork parameters
-    if fork_run_id is not None and fork_step is None:
-        raise ValueError('fork_step is required when fork_run_id is provided')
-    if fork_step is not None and fork_run_id is None:
-        raise ValueError('fork_run_id is required when fork_step is provided')
+    if (fork_run_id is not None) ^ (fork_step is not None):
+        raise ValueError('fork_run_id and fork_step must be provided together')
 
     # TODO: remove legacy compat
     dir = kwargs.get('save_dir', dir)

--- a/pluto/op.py
+++ b/pluto/op.py
@@ -219,6 +219,8 @@ class Op:
         self._resumed: bool = False  # Whether this run was resumed (multi-node)
         self._resume: bool = resume  # Whether resume was explicitly requested
         self._sync_manager: Optional[SyncProcessManager] = None
+        self._fork_run_id: Optional[int] = None  # Resolved parent run ID from response
+        self._fork_step: Optional[int] = None  # Fork step from response
 
         # Determine if sync process should be used
         self._use_sync_process = settings.sync_process_enabled
@@ -264,6 +266,8 @@ class Op:
             self.settings.url_view = response_data['url']
             self.settings._op_id = response_data['runId']
             self._resumed = response_data.get('resumed', False)
+            self._fork_run_id = response_data.get('forkedFromRunId')
+            self._fork_step = response_data.get('forkStep')
             if self._resumed:
                 # Collision detection: prevent accidental data interleaving
                 if self._resume:
@@ -786,6 +790,25 @@ class Op:
         The server-assigned numeric run ID.
         """
         return self.settings._op_id
+
+    @property
+    def fork_run_id(self) -> Optional[int]:
+        """
+        The resolved parent run ID this run was forked from.
+
+        May differ from the requested fork_run_id due to lineage resolution.
+        Returns None if this run was not forked.
+        """
+        return self._fork_run_id
+
+    @property
+    def fork_step(self) -> Optional[int]:
+        """
+        The step at which this run was forked from its parent.
+
+        Returns None if this run was not forked.
+        """
+        return self._fork_step
 
     def alert(
         self,

--- a/pluto/sets.py
+++ b/pluto/sets.py
@@ -51,6 +51,12 @@ class Settings:
     _resume_run_id: Optional[int] = None  # Numeric run ID for resuming
     _resume_display_id: Optional[str] = None  # Display ID (e.g. "T0-123") for resuming
 
+    # Fork parameters
+    _fork_run_id: Optional[int] = None  # Parent run ID to fork from
+    _fork_step: Optional[int] = None  # Step number to fork at
+    _inherit_config: Optional[bool] = None  # Inherit parent config
+    _inherit_tags: Optional[bool] = None  # Inherit parent tags (server default: False)
+
     store_db: str = 'store.db'
     store_table_num: str = 'num'
     store_table_file: str = 'file'

--- a/tests/fork_integration_test.py
+++ b/tests/fork_integration_test.py
@@ -59,18 +59,19 @@ def wait_for_metrics(run_id: int, expected: list[str], timeout: float = 30.0) ->
 
 def main() -> None:
     commit = get_commit_hash()
+    experiment_name = f'fork-experiment-{commit}'
     print(f'Fork integration test — commit {commit}')
     print(f'Project: {FORK_PROJECT}')
+    print(f'Experiment name: {experiment_name}')
     print()
 
     # ------------------------------------------------------------------
     # 1. Parent run
     # ------------------------------------------------------------------
-    parent_name = f'parent-{commit}'
-    print(f'[1/5] Creating parent run: {parent_name}')
+    print('[1/5] Creating parent run')
     parent = pluto.init(
         project=FORK_PROJECT,
-        name=parent_name,
+        name=experiment_name,
         config=PARENT_CONFIG,
         tags=PARENT_TAGS,
     )
@@ -93,11 +94,10 @@ def main() -> None:
     # ------------------------------------------------------------------
     # 2. Fork with inherited config + overrides
     # ------------------------------------------------------------------
-    fork1_name = f'fork-inherit-config-{commit}'
-    print(f'\n[2/5] Forking with config inheritance + override: {fork1_name}')
+    print('\n[2/5] Forking with config inheritance + override')
     fork1 = pluto.init(
         project=FORK_PROJECT,
-        name=fork1_name,
+        name=experiment_name,
         fork_run_id=parent_id,
         fork_step=5,
         inherit_config=True,
@@ -122,11 +122,10 @@ def main() -> None:
     # ------------------------------------------------------------------
     # 3. Fork with inherited tags
     # ------------------------------------------------------------------
-    fork2_name = f'fork-inherit-tags-{commit}'
-    print(f'\n[3/5] Forking with tag inheritance: {fork2_name}')
+    print('\n[3/5] Forking with tag inheritance')
     fork2 = pluto.init(
         project=FORK_PROJECT,
-        name=fork2_name,
+        name=experiment_name,
         fork_run_id=parent_id,
         fork_step=5,
         inherit_tags=True,
@@ -150,11 +149,10 @@ def main() -> None:
     # ------------------------------------------------------------------
     # 4. Fork without inheritance
     # ------------------------------------------------------------------
-    fork3_name = f'fork-no-inherit-{commit}'
-    print(f'\n[4/5] Forking without inheritance: {fork3_name}')
+    print('\n[4/5] Forking without inheritance')
     fork3 = pluto.init(
         project=FORK_PROJECT,
-        name=fork3_name,
+        name=experiment_name,
         fork_run_id=parent_id,
         fork_step=3,
         inherit_config=False,
@@ -180,11 +178,10 @@ def main() -> None:
     # ------------------------------------------------------------------
     # 5. Chain fork (fork from fork1)
     # ------------------------------------------------------------------
-    fork4_name = f'fork-chain-{commit}'
-    print(f'\n[5/5] Chain fork (from fork 1): {fork4_name}')
+    print('\n[5/5] Chain fork (from fork 1)')
     fork4 = pluto.init(
         project=FORK_PROJECT,
-        name=fork4_name,
+        name=experiment_name,
         fork_run_id=fork1_id,
         fork_step=5,
         inherit_config=True,
@@ -210,14 +207,15 @@ def main() -> None:
     # ------------------------------------------------------------------
     print('\n' + '=' * 60)
     print('Fork integration test completed successfully!')
-    print(f'Commit: {commit}')
-    print(f'Project: {FORK_PROJECT}')
-    print('Runs created:')
-    print(f'  Parent:              {parent_name} (id={parent_id})')
-    print(f'  Fork (config):       {fork1_name} (id={fork1_id})')
-    print(f'  Fork (tags):         {fork2_name} (id={fork2_id})')
-    print(f'  Fork (no inherit):   {fork3_name} (id={fork3_id})')
-    print(f'  Fork (chain):        {fork4_name} (id={fork4_id})')
+    print(f'Commit:     {commit}')
+    print(f'Project:    {FORK_PROJECT}')
+    print(f'Experiment: {experiment_name}')
+    print('Runs created (all share the same name for experiments mode):')
+    print(f'  Parent:            id={parent_id}')
+    print(f'  Fork (config):     id={fork1_id}  fork_step=5')
+    print(f'  Fork (tags):       id={fork2_id}  fork_step=5')
+    print(f'  Fork (no inherit): id={fork3_id}  fork_step=3')
+    print(f'  Fork (chain):      id={fork4_id}  fork_step=5 (from {fork1_id})')
     print('=' * 60)
 
 

--- a/tests/fork_integration_test.py
+++ b/tests/fork_integration_test.py
@@ -44,17 +44,29 @@ def get_commit_hash() -> str:
         return 'unknown'
 
 
-def wait_for_metrics(run_id: int, expected: list[str], timeout: float = 30.0) -> None:
-    """Poll until expected metric names appear on the server."""
+def wait_for_step(run_id: int, expected_step: int, timeout: float = 60.0) -> None:
+    """Poll until ClickHouse has ingested metrics up to expected_step."""
     import pluto.query as pq
 
     deadline = time.monotonic() + timeout
+    max_seen = -1
     while time.monotonic() < deadline:
-        names = pq.get_metric_names(FORK_PROJECT, run_ids=[run_id])
-        if all(e in names for e in expected):
-            return
-        time.sleep(2)
-    print(f'  Warning: timed out waiting for metrics {expected} on run {run_id}')
+        try:
+            metrics = pq.get_metrics(FORK_PROJECT, run_id, metric_names=['train/loss'])
+            if hasattr(metrics, 'to_dict'):
+                steps = metrics['step'].tolist()
+            else:
+                steps = [m['step'] for m in metrics]
+            max_seen = max(steps) if steps else -1
+            if max_seen >= expected_step:
+                return
+        except Exception:
+            pass
+        time.sleep(3)
+    print(
+        f'  Warning: timed out waiting for step {expected_step} '
+        f'on run {run_id} (max seen: {max_seen})'
+    )
 
 
 def main() -> None:
@@ -88,8 +100,8 @@ def main() -> None:
     parent.finish()
     print(f'  Parent run finished (id={parent_id})')
 
-    # Wait for parent metrics to be ingested so forkStep validation passes
-    wait_for_metrics(parent_id, ['train/loss', 'train/acc'])
+    # Wait for ClickHouse to ingest all parent steps so forkStep validation passes
+    wait_for_step(parent_id, PARENT_STEPS - 1)
 
     # ------------------------------------------------------------------
     # 2. Fork with inherited config + overrides
@@ -117,7 +129,7 @@ def main() -> None:
     fork1.finish()
     print(f'  Fork 1 finished (id={fork1_id})')
 
-    wait_for_metrics(fork1_id, ['train/loss', 'train/acc'])
+    wait_for_step(fork1_id, 9)
 
     # ------------------------------------------------------------------
     # 3. Fork with inherited tags
@@ -143,8 +155,6 @@ def main() -> None:
         )
     fork2.finish()
     print(f'  Fork 2 finished (id={fork2_id})')
-
-    wait_for_metrics(fork2_id, ['train/loss', 'val/loss'])
 
     # ------------------------------------------------------------------
     # 4. Fork without inheritance
@@ -172,8 +182,6 @@ def main() -> None:
         )
     fork3.finish()
     print(f'  Fork 3 finished (id={fork3_id})')
-
-    wait_for_metrics(fork3_id, ['train/loss', 'train/acc'])
 
     # ------------------------------------------------------------------
     # 5. Chain fork (fork from fork1)

--- a/tests/fork_integration_test.py
+++ b/tests/fork_integration_test.py
@@ -1,0 +1,225 @@
+"""
+End-to-end fork integration test for the Pluto platform.
+
+This test validates the full fork workflow by:
+1. Creating a parent run with config, tags, and metrics
+2. Forking from the parent with various inheritance options
+3. Logging metrics on forked runs
+4. Chaining forks (fork from a fork)
+
+Run names are suffixed with the git commit hash so results are
+visible in the testing-ci-fork project UI.
+
+Usage:
+    python tests/fork_integration_test.py
+"""
+
+import subprocess
+import time
+from pathlib import Path
+
+import pluto
+
+FORK_PROJECT = 'testing-ci-fork'
+
+PARENT_CONFIG = {
+    'model': 'resnet50',
+    'lr': 0.001,
+    'optimizer': 'adam',
+    'epochs': 100,
+}
+PARENT_TAGS = ['baseline', 'integration-test']
+PARENT_STEPS = 10
+
+
+def get_commit_hash() -> str:
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        result = subprocess.check_output(
+            ['git', 'rev-parse', '--short', 'HEAD'],
+            cwd=str(repo_root),
+        )
+        return result.decode().strip()
+    except Exception:
+        return 'unknown'
+
+
+def wait_for_metrics(run_id: int, expected: list[str], timeout: float = 30.0) -> None:
+    """Poll until expected metric names appear on the server."""
+    import pluto.query as pq
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        names = pq.get_metric_names(FORK_PROJECT, run_ids=[run_id])
+        if all(e in names for e in expected):
+            return
+        time.sleep(2)
+    print(f'  Warning: timed out waiting for metrics {expected} on run {run_id}')
+
+
+def main() -> None:
+    commit = get_commit_hash()
+    print(f'Fork integration test — commit {commit}')
+    print(f'Project: {FORK_PROJECT}')
+    print()
+
+    # ------------------------------------------------------------------
+    # 1. Parent run
+    # ------------------------------------------------------------------
+    parent_name = f'parent-{commit}'
+    print(f'[1/5] Creating parent run: {parent_name}')
+    parent = pluto.init(
+        project=FORK_PROJECT,
+        name=parent_name,
+        config=PARENT_CONFIG,
+        tags=PARENT_TAGS,
+    )
+    parent_id = parent.settings._op_id
+
+    for step in range(PARENT_STEPS):
+        parent.log(
+            {
+                'train/loss': 1.0 - step * 0.08,
+                'train/acc': step * 0.09,
+            }
+        )
+        print(f'  step {step}: loss={1.0 - step * 0.08:.2f}  acc={step * 0.09:.2f}')
+    parent.finish()
+    print(f'  Parent run finished (id={parent_id})')
+
+    # Wait for parent metrics to be ingested so forkStep validation passes
+    wait_for_metrics(parent_id, ['train/loss', 'train/acc'])
+
+    # ------------------------------------------------------------------
+    # 2. Fork with inherited config + overrides
+    # ------------------------------------------------------------------
+    fork1_name = f'fork-inherit-config-{commit}'
+    print(f'\n[2/5] Forking with config inheritance + override: {fork1_name}')
+    fork1 = pluto.init(
+        project=FORK_PROJECT,
+        name=fork1_name,
+        fork_run_id=parent_id,
+        fork_step=5,
+        inherit_config=True,
+        config={'lr': 0.01, 'scheduler': 'cosine'},
+        tags=['fork', 'config-override'],
+    )
+    fork1_id = fork1.settings._op_id
+    print(f'  fork_run_id={fork1.fork_run_id}  fork_step={fork1.fork_step}')
+
+    for step in range(10):
+        fork1.log(
+            {
+                'train/loss': 0.5 - step * 0.04,
+                'train/acc': 0.5 + step * 0.05,
+            }
+        )
+    fork1.finish()
+    print(f'  Fork 1 finished (id={fork1_id})')
+
+    wait_for_metrics(fork1_id, ['train/loss', 'train/acc'])
+
+    # ------------------------------------------------------------------
+    # 3. Fork with inherited tags
+    # ------------------------------------------------------------------
+    fork2_name = f'fork-inherit-tags-{commit}'
+    print(f'\n[3/5] Forking with tag inheritance: {fork2_name}')
+    fork2 = pluto.init(
+        project=FORK_PROJECT,
+        name=fork2_name,
+        fork_run_id=parent_id,
+        fork_step=5,
+        inherit_tags=True,
+        tags=['fork', 'tag-inherit'],
+    )
+    fork2_id = fork2.settings._op_id
+    print(f'  fork_run_id={fork2.fork_run_id}  fork_step={fork2.fork_step}')
+
+    for step in range(8):
+        fork2.log(
+            {
+                'train/loss': 0.6 - step * 0.06,
+                'val/loss': 0.7 - step * 0.05,
+            }
+        )
+    fork2.finish()
+    print(f'  Fork 2 finished (id={fork2_id})')
+
+    wait_for_metrics(fork2_id, ['train/loss', 'val/loss'])
+
+    # ------------------------------------------------------------------
+    # 4. Fork without inheritance
+    # ------------------------------------------------------------------
+    fork3_name = f'fork-no-inherit-{commit}'
+    print(f'\n[4/5] Forking without inheritance: {fork3_name}')
+    fork3 = pluto.init(
+        project=FORK_PROJECT,
+        name=fork3_name,
+        fork_run_id=parent_id,
+        fork_step=3,
+        inherit_config=False,
+        inherit_tags=False,
+        config={'model': 'vit', 'lr': 0.0001},
+        tags=['fork', 'fresh-start'],
+    )
+    fork3_id = fork3.settings._op_id
+    print(f'  fork_run_id={fork3.fork_run_id}  fork_step={fork3.fork_step}')
+
+    for step in range(15):
+        fork3.log(
+            {
+                'train/loss': 0.8 - step * 0.05,
+                'train/acc': 0.2 + step * 0.05,
+            }
+        )
+    fork3.finish()
+    print(f'  Fork 3 finished (id={fork3_id})')
+
+    wait_for_metrics(fork3_id, ['train/loss', 'train/acc'])
+
+    # ------------------------------------------------------------------
+    # 5. Chain fork (fork from fork1)
+    # ------------------------------------------------------------------
+    fork4_name = f'fork-chain-{commit}'
+    print(f'\n[5/5] Chain fork (from fork 1): {fork4_name}')
+    fork4 = pluto.init(
+        project=FORK_PROJECT,
+        name=fork4_name,
+        fork_run_id=fork1_id,
+        fork_step=5,
+        inherit_config=True,
+        inherit_tags=True,
+        config={'lr': 0.005},
+        tags=['fork', 'chain'],
+    )
+    fork4_id = fork4.settings._op_id
+    print(f'  fork_run_id={fork4.fork_run_id}  fork_step={fork4.fork_step}')
+
+    for step in range(10):
+        fork4.log(
+            {
+                'train/loss': 0.3 - step * 0.02,
+                'train/acc': 0.7 + step * 0.03,
+            }
+        )
+    fork4.finish()
+    print(f'  Fork 4 finished (id={fork4_id})')
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+    print('\n' + '=' * 60)
+    print('Fork integration test completed successfully!')
+    print(f'Commit: {commit}')
+    print(f'Project: {FORK_PROJECT}')
+    print('Runs created:')
+    print(f'  Parent:              {parent_name} (id={parent_id})')
+    print(f'  Fork (config):       {fork1_name} (id={fork1_id})')
+    print(f'  Fork (tags):         {fork2_name} (id={fork2_id})')
+    print(f'  Fork (no inherit):   {fork3_name} (id={fork3_id})')
+    print(f'  Fork (chain):        {fork4_name} (id={fork4_id})')
+    print('=' * 60)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/manual_fork_chain.py
+++ b/tests/manual_fork_chain.py
@@ -1,0 +1,147 @@
+"""
+Manual fork chain test — simulates iterative LLM training over 5 runs.
+
+Each run forks from the previous one at its last step, inheriting config
+and adding its own metrics. All runs share the same name so they group
+in experiments mode.
+
+Usage:
+    PLUTO_API_KEY=<token> python tests/manual_fork_chain.py
+
+Then open the testing-ci-fork project in the UI and look for the
+experiment named 'llm-pretrain-<commit>'.
+"""
+
+import subprocess
+import time
+from pathlib import Path
+
+import pluto
+
+PROJECT = 'testing-ci-fork'
+NUM_RUNS = 5
+STEPS_PER_RUN = 20
+
+
+def get_commit_hash() -> str:
+    try:
+        result = subprocess.check_output(
+            ['git', 'rev-parse', '--short', 'HEAD'],
+            cwd=str(Path(__file__).resolve().parents[1]),
+        )
+        return result.decode().strip()
+    except Exception:
+        return 'unknown'
+
+
+def wait_for_metrics(run_id: int, timeout: float = 30.0) -> None:
+    import pluto.query as pq
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        names = pq.get_metric_names(PROJECT, run_ids=[run_id])
+        if 'train/loss' in names:
+            return
+        time.sleep(2)
+    print(f'  Warning: timed out waiting for metrics on run {run_id}')
+
+
+def main() -> None:
+    commit = get_commit_hash()
+    experiment_name = f'llm-pretrain-{commit}'
+
+    print(f'Chained fork test — {NUM_RUNS} runs, {STEPS_PER_RUN} steps each')
+    print(f'Project:    {PROJECT}')
+    print(f'Experiment: {experiment_name}')
+    print()
+
+    prev_id = None
+    prev_last_step = None
+    all_runs = []
+
+    for i in range(NUM_RUNS):
+        # Each run tweaks the learning rate (simulating LR decay across restarts)
+        lr = 0.001 * (0.5**i)
+        config = {
+            'model': 'llama-7b',
+            'lr': lr,
+            'run_index': i,
+            'total_steps': (i + 1) * STEPS_PER_RUN,
+        }
+
+        fork_kwargs = {}
+        if prev_id is not None:
+            fork_kwargs = {
+                'fork_run_id': prev_id,
+                'fork_step': prev_last_step,
+                'inherit_config': True,
+            }
+            print(
+                f'[{i + 1}/{NUM_RUNS}] Forking from run {prev_id}'
+                f' at step {prev_last_step}  (lr={lr})'
+            )
+        else:
+            print(f'[{i + 1}/{NUM_RUNS}] Starting root run  (lr={lr})')
+
+        run = pluto.init(
+            project=PROJECT,
+            name=experiment_name,
+            config=config,
+            tags=['chain-test', f'run-{i}'],
+            **fork_kwargs,
+        )
+        run_id = run.settings._op_id
+
+        if prev_id is not None:
+            print(
+                f'  Server resolved: fork_run_id={run.fork_run_id}'
+                f'  fork_step={run.fork_step}'
+            )
+
+        # Log metrics — global step is continuous across all runs
+        global_step_offset = i * STEPS_PER_RUN
+        for s in range(STEPS_PER_RUN):
+            global_step = global_step_offset + s
+            loss = 2.0 / (global_step + 1) + 0.01 * (0.5**i)
+            run.log(
+                {
+                    'train/loss': loss,
+                    'train/lr': lr,
+                    'train/tokens_seen': (global_step + 1) * 4096,
+                }
+            )
+
+        last_step = global_step_offset + STEPS_PER_RUN - 1
+        run.finish()
+        print(f'  Finished run {run_id}  (steps {global_step_offset}..{last_step})')
+
+        # Wait for metrics before forking the next run
+        if i < NUM_RUNS - 1:
+            wait_for_metrics(run_id)
+
+        all_runs.append({'index': i, 'id': run_id, 'lr': lr})
+        prev_id = run_id
+        prev_last_step = last_step
+
+    # Summary
+    print()
+    print('=' * 60)
+    print('Chain complete!')
+    print(f'Experiment: {experiment_name}')
+    print(f'Project:    {PROJECT}')
+    print()
+    print('What to verify in the UI:')
+    print('  1. Switch to experiments mode — all 5 runs group under one name')
+    print('  2. Open a chart for train/loss — should be one continuous line')
+    print(f'     from step 0 to step {NUM_RUNS * STEPS_PER_RUN - 1}')
+    print('  3. Each fork point should be seamless (no gaps)')
+    print()
+    for r in all_runs:
+        idx = r['index']
+        fork_note = f'fork from {all_runs[idx - 1]["id"]}' if idx > 0 else 'root'
+        print(f'  Run {r["index"]}: id={r["id"]}  lr={r["lr"]}  ({fork_note})')
+    print('=' * 60)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/manual_fork_chain.py
+++ b/tests/manual_fork_chain.py
@@ -21,7 +21,10 @@ import pluto
 
 PROJECT = 'testing-ci-fork'
 NUM_RUNS = 5
-STEPS_PER_RUN = 20
+STEPS_PER_RUN = 30
+# Fork 10 steps before the end of each run, creating a 10-step overlap
+# where both parent and child have logged data for the same step range.
+FORK_OVERLAP = 10
 
 
 def get_commit_hash() -> str:
@@ -87,14 +90,19 @@ def main() -> None:
 
         fork_kwargs = {}
         if prev_id is not None:
+            # Fork 10 steps before the parent's end, so parent has data
+            # past the fork point that the stitching should ignore.
+            fork_step = prev_last_step - FORK_OVERLAP
             fork_kwargs = {
                 'fork_run_id': prev_id,
-                'fork_step': prev_last_step,
+                'fork_step': fork_step,
                 'inherit_config': True,
             }
             print(
                 f'[{i + 1}/{NUM_RUNS}] Forking from run {prev_id}'
-                f' at step {prev_last_step}  (lr={lr})'
+                f' at step {fork_step}  (lr={lr})'
+                f'  (parent went to {prev_last_step},'
+                f' {FORK_OVERLAP}-step overlap)'
             )
         else:
             print(f'[{i + 1}/{NUM_RUNS}] Starting root run  (lr={lr})')
@@ -114,23 +122,26 @@ def main() -> None:
                 f'  fork_step={run.fork_step}'
             )
 
-        # Log metrics — global step is continuous across all runs
-        global_step_offset = i * STEPS_PER_RUN
+        # Log metrics — child starts at fork_step+1 for continuity
+        if prev_id is not None:
+            start_step = fork_step + 1
+        else:
+            start_step = 0
         for s in range(STEPS_PER_RUN):
-            global_step = global_step_offset + s
-            loss = 2.0 / (global_step + 1) + 0.01 * (0.5**i)
+            step = start_step + s
+            loss = 2.0 / (step + 1) + 0.01 * (0.5**i)
             run.log(
                 {
                     'train/loss': loss,
                     'train/lr': lr,
-                    'train/tokens_seen': (global_step + 1) * 4096,
+                    'train/tokens_seen': (step + 1) * 4096,
                 },
-                step=global_step,
+                step=step,
             )
 
-        last_step = global_step_offset + STEPS_PER_RUN - 1
+        last_step = start_step + STEPS_PER_RUN - 1
         run.finish()
-        print(f'  Finished run {run_id}  (steps {global_step_offset}..{last_step})')
+        print(f'  Finished run {run_id}  (steps {start_step}..{last_step})')
 
         # Wait for ClickHouse to ingest up to last_step before forking
         if i < NUM_RUNS - 1:
@@ -150,7 +161,7 @@ def main() -> None:
     print('What to verify in the UI:')
     print('  1. Switch to experiments mode — all 5 runs group under one name')
     print('  2. Open a chart for train/loss — should be one continuous line')
-    print(f'     from step 0 to step {NUM_RUNS * STEPS_PER_RUN - 1}')
+    print('     (stitching ignores parent data past each fork point)')
     print('  3. Each fork point should be seamless (no gaps)')
     print()
     for r in all_runs:

--- a/tests/manual_fork_chain.py
+++ b/tests/manual_fork_chain.py
@@ -34,16 +34,30 @@ def get_commit_hash() -> str:
         return 'unknown'
 
 
-def wait_for_metrics(run_id: int, timeout: float = 30.0) -> None:
+def wait_for_step(run_id: int, expected_step: int, timeout: float = 60.0) -> None:
+    """Poll until ClickHouse has ingested metrics up to expected_step."""
     import pluto.query as pq
 
     deadline = time.monotonic() + timeout
+    max_seen = -1
     while time.monotonic() < deadline:
-        names = pq.get_metric_names(PROJECT, run_ids=[run_id])
-        if 'train/loss' in names:
-            return
-        time.sleep(2)
-    print(f'  Warning: timed out waiting for metrics on run {run_id}')
+        try:
+            metrics = pq.get_metrics(PROJECT, run_id, metric_names=['train/loss'])
+            if hasattr(metrics, 'to_dict'):
+                steps = metrics['step'].tolist()
+            else:
+                steps = [m['step'] for m in metrics]
+            max_seen = max(steps) if steps else -1
+            if max_seen >= expected_step:
+                print(f'  ClickHouse has step {max_seen} (needed {expected_step})')
+                return
+        except Exception:
+            pass
+        time.sleep(3)
+    print(
+        f'  Warning: timed out waiting for step {expected_step} '
+        f'on run {run_id} (max seen: {max_seen})'
+    )
 
 
 def main() -> None:
@@ -115,9 +129,9 @@ def main() -> None:
         run.finish()
         print(f'  Finished run {run_id}  (steps {global_step_offset}..{last_step})')
 
-        # Wait for metrics before forking the next run
+        # Wait for ClickHouse to ingest up to last_step before forking
         if i < NUM_RUNS - 1:
-            wait_for_metrics(run_id)
+            wait_for_step(run_id, last_step)
 
         all_runs.append({'index': i, 'id': run_id, 'lr': lr})
         prev_id = run_id

--- a/tests/manual_fork_chain.py
+++ b/tests/manual_fork_chain.py
@@ -14,6 +14,7 @@ experiment named 'llm-pretrain-<commit>'.
 
 import subprocess
 import time
+import uuid
 from pathlib import Path
 
 import pluto
@@ -62,7 +63,8 @@ def wait_for_step(run_id: int, expected_step: int, timeout: float = 60.0) -> Non
 
 def main() -> None:
     commit = get_commit_hash()
-    experiment_name = f'llm-pretrain-{commit}'
+    suffix = str(uuid.uuid4())[:4]
+    experiment_name = f'llm-pretrain-{commit}-{suffix}'
 
     print(f'Chained fork test — {NUM_RUNS} runs, {STEPS_PER_RUN} steps each')
     print(f'Project:    {PROJECT}')
@@ -122,7 +124,8 @@ def main() -> None:
                     'train/loss': loss,
                     'train/lr': lr,
                     'train/tokens_seen': (global_step + 1) * 4096,
-                }
+                },
+                step=global_step,
             )
 
         last_step = global_step_offset + STEPS_PER_RUN - 1

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -22,6 +22,7 @@ import numpy as np
 
 import pluto
 from pluto.api import make_compat_start_v1
+from pluto.init import _resolve_fork_run_id
 from pluto.sets import Settings
 from tests.utils import get_task_name
 
@@ -370,6 +371,22 @@ def test_fork_parameters_omitted_when_none():
     assert 'forkStep' not in payload
     assert 'inheritConfig' not in payload
     assert 'inheritTags' not in payload
+
+
+def test_fork_resolve_int():
+    """Resolve fork_run_id passes through int unchanged."""
+    assert _resolve_fork_run_id(12345, 'proj') == 12345
+
+
+def test_fork_resolve_numeric_string():
+    """Resolve fork_run_id casts numeric string to int."""
+    assert _resolve_fork_run_id('12345', 'proj') == 12345
+
+
+def test_fork_resolve_invalid_string():
+    """Resolve fork_run_id raises on non-display-ID string."""
+    with pytest.raises(ValueError, match='numeric run ID or display ID'):
+        _resolve_fork_run_id('not-a-valid-id', 'proj')
 
 
 def test_fork_metadata_properties_default_none():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -318,3 +318,69 @@ def test_update_config_multiple_calls():
     assert run.config['model'] == 'resnet50'
 
     run.finish()
+
+
+def test_fork_validation_missing_fork_step():
+    """Test that fork_run_id without fork_step raises ValueError."""
+    with pytest.raises(ValueError, match='fork_step is required'):
+        pluto.init(
+            project=TESTING_PROJECT_NAME,
+            name=get_task_name(),
+            fork_run_id=12345,
+        )
+
+
+def test_fork_validation_missing_fork_run_id():
+    """Test that fork_step without fork_run_id raises ValueError."""
+    with pytest.raises(ValueError, match='fork_run_id is required'):
+        pluto.init(
+            project=TESTING_PROJECT_NAME,
+            name=get_task_name(),
+            fork_step=500,
+        )
+
+
+def test_fork_parameters_in_start_payload():
+    """Test that fork parameters are included in the start payload."""
+    import json
+
+    from pluto.api import make_compat_start_v1
+    from pluto.sets import Settings
+
+    settings = Settings()
+    settings._fork_run_id = 12345
+    settings._fork_step = 500
+    settings._inherit_config = True
+    settings._inherit_tags = False
+
+    payload = json.loads(make_compat_start_v1({}, settings, None))
+
+    assert payload['forkRunId'] == 12345
+    assert payload['forkStep'] == 500
+    assert payload['inheritConfig'] is True
+    assert payload['inheritTags'] is False
+
+
+def test_fork_parameters_omitted_when_none():
+    """Test that fork parameters are omitted from payload when not set."""
+    import json
+
+    from pluto.api import make_compat_start_v1
+    from pluto.sets import Settings
+
+    settings = Settings()
+
+    payload = json.loads(make_compat_start_v1({}, settings, None))
+
+    assert 'forkRunId' not in payload
+    assert 'forkStep' not in payload
+    assert 'inheritConfig' not in payload
+    assert 'inheritTags' not in payload
+
+
+def test_fork_metadata_properties_default_none():
+    """Test that fork properties are None on a normal (non-forked) run."""
+    run = pluto.init(project=TESTING_PROJECT_NAME, name=get_task_name(), config={})
+    assert run.fork_run_id is None
+    assert run.fork_step is None
+    run.finish()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -16,9 +16,13 @@ except ImportError:  # pragma: no cover - optional dependency
     plt = None
     HAS_MATPLOTLIB = False
 
+import json
+
 import numpy as np
 
 import pluto
+from pluto.api import make_compat_start_v1
+from pluto.sets import Settings
 from tests.utils import get_task_name
 
 try:
@@ -322,7 +326,7 @@ def test_update_config_multiple_calls():
 
 def test_fork_validation_missing_fork_step():
     """Test that fork_run_id without fork_step raises ValueError."""
-    with pytest.raises(ValueError, match='fork_step is required'):
+    with pytest.raises(ValueError, match='must be provided together'):
         pluto.init(
             project=TESTING_PROJECT_NAME,
             name=get_task_name(),
@@ -332,7 +336,7 @@ def test_fork_validation_missing_fork_step():
 
 def test_fork_validation_missing_fork_run_id():
     """Test that fork_step without fork_run_id raises ValueError."""
-    with pytest.raises(ValueError, match='fork_run_id is required'):
+    with pytest.raises(ValueError, match='must be provided together'):
         pluto.init(
             project=TESTING_PROJECT_NAME,
             name=get_task_name(),
@@ -342,11 +346,6 @@ def test_fork_validation_missing_fork_run_id():
 
 def test_fork_parameters_in_start_payload():
     """Test that fork parameters are included in the start payload."""
-    import json
-
-    from pluto.api import make_compat_start_v1
-    from pluto.sets import Settings
-
     settings = Settings()
     settings._fork_run_id = 12345
     settings._fork_step = 500
@@ -363,11 +362,6 @@ def test_fork_parameters_in_start_payload():
 
 def test_fork_parameters_omitted_when_none():
     """Test that fork parameters are omitted from payload when not set."""
-    import json
-
-    from pluto.api import make_compat_start_v1
-    from pluto.sets import Settings
-
     settings = Settings()
 
     payload = json.loads(make_compat_start_v1({}, settings, None))

--- a/tests/test_fork_e2e.py
+++ b/tests/test_fork_e2e.py
@@ -1,0 +1,292 @@
+"""End-to-end tests for run forking.
+
+Creates a parent run once per module, then forks from it in each test to verify
+fork metadata, config/tag inheritance, and metric logging on forked runs.
+
+Requires:
+    - PLUTO_API_KEY environment variable
+    - Network access to the Pluto server (staging with fork support)
+"""
+
+import time
+from typing import Callable, Dict, List, TypeVar
+
+import pytest
+
+import pluto
+import pluto.query as pq
+
+FORK_PROJECT = 'testing-ci-fork'
+
+_POLL_TIMEOUT = 15
+_POLL_INTERVAL = 2
+
+T = TypeVar('T')
+
+
+def _poll(
+    fn: Callable[[], T],
+    check: Callable[[T], bool],
+    timeout: float = _POLL_TIMEOUT,
+    interval: float = _POLL_INTERVAL,
+) -> T:
+    """Call *fn* repeatedly until *check(result)* is truthy, then return result."""
+    deadline = time.monotonic() + timeout
+    last: T = fn()
+    while not check(last):
+        if time.monotonic() >= deadline:
+            return last
+        time.sleep(interval)
+        last = fn()
+    return last
+
+
+def _poll_metric_names(
+    project: str,
+    run_id: int,
+    expected: List[str],
+    timeout: float = _POLL_TIMEOUT,
+) -> List[str]:
+    """Poll until all *expected* metric names are present on the server."""
+    return _poll(
+        fn=lambda: pq.get_metric_names(project, run_ids=[run_id]),
+        check=lambda names: all(e in names for e in expected),
+        timeout=timeout,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped parent run (created once, shared by all fork tests)
+# ---------------------------------------------------------------------------
+
+_PARENT_CONFIG = {'model': 'resnet50', 'lr': 0.001, 'epochs': 100}
+_PARENT_TAGS = ['baseline', 'fork-parent']
+_PARENT_STEPS = 10
+
+
+@pytest.fixture(scope='module')
+def parent_run() -> Dict:
+    """Create a parent run with known config, tags, and metrics.
+
+    Returns a dict with ``run_id``, ``config``, ``tags``, and ``max_step``.
+    """
+    run = pluto.init(
+        project=FORK_PROJECT,
+        name=f'fork-parent-{int(time.time())}',
+        config=_PARENT_CONFIG,
+        tags=_PARENT_TAGS,
+    )
+    run_id = run.settings._op_id
+
+    for step in range(_PARENT_STEPS):
+        run.log({'train/loss': 1.0 - step * 0.1, 'train/acc': step * 0.1})
+    run.finish()
+
+    # Wait for metrics to be ingested so the server can validate forkStep
+    _poll_metric_names(FORK_PROJECT, run_id, ['train/loss', 'train/acc'])
+
+    return {
+        'run_id': run_id,
+        'config': _PARENT_CONFIG,
+        'tags': _PARENT_TAGS,
+        'max_step': _PARENT_STEPS - 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fork metadata
+# ---------------------------------------------------------------------------
+
+
+def test_fork_e2e_run_metadata(parent_run):
+    """Forked run has correct fork_run_id and fork_step on the client."""
+    fork_step = 5
+    run = pluto.init(
+        project=FORK_PROJECT,
+        name=f'fork-meta-{int(time.time())}',
+        fork_run_id=parent_run['run_id'],
+        fork_step=fork_step,
+    )
+    run_id = run.settings._op_id
+
+    assert run.fork_run_id == parent_run['run_id']
+    assert run.fork_step == fork_step
+
+    run.finish()
+
+    server_run = pq.get_run(FORK_PROJECT, run_id)
+    assert server_run['status'] == 'COMPLETED'
+
+
+def test_fork_e2e_default_inherits_config(parent_run):
+    """By default (inherit_config not set), forked run inherits parent config."""
+    run = pluto.init(
+        project=FORK_PROJECT,
+        name=f'fork-cfg-default-{int(time.time())}',
+        fork_run_id=parent_run['run_id'],
+        fork_step=5,
+    )
+    run_id = run.settings._op_id
+    run.finish()
+
+    server_config = pq.get_run(FORK_PROJECT, run_id).get('config', {})
+    assert server_config.get('model') == 'resnet50'
+    assert server_config.get('lr') == 0.001
+    assert server_config.get('epochs') == 100
+
+
+def test_fork_e2e_inherit_config_with_override(parent_run):
+    """Forked run merges explicit config on top of inherited parent config."""
+    run = pluto.init(
+        project=FORK_PROJECT,
+        name=f'fork-cfg-override-{int(time.time())}',
+        fork_run_id=parent_run['run_id'],
+        fork_step=5,
+        inherit_config=True,
+        config={'lr': 0.01, 'scheduler': 'cosine'},
+    )
+    run_id = run.settings._op_id
+    run.finish()
+
+    server_config = pq.get_run(FORK_PROJECT, run_id).get('config', {})
+    # Inherited from parent
+    assert server_config.get('model') == 'resnet50'
+    assert server_config.get('epochs') == 100
+    # Overridden by child
+    assert server_config.get('lr') == 0.01
+    # New from child
+    assert server_config.get('scheduler') == 'cosine'
+
+
+def test_fork_e2e_no_inherit_config(parent_run):
+    """inherit_config=False means forked run only has its own config."""
+    run = pluto.init(
+        project=FORK_PROJECT,
+        name=f'fork-no-cfg-{int(time.time())}',
+        fork_run_id=parent_run['run_id'],
+        fork_step=5,
+        inherit_config=False,
+        config={'custom_only': True},
+    )
+    run_id = run.settings._op_id
+    run.finish()
+
+    server_config = pq.get_run(FORK_PROJECT, run_id).get('config', {})
+    assert server_config.get('custom_only') is True
+    # Parent config should NOT be inherited
+    assert 'model' not in server_config
+
+
+# ---------------------------------------------------------------------------
+# Tag inheritance
+# ---------------------------------------------------------------------------
+
+
+def test_fork_e2e_inherit_tags(parent_run):
+    """inherit_tags=True copies parent tags to forked run."""
+    run = pluto.init(
+        project=FORK_PROJECT,
+        name=f'fork-tags-inherit-{int(time.time())}',
+        fork_run_id=parent_run['run_id'],
+        fork_step=5,
+        inherit_tags=True,
+        tags=['child-tag'],
+    )
+    run_id = run.settings._op_id
+    run.finish()
+
+    server_tags = pq.get_run(FORK_PROJECT, run_id).get('tags', [])
+    # Inherited from parent
+    for tag in _PARENT_TAGS:
+        assert tag in server_tags, f"Inherited tag '{tag}' not found"
+    # Child's own tag
+    assert 'child-tag' in server_tags
+
+
+def test_fork_e2e_no_inherit_tags_by_default(parent_run):
+    """By default (inherit_tags not set), parent tags are NOT inherited."""
+    run = pluto.init(
+        project=FORK_PROJECT,
+        name=f'fork-tags-default-{int(time.time())}',
+        fork_run_id=parent_run['run_id'],
+        fork_step=5,
+        tags=['only-mine'],
+    )
+    run_id = run.settings._op_id
+    run.finish()
+
+    server_tags = pq.get_run(FORK_PROJECT, run_id).get('tags', [])
+    assert 'only-mine' in server_tags
+    # Parent tags should NOT appear (server default is inheritTags=false)
+    assert 'fork-parent' not in server_tags
+
+
+# ---------------------------------------------------------------------------
+# Metrics on forked runs
+# ---------------------------------------------------------------------------
+
+
+def test_fork_e2e_log_metrics(parent_run):
+    """Forked run can log its own metrics that appear on the server."""
+    run = pluto.init(
+        project=FORK_PROJECT,
+        name=f'fork-metrics-{int(time.time())}',
+        fork_run_id=parent_run['run_id'],
+        fork_step=5,
+    )
+    run_id = run.settings._op_id
+
+    for step in range(5):
+        run.log({'fork/loss': 0.5 - step * 0.1})
+    run.finish()
+
+    metric_names = _poll_metric_names(FORK_PROJECT, run_id, ['fork/loss'])
+    assert 'fork/loss' in metric_names
+
+    metrics = pq.get_metrics(FORK_PROJECT, run_id, metric_names=['fork/loss'])
+    if hasattr(metrics, 'to_dict'):
+        values = metrics['value'].tolist()
+    else:
+        values = [m['value'] for m in metrics]
+    assert len(values) == 5
+    assert values[0] == pytest.approx(0.5, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Chain forking (fork from a fork)
+# ---------------------------------------------------------------------------
+
+
+def test_fork_e2e_chain_fork(parent_run):
+    """Fork from a forked run (two-level lineage)."""
+    # First fork
+    run1 = pluto.init(
+        project=FORK_PROJECT,
+        name=f'fork-chain-1-{int(time.time())}',
+        fork_run_id=parent_run['run_id'],
+        fork_step=5,
+    )
+    run1_id = run1.settings._op_id
+    for step in range(5):
+        run1.log({'chain/metric': step})
+    run1.finish()
+
+    _poll_metric_names(FORK_PROJECT, run1_id, ['chain/metric'])
+
+    # Second fork (from the first fork)
+    run2 = pluto.init(
+        project=FORK_PROJECT,
+        name=f'fork-chain-2-{int(time.time())}',
+        fork_run_id=run1_id,
+        fork_step=3,
+    )
+    run2_id = run2.settings._op_id
+
+    # Server may resolve lineage — fork_run_id could be run1 or parent
+    assert run2.fork_run_id is not None
+    assert run2.fork_step == 3
+
+    run2.finish()
+
+    server_run = pq.get_run(FORK_PROJECT, run2_id)
+    assert server_run['status'] == 'COMPLETED'

--- a/tests/test_fork_e2e.py
+++ b/tests/test_fork_e2e.py
@@ -55,6 +55,26 @@ def _poll_metric_names(
     )
 
 
+def _poll_max_step(
+    project: str,
+    run_id: int,
+    expected_step: int,
+    metric: str = 'train/loss',
+    timeout: float = 60,
+) -> None:
+    """Poll until ClickHouse has ingested metrics up to *expected_step*."""
+
+    def _check() -> int:
+        metrics = pq.get_metrics(project, run_id, metric_names=[metric])
+        if hasattr(metrics, 'to_dict'):
+            steps = metrics['step'].tolist()
+        else:
+            steps = [m['step'] for m in metrics]
+        return max(steps) if steps else -1
+
+    _poll(fn=_check, check=lambda s: s >= expected_step, timeout=timeout)
+
+
 # ---------------------------------------------------------------------------
 # Module-scoped parent run (created once, shared by all fork tests)
 # ---------------------------------------------------------------------------
@@ -82,8 +102,8 @@ def parent_run() -> Dict:
         run.log({'train/loss': 1.0 - step * 0.1, 'train/acc': step * 0.1})
     run.finish()
 
-    # Wait for metrics to be ingested so the server can validate forkStep
-    _poll_metric_names(FORK_PROJECT, run_id, ['train/loss', 'train/acc'])
+    # Wait for ClickHouse to ingest all steps so forkStep validation passes
+    _poll_max_step(FORK_PROJECT, run_id, _PARENT_STEPS - 1)
 
     return {
         'run_id': run_id,
@@ -271,7 +291,7 @@ def test_fork_e2e_chain_fork(parent_run):
         run1.log({'chain/metric': step})
     run1.finish()
 
-    _poll_metric_names(FORK_PROJECT, run1_id, ['chain/metric'])
+    _poll_max_step(FORK_PROJECT, run1_id, 4, metric='chain/metric')
 
     # Second fork (from the first fork)
     run2 = pluto.init(


### PR DESCRIPTION
## Summary
- Adds `fork_run_id`, `fork_step`, `inherit_config`, and `inherit_tags` parameters to `pluto.init()` for forking runs from the Python SDK
- Fork parameters are conditionally included in the `POST /api/runs/create` payload (omitted when `None`)
- Stores server-resolved `forkedFromRunId` and `forkStep` from the response, exposed as `run.fork_run_id` and `run.fork_step` properties
- Validates that `fork_run_id` and `fork_step` must be provided together

Corresponds to server-side support in

### Usage
```python
run = pluto.init(
    project="my-project",
    name="lr-tuned",
    fork_run_id=12345,
    fork_step=500,
    inherit_config=True,
    inherit_tags=False,
    config={"lr": 0.01},
)
print(run.fork_run_id, run.fork_step)
```

### Files changed
- `pluto/sets.py` — Fork settings fields
- `pluto/init.py` — New parameters + validation
- `pluto/api.py` — Conditional fork fields in start payload
- `pluto/op.py` — Store fork metadata from response + properties
- `tests/test_basic.py` — 5 unit tests (validation, payload, defaults)

## Test plan
- [x] `poetry run pytest tests/test_basic.py -k fork` — all 5 pass
- [x] `ruff check` — clean
- [x] `mypy` — clean
- [ ] E2E test against server with fork support (once server-private#312 is deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)