### PR TITLE
Add preview warning for run forking API

### DIFF
--- a/pluto/init.py
+++ b/pluto/init.py
@@ -183,7 +183,10 @@ def init(
 
     # Set fork parameters on settings
     if fork_run_id is not None:
-        logger.info('Run forking is currently in preview. The API may change in future releases.')
+        logger.info(
+            'Run forking is currently in preview.'
+            ' The API may change in future releases.'
+        )
         settings._fork_run_id = _resolve_fork_run_id(fork_run_id, settings.project)
         settings._fork_step = fork_step
     if inherit_config is not None:

--- a/pluto/init.py
+++ b/pluto/init.py
@@ -183,6 +183,7 @@ def init(
 
     # Set fork parameters on settings
     if fork_run_id is not None:
+        logger.info('Run forking is currently in preview. The API may change in future releases.')
         settings._fork_run_id = _resolve_fork_run_id(fork_run_id, settings.project)
         settings._fork_step = fork_step
     if inherit_config is not None:


### PR DESCRIPTION
Log an info message when fork_run_id is provided to pluto.init(), notifying users that run forking is currently in preview and the API may change in future releases.

https://claude.ai/code/session_015r7SgHp4Nd8SUfgSYZ2wv9

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)