### PR TITLE
Accept display IDs in query methods that take a run ID

### DIFF
--- a/pluto/query.py
+++ b/pluto/query.py
@@ -198,7 +198,7 @@ class Client:
     def get_metrics(
         self,
         project: str,
-        run_id: int,
+        run_id: Union[int, str],
         metric_names: Optional[List[str]] = None,
         limit: int = 10000,
     ) -> Any:
@@ -213,7 +213,8 @@ class Client:
 
         Args:
             project: Project name.
-            run_id: Numeric server ID.
+            run_id: Numeric server ID (``int``) or display ID string
+                (e.g. ``"MMP-1"``).
             metric_names: Metric names to fetch. ``None`` fetches all.
             limit: Max data points per metric (max 10 000).
 
@@ -221,7 +222,7 @@ class Client:
             ``pandas.DataFrame`` or ``list[dict]``.
         """
         params: Dict[str, Any] = {
-            'runId': run_id,
+            'runId': self._resolve_run_id(project, run_id),
             'projectName': project,
             'limit': min(limit, 10000),
         }
@@ -253,7 +254,7 @@ class Client:
     def get_statistics(
         self,
         project: str,
-        run_id: int,
+        run_id: Union[int, str],
         metric_names: Optional[List[str]] = None,
     ) -> Any:
         """Compute statistics for run metrics.
@@ -263,13 +264,17 @@ class Client:
 
         Args:
             project: Project name.
-            run_id: Numeric server ID.
+            run_id: Numeric server ID (``int``) or display ID string
+                (e.g. ``"MMP-1"``).
             metric_names: Restrict to these metrics.
 
         Returns:
             Server response dict.
         """
-        params: Dict[str, Any] = {'runId': run_id, 'projectName': project}
+        params: Dict[str, Any] = {
+            'runId': self._resolve_run_id(project, run_id),
+            'projectName': project,
+        }
         if metric_names is not None and len(metric_names) == 1:
             params['logName'] = metric_names[0]
         return self._get('/api/runs/statistics', params=params)
@@ -277,21 +282,23 @@ class Client:
     def compare_runs(
         self,
         project: str,
-        run_ids: List[int],
+        run_ids: List[Union[int, str]],
         metric_name: str,
     ) -> Dict[str, Any]:
         """Compare a metric across multiple runs.
 
         Args:
             project: Project name.
-            run_ids: List of numeric run IDs (max 100).
+            run_ids: List of run IDs (max 100). Each entry may be a numeric
+                server ID or a display ID string (e.g. ``"MMP-1"``).
             metric_name: The metric to compare.
 
         Returns:
             Dict with per-run statistics and a ``bestRun`` recommendation.
         """
+        resolved = [self._resolve_run_id(project, r) for r in run_ids[:100]]
         params: Dict[str, Any] = {
-            'runIds': ','.join(str(r) for r in run_ids[:100]),
+            'runIds': ','.join(str(r) for r in resolved),
             'projectName': project,
             'logName': metric_name,
         }
@@ -337,21 +344,25 @@ class Client:
     def get_files(
         self,
         project: str,
-        run_id: int,
+        run_id: Union[int, str],
         file_name: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Get file metadata with presigned download URLs.
 
         Args:
             project: Project name.
-            run_id: Numeric server ID.
+            run_id: Numeric server ID (``int``) or display ID string
+                (e.g. ``"MMP-1"``).
             file_name: Filter by log name / file name.
 
         Returns:
             List of file dicts with keys: ``fileName``, ``fileType``,
             ``fileSize``, ``step``, ``time``, ``downloadUrl``.
         """
-        params: Dict[str, Any] = {'runId': run_id, 'projectName': project}
+        params: Dict[str, Any] = {
+            'runId': self._resolve_run_id(project, run_id),
+            'projectName': project,
+        }
         if file_name is not None:
             params['logName'] = file_name
         return self._get('/api/runs/files', params=params)['files']
@@ -359,7 +370,7 @@ class Client:
     def download_file(
         self,
         project: str,
-        run_id: int,
+        run_id: Union[int, str],
         file_name: str,
         destination: Union[str, Path] = '.',
     ) -> Path:
@@ -367,7 +378,8 @@ class Client:
 
         Args:
             project: Project name.
-            run_id: Numeric server ID.
+            run_id: Numeric server ID (``int``) or display ID string
+                (e.g. ``"MMP-1"``).
             file_name: Log name of the file to download.
             destination: Directory or file path.
 
@@ -403,7 +415,7 @@ class Client:
     def get_logs(
         self,
         project: str,
-        run_id: int,
+        run_id: Union[int, str],
         log_type: Optional[str] = None,
         limit: int = 10000,
         offset: int = 0,
@@ -412,7 +424,8 @@ class Client:
 
         Args:
             project: Project name.
-            run_id: Numeric server ID.
+            run_id: Numeric server ID (``int``) or display ID string
+                (e.g. ``"MMP-1"``).
             log_type: Filter by type: ``"info"``, ``"error"``, ``"warning"``,
                 ``"debug"``, ``"print"``.
             limit: Max lines (max 10 000).
@@ -423,7 +436,7 @@ class Client:
             ``lineNumber``, ``step``.
         """
         params: Dict[str, Any] = {
-            'runId': run_id,
+            'runId': self._resolve_run_id(project, run_id),
             'projectName': project,
             'limit': min(limit, 10000),
             'offset': offset,
@@ -433,8 +446,21 @@ class Client:
         return self._get('/api/runs/logs', params=params)['logs']
 
     # ------------------------------------------------------------------
-    # Internal HTTP helpers
+    # Internal helpers
     # ------------------------------------------------------------------
+
+    def _resolve_run_id(self, project: str, run_id: Union[int, str]) -> int:
+        """Resolve a run ID argument to a numeric server ID.
+
+        Accepts an ``int`` (returned as-is) or a display ID string like
+        ``"MMP-1"`` (looked up via :meth:`get_run`). Numeric strings are
+        treated as server IDs.
+        """
+        if isinstance(run_id, int):
+            return run_id
+        if isinstance(run_id, str) and run_id.isdigit():
+            return int(run_id)
+        return int(self.get_run(project, run_id)['id'])
 
     def _get(
         self,
@@ -545,7 +571,7 @@ def get_metric_names(
 
 def get_metrics(
     project: str,
-    run_id: int,
+    run_id: Union[int, str],
     metric_names: Optional[List[str]] = None,
     limit: int = 10000,
 ) -> Any:
@@ -560,7 +586,7 @@ def get_metrics(
 
 def get_statistics(
     project: str,
-    run_id: int,
+    run_id: Union[int, str],
     metric_names: Optional[List[str]] = None,
 ) -> Any:
     """Compute metric statistics. See :meth:`Client.get_statistics`."""
@@ -569,7 +595,7 @@ def get_statistics(
 
 def compare_runs(
     project: str,
-    run_ids: List[int],
+    run_ids: List[Union[int, str]],
     metric_name: str,
 ) -> Dict[str, Any]:
     """Compare runs by metric. See :meth:`Client.compare_runs`."""
@@ -597,7 +623,7 @@ def leaderboard(
 
 def get_files(
     project: str,
-    run_id: int,
+    run_id: Union[int, str],
     file_name: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Get file metadata. See :meth:`Client.get_files`."""
@@ -606,7 +632,7 @@ def get_files(
 
 def download_file(
     project: str,
-    run_id: int,
+    run_id: Union[int, str],
     file_name: str,
     destination: Union[str, Path] = '.',
 ) -> Path:
@@ -616,7 +642,7 @@ def download_file(
 
 def get_logs(
     project: str,
-    run_id: int,
+    run_id: Union[int, str],
     log_type: Optional[str] = None,
     limit: int = 10000,
     offset: int = 0,

--- a/pluto/query.py
+++ b/pluto/query.py
@@ -296,7 +296,12 @@ class Client:
         Returns:
             Dict with per-run statistics and a ``bestRun`` recommendation.
         """
-        resolved = [self._resolve_run_id(project, r) for r in run_ids[:100]]
+        cache: Dict[Union[int, str], int] = {}
+        resolved: List[int] = []
+        for r in run_ids[:100]:
+            if r not in cache:
+                cache[r] = self._resolve_run_id(project, r)
+            resolved.append(cache[r])
         params: Dict[str, Any] = {
             'runIds': ','.join(str(r) for r in resolved),
             'projectName': project,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -306,6 +306,27 @@ class TestGetMetrics:
         except ImportError:
             assert result == []
 
+    def test_display_id_resolves_to_numeric(self, client, mock_response):
+        client._client.get.side_effect = [
+            mock_response(200, {'id': 99, 'displayId': 'MMP-1'}),
+            mock_response(200, {'metrics': []}),
+        ]
+        client.get_metrics('proj', 'MMP-1', metric_names=['loss'])
+        # First call: get_run by display ID
+        first_url = client._client.get.call_args_list[0][0][0]
+        assert 'by-display-id/MMP-1' in first_url
+        # Second call: /api/runs/metrics with resolved numeric ID
+        second_params = client._client.get.call_args_list[1][1]['params']
+        assert second_params['runId'] == 99
+
+    def test_numeric_string_is_treated_as_server_id(self, client, mock_response):
+        client._client.get.return_value = mock_response(200, {'metrics': []})
+        client.get_metrics('proj', '42')
+        # Only one call — no get_run lookup for numeric strings
+        assert client._client.get.call_count == 1
+        params = client._client.get.call_args[1]['params']
+        assert params['runId'] == 42
+
 
 # ---------------------------------------------------------------------------
 # get_statistics
@@ -333,6 +354,15 @@ class TestCompareRuns:
         params = client._client.get.call_args[1]['params']
         assert params['runIds'] == '1,2,3'
         assert params['logName'] == 'loss'
+
+    def test_mixed_display_and_numeric_ids(self, client, mock_response):
+        client._client.get.side_effect = [
+            mock_response(200, {'id': 7, 'displayId': 'MMP-1'}),
+            mock_response(200, {'runs': [], 'bestRun': None}),
+        ]
+        client.compare_runs('proj', [1, 'MMP-1'], 'loss')
+        params = client._client.get.call_args_list[-1][1]['params']
+        assert params['runIds'] == '1,7'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -364,6 +364,18 @@ class TestCompareRuns:
         params = client._client.get.call_args_list[-1][1]['params']
         assert params['runIds'] == '1,7'
 
+    def test_duplicate_display_ids_resolved_once(self, client, mock_response):
+        client._client.get.side_effect = [
+            mock_response(200, {'id': 7, 'displayId': 'MMP-1'}),
+            mock_response(200, {'id': 9, 'displayId': 'MMP-2'}),
+            mock_response(200, {'runs': [], 'bestRun': None}),
+        ]
+        client.compare_runs('proj', ['MMP-1', 'MMP-2', 'MMP-1', 'MMP-2'], 'loss')
+        # 2 get_run lookups + 1 compare = 3 calls (not 5)
+        assert client._client.get.call_count == 3
+        params = client._client.get.call_args_list[-1][1]['params']
+        assert params['runIds'] == '7,9,7,9'
+
 
 # ---------------------------------------------------------------------------
 # leaderboard


### PR DESCRIPTION
Previously only get_run() accepted display IDs like "MMP-1"; the rest of the query API required a numeric server ID, forcing callers to look it up first. Add a _resolve_run_id() helper that transparently resolves display IDs via get_run(), and widen get_metrics, get_statistics, get_files, download_file, get_logs, and compare_runs to Union[int, str].

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)