### PR TITLE
Add Op.close() — release resources without marking run complete

### DIFF
--- a/pluto/op.py
+++ b/pluto/op.py
@@ -641,14 +641,64 @@ class Op:
             )
 
     def finish(self, code: Union[int, None] = None) -> None:
-        """Finish logging"""
-        # Make finish() idempotent - can be called multiple times safely
-        # (e.g., from atexit and explicit finish() call)
+        """Finish logging and mark the run as a terminal status on the server.
+
+        Flushes pending metrics, tears down local resources, and calls
+        ``update_status`` on the server so the run transitions out of the
+        active state. Idempotent and registered via ``atexit`` in
+        ``__init__``.
+
+        Callers attaching to an already-active run from a short-lived process
+        (e.g., writing eval metrics to an ongoing training run) should prefer
+        :meth:`close`, which performs the same local teardown without
+        changing the server-side run status.
+        """
         with self._finish_lock:
             if self._finished:
                 return
             self._finished = True
 
+        self._teardown(code, update_status=True)
+
+    def close(self, code: Union[int, None] = None) -> None:
+        """Release local resources without changing the server-side run status.
+
+        Performs the same local cleanup as :meth:`finish` (stops the monitor,
+        drains the sync manager, closes HTTP clients) but does **not** call
+        ``update_status`` on the server — the run stays in its current state
+        (typically "running") rather than being marked as a terminal status.
+
+        Also unregisters the ``atexit``-registered ``finish`` hook so
+        interpreter shutdown won't implicitly mark the run complete after
+        the caller has released the op.
+
+        Useful when a short-lived process resumes an active run just to
+        append data (e.g., an eval job writing metrics to an ongoing
+        training run) and must not interfere with its lifecycle.
+        Idempotent.
+        """
+        with self._finish_lock:
+            if self._finished:
+                return
+            self._finished = True
+
+        # Prevent the atexit-registered finish() from marking the run complete
+        # on interpreter shutdown after the caller has released this op.
+        try:
+            atexit.unregister(self.finish)
+        except Exception:
+            pass
+
+        self._teardown(code, update_status=False)
+
+    def _teardown(self, code: Union[int, None], update_status: bool) -> None:
+        """Shared teardown used by :meth:`finish` and :meth:`close`.
+
+        When ``update_status`` is True, notifies the server that the run has
+        reached a terminal state (and marks it FAILED if teardown itself
+        raises). When False, the run's server-side status is left untouched
+        and local errors are merely logged.
+        """
         # In DDP/distributed, don't block waiting for sync - it causes deadlocks
         # because all ranks must progress together for collective operations
         is_distributed = _is_distributed_environment()
@@ -684,8 +734,8 @@ class Op:
                 self._sync_manager.close()
                 self._sync_manager = None
 
-            # Update run status on server
-            if self._iface:
+            # Update run status on server (only when finishing)
+            if update_status and self._iface:
                 self._iface.update_status()
 
             # Clean up data store if used (legacy mode)
@@ -696,32 +746,36 @@ class Op:
             if self._iface:
                 self._iface.close()
 
-            # Print URL where users can view the completed run
-            logger.info(f'{tag}: View run at {print_url(self.settings.url_view)}')
+            if update_status:
+                # Print URL where users can view the completed run
+                logger.info(f'{tag}: View run at {print_url(self.settings.url_view)}')
+            else:
+                logger.debug(f'{tag}: closed (run status unchanged)')
         except (Exception, KeyboardInterrupt) as e:
             _sentry.capture_exception(e)
-            self.settings._op_status = signal.SIGINT.value
-            if self._iface:
-                self._iface._update_status(
-                    self.settings,
-                    trace={
-                        'type': e.__class__.__name__,
-                        'message': str(e),
-                        'frames': [
-                            {
-                                'filename': frame.filename,
-                                'lineno': frame.lineno,
-                                'name': frame.name,
-                                'line': frame.line,
-                            }
-                            for frame in traceback.extract_tb(e.__traceback__)
-                        ],
-                        'trace': traceback.format_exc(),
-                    },
-                )
+            if update_status:
+                self.settings._op_status = signal.SIGINT.value
+                if self._iface:
+                    self._iface._update_status(
+                        self.settings,
+                        trace={
+                            'type': e.__class__.__name__,
+                            'message': str(e),
+                            'frames': [
+                                {
+                                    'filename': frame.filename,
+                                    'lineno': frame.lineno,
+                                    'name': frame.name,
+                                    'line': frame.line,
+                                }
+                                for frame in traceback.extract_tb(e.__traceback__)
+                            ],
+                            'trace': traceback.format_exc(),
+                        },
+                    )
             logger.critical('%s: interrupted %s', tag, e)
         _sentry.flush()
-        logger.debug(f'{tag}: finished')
+        logger.debug(f'{tag}: finished' if update_status else f'{tag}: closed')
         teardown_logger(logger, console=logging.getLogger('console'))
 
         self.settings.meta = []

--- a/pluto/op.py
+++ b/pluto/op.py
@@ -682,13 +682,6 @@ class Op:
                 return
             self._finished = True
 
-        # Prevent the atexit-registered finish() from marking the run complete
-        # on interpreter shutdown after the caller has released this op.
-        try:
-            atexit.unregister(self.finish)
-        except Exception:
-            pass
-
         self._teardown(code, update_status=False)
 
     def _teardown(self, code: Union[int, None], update_status: bool) -> None:
@@ -699,6 +692,16 @@ class Op:
         raises). When False, the run's server-side status is left untouched
         and local errors are merely logged.
         """
+        # Once teardown is underway, the atexit-registered finish() is no
+        # longer needed. Unregistering here centralises the cleanup so both
+        # finish() and close() self-unregister; it also prevents the atexit
+        # hook from firing an idempotent (but wasteful) second finish() at
+        # interpreter shutdown after close() has already detached the op.
+        try:
+            atexit.unregister(self.finish)
+        except Exception:
+            pass
+
         # In DDP/distributed, don't block waiting for sync - it causes deadlocks
         # because all ranks must progress together for collective operations
         is_distributed = _is_distributed_environment()

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -787,21 +787,18 @@ class TestClose:
     def test_close_unregisters_atexit_hook(self):
         """close() must unregister the atexit-registered finish() so interpreter
         shutdown doesn't implicitly mark the run complete."""
-        import atexit
-
         op = self._make_op()
-        # Verify the hook is registered before close()
-        # (can't assert directly on atexit state portably, so we verify via
-        # unregister return, which is no-op-safe)
-        op.close()
-        # A second unregister call returns silently on 3.x — we assert that
-        # status was not updated by the close path, and that finish() having
-        # been unregistered means we don't double-call it.
-        op._iface.update_status.assert_not_called()
-        # Calling atexit.unregister again must be a no-op — this asserts that
-        # close() already removed the handler (otherwise we'd see a second
-        # handler fire during interpreter shutdown).
-        atexit.unregister(op.finish)  # no-op; just verifies no exception
+        with patch('atexit.unregister') as mock_unregister:
+            op.close()
+            mock_unregister.assert_called_with(op.finish)
+
+    def test_finish_unregisters_atexit_hook(self):
+        """finish() also self-unregisters so the atexit hook doesn't fire a
+        redundant (idempotent) second call at interpreter shutdown."""
+        op = self._make_op()
+        with patch('atexit.unregister') as mock_unregister:
+            op.finish()
+            mock_unregister.assert_called_with(op.finish)
 
     def test_close_thread_safe(self):
         """Concurrent close() calls must only tear down once."""

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -664,12 +664,12 @@ class TestHttpxLoggingSuppression:
             crumbs = events[0].get('breadcrumbs', {}).get('values', [])
             trigger_crumbs = [b for b in crumbs if 'trigger' in str(b)]
 
-            assert (
-                len(trigger_crumbs) == 0
-            ), f'{len(trigger_crumbs)} trigger breadcrumbs leaked to Sentry'
-            assert (
-                logging.getLogger('httpx').level < logging.WARNING
-            ), 'httpx logger level was not restored after _try()'
+            assert len(trigger_crumbs) == 0, (
+                f'{len(trigger_crumbs)} trigger breadcrumbs leaked to Sentry'
+            )
+            assert logging.getLogger('httpx').level < logging.WARNING, (
+                'httpx logger level was not restored after _try()'
+            )
         finally:
             srv.shutdown()
             client.close()
@@ -727,6 +727,102 @@ class TestFinishIdempotency:
 
         # Monitor.stop should only be called once
         assert finish_count['count'] == 1
+
+
+class TestClose:
+    """Test that Op.close() releases local resources without marking the run complete."""
+
+    def _make_op(self):
+        from pluto.op import Op
+        from pluto.sets import Settings
+
+        settings = Settings()
+        settings.mode = 'noop'  # disables network iface during start()
+        op = Op(config={}, settings=settings)
+        op.start()
+        # Inject a mock iface AFTER start() — noop mode leaves _iface as None,
+        # which would hide the update_status assertion. Injecting before start()
+        # breaks start() because it expects a real _sys accessor.
+        op._iface = MagicMock()
+        return op
+
+    def test_close_does_not_update_status(self):
+        """close() must NOT call update_status() on the server interface."""
+        op = self._make_op()
+        op.close()
+        op._iface.update_status.assert_not_called()
+        assert op._finished is True
+
+    def test_finish_still_updates_status(self):
+        """finish() must still call update_status() (regression guard)."""
+        op = self._make_op()
+        op.finish()
+        op._iface.update_status.assert_called_once()
+        assert op._finished is True
+
+    def test_close_is_idempotent(self):
+        """Second close() call is a no-op — no duplicate teardown."""
+        op = self._make_op()
+        original_monitor_stop = op._monitor.stop
+        call_count = {'n': 0}
+
+        def counting_stop(code=None):
+            call_count['n'] += 1
+            return original_monitor_stop(code)
+
+        op._monitor.stop = counting_stop
+
+        op.close()
+        op.close()  # second call must be a no-op
+        assert call_count['n'] == 1
+
+    def test_close_blocks_subsequent_finish(self):
+        """After close(), a later finish() call must not update status."""
+        op = self._make_op()
+        op.close()
+        op._iface.update_status.reset_mock()
+        op.finish()  # should early-return via _finished flag
+        op._iface.update_status.assert_not_called()
+
+    def test_close_unregisters_atexit_hook(self):
+        """close() must unregister the atexit-registered finish() so interpreter
+        shutdown doesn't implicitly mark the run complete."""
+        import atexit
+
+        op = self._make_op()
+        # Verify the hook is registered before close()
+        # (can't assert directly on atexit state portably, so we verify via
+        # unregister return, which is no-op-safe)
+        op.close()
+        # A second unregister call returns silently on 3.x — we assert that
+        # status was not updated by the close path, and that finish() having
+        # been unregistered means we don't double-call it.
+        op._iface.update_status.assert_not_called()
+        # Calling atexit.unregister again must be a no-op — this asserts that
+        # close() already removed the handler (otherwise we'd see a second
+        # handler fire during interpreter shutdown).
+        atexit.unregister(op.finish)  # no-op; just verifies no exception
+
+    def test_close_thread_safe(self):
+        """Concurrent close() calls must only tear down once."""
+        op = self._make_op()
+        call_count = {'n': 0}
+        original_monitor_stop = op._monitor.stop
+
+        def counting_stop(code=None):
+            call_count['n'] += 1
+            return original_monitor_stop(code)
+
+        op._monitor.stop = counting_stop
+
+        threads = [threading.Thread(target=op.close) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert call_count['n'] == 1
+        op._iface.update_status.assert_not_called()
 
 
 # Helper scripts used by integration tests below.  Spawned as subprocesses
@@ -934,9 +1030,9 @@ class TestSignalTerminationIntegration:
             start = time.monotonic()
             proc.wait(timeout=self._DEADLINE)
             elapsed = time.monotonic() - start
-            assert (
-                elapsed < self._DEADLINE
-            ), f'Process took {elapsed:.1f}s to exit after SIGTERM'
+            assert elapsed < self._DEADLINE, (
+                f'Process took {elapsed:.1f}s to exit after SIGTERM'
+            )
             # Default SIGTERM kills with negative signal code
             assert proc.returncode == -signal.SIGTERM
         finally:
@@ -953,9 +1049,9 @@ class TestSignalTerminationIntegration:
             start = time.monotonic()
             proc.wait(timeout=self._DEADLINE)
             elapsed = time.monotonic() - start
-            assert (
-                elapsed < self._DEADLINE
-            ), f'Process took {elapsed:.1f}s to exit after SIGINT'
+            assert elapsed < self._DEADLINE, (
+                f'Process took {elapsed:.1f}s to exit after SIGINT'
+            )
         finally:
             if proc.poll() is None:
                 proc.kill()


### PR DESCRIPTION
## Summary

Add a new \`Op.close()\` method that performs the same local teardown as \`finish()\` (stops the monitor, drains the sync manager, closes HTTP clients) but does **not** call \`update_status\` on the server — the run stays in its current state rather than transitioning to a terminal one. \`close()\` also unregisters the \`atexit\`-registered \`finish()\` hook.

## Motivation

Currently \`Op.finish()\` is the only teardown path, and it couples two concerns:

1. Releasing local resources (monitor thread, sync manager, HTTP clients).
2. Updating the run status on the server so it transitions out of the active state.

\`Op.__init__\` also registers \`finish()\` as an \`atexit\` hook, so concern (2) fires on **any** interpreter shutdown — even if the caller never calls \`finish()\` explicitly.

That makes it impossible for a short-lived process to attach to an active run (via \`pluto.init(resume=True)\`) just to append data. In practice this breaks flows like:

- An evaluation job writing metrics to an ongoing training run.
- A side process uploading artifacts while the main run is still producing data elsewhere.

In those cases, even a guarded \`if training_finished: run.finish()\` at the caller level doesn't prevent the active run from being flagged complete, because the \`atexit\` hook fires \`finish()\` unconditionally at process exit.

## API

\`\`\`python
run = pluto.init(project=..., run_id=..., resume=True)
run.log({...})
run.close()  # releases local resources; run stays in its current state on the server
\`\`\`

- \`finish()\`: unchanged externally. Still registered via \`atexit\` in \`__init__\`. Still marks the run complete on the server.
- \`close()\`: new. Local teardown only, no status update, unregisters the \`atexit\` hook. Idempotent.

Both delegate to a shared private \`_teardown(code, update_status)\` helper so there is no code duplication; the status-update branch (including the FAILED status path on exception) is gated on \`update_status=True\`.

## Test plan

- [x] Added \`TestClose\` in \`tests/test_shutdown.py\` with 6 tests:
  - \`test_close_does_not_update_status\` — \`close()\` must not call \`update_status\`
  - \`test_finish_still_updates_status\` — regression guard for \`finish()\`
  - \`test_close_is_idempotent\` — second \`close()\` call is a no-op
  - \`test_close_blocks_subsequent_finish\` — \`finish()\` after \`close()\` is a no-op (via \`_finished\` flag)
  - \`test_close_unregisters_atexit_hook\` — hook is removed so interpreter shutdown doesn't mark the run complete
  - \`test_close_thread_safe\` — concurrent \`close()\` calls only tear down once
- [x] All 6 new tests pass.
- [x] All 21 existing \`test_run_status.py\` tests still pass.
- [x] All adjacent \`test_shutdown.py\` tests pass (one pre-existing Sentry-breadcrumb failure is unrelated and reproduces on \`main\`).