### PR TITLE
fix(compat/neptune): leave pluto alive on close/__exit__

### DIFF
--- a/pluto/compat/neptune.py
+++ b/pluto/compat/neptune.py
@@ -708,10 +708,19 @@ class NeptuneRunWrapper:
 
     def close(self, **kwargs):
         """
-        Close both Neptune and pluto runs.
+        Close the Neptune run. Pluto is left running.
 
-        Pluto cleanup uses a timeout to ensure it never blocks Neptune's close.
-        Neptune's close() is always called, preserving exact Neptune behavior.
+        Some Neptune callers — notably Lightning's ``NeptuneLogger.finalize`` —
+        invoke ``close()`` from inside Trainer's exception path (e.g. on a CUDA
+        OOM). Tearing pluto down here would lose any output emitted during
+        framework cleanup, including the traceback that triggered finalize in
+        the first place. We instead leave the pluto run alive; it is finalised
+        by:
+            * ``terminate()`` — explicit force-quit by the caller
+            * ``_atexit_cleanup_pluto`` — interpreter shutdown (with timeout)
+        ``sys.excepthook`` (registered in ``Op.__init__``) marks the run
+        FAILED before atexit fires when an exception propagates, so the
+        eventual status is correct without the close path doing it.
         """
         with self._close_lock:
             if self._closed:
@@ -721,8 +730,7 @@ class NeptuneRunWrapper:
                 return None
             self._closed = True
 
-        # Close pluto first with timeout (non-blocking, silent failure)
-        self._finish_pluto_with_timeout(timeout=self._PLUTO_CLEANUP_TIMEOUT_SECONDS)
+        # Deliberately do NOT touch pluto here — see docstring.
 
         # Close Neptune (unless disabled) - this is the critical path
         if not self._neptune_disabled:
@@ -877,14 +885,13 @@ class NeptuneRunWrapper:
         """
         Support context manager protocol.
 
-        Pluto cleanup uses a timeout to ensure it never blocks Neptune's __exit__.
-        Neptune's __exit__ is always called, preserving exact Neptune behavior.
+        Same rationale as :meth:`close`: pluto is left alive and finalised
+        via the atexit/excepthook path, not here.
         """
         with self._close_lock:
             self._closed = True
 
-        # Finish pluto with timeout (non-blocking, silent failure)
-        self._finish_pluto_with_timeout(timeout=self._PLUTO_CLEANUP_TIMEOUT_SECONDS)
+        # Deliberately do NOT touch pluto here — see close() docstring.
 
         if self._neptune_disabled:
             return False

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -29,11 +29,12 @@ TESTING_PROJECT_NAME = 'testing-ci'
 HAS_TORCH = importlib.util.find_spec('torch') is not None
 
 # Max seconds to wait for data to appear on the server after finish().
-# 30s absorbs occasional server-side propagation lag for config/tag updates
-# seen on GH Actions (CI run 25195677398: lifecycle test still saw lr=0.001
-# after 15s polling). Successful polls exit on first check match, so this
-# only affects worst-case latency, not happy-path test runtime.
-_POLL_TIMEOUT = 30
+# 60s is large enough to absorb tail-latency on the server's config/tag
+# update propagation seen on GH Actions: CI run 25195677398 hit the limit
+# at 15s; CI run 25196590153 hit it again at 30s. Successful polls exit
+# on first check match, so this only widens the worst-case window —
+# happy-path test runtime is unchanged.
+_POLL_TIMEOUT = 60
 _POLL_INTERVAL = 2
 
 T = TypeVar('T')

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -29,7 +29,11 @@ TESTING_PROJECT_NAME = 'testing-ci'
 HAS_TORCH = importlib.util.find_spec('torch') is not None
 
 # Max seconds to wait for data to appear on the server after finish().
-_POLL_TIMEOUT = 15
+# 30s absorbs occasional server-side propagation lag for config/tag updates
+# seen on GH Actions (CI run 25195677398: lifecycle test still saw lr=0.001
+# after 15s polling). Successful polls exit on first check match, so this
+# only affects worst-case latency, not happy-path test runtime.
+_POLL_TIMEOUT = 30
 _POLL_INTERVAL = 2
 
 T = TypeVar('T')

--- a/tests/test_neptune_compat.py
+++ b/tests/test_neptune_compat.py
@@ -1317,6 +1317,78 @@ class TestNeptuneCompatCleanup:
             ), f'Pluto finish called {finish_call_count} times, should be 1'
 
 
+class TestPlutoNotReleasedFromCloseOrExit:
+    """close() and __exit__ leave the pluto run alive.
+
+    Some Neptune callers — notably Lightning's NeptuneLogger.finalize —
+    invoke close() from inside Trainer's exception path (e.g. on a CUDA
+    OOM). Tearing pluto down there would lose any output emitted during
+    framework cleanup, including the traceback that triggered finalize.
+    The pluto run is finalised by terminate() or by the atexit handler
+    instead; sys.excepthook (set in Op.__init__) marks status FAILED
+    before atexit runs when an exception propagates.
+    """
+
+    @pytest.fixture
+    def pluto_config_env(self, clean_env):
+        os.environ['PLUTO_PROJECT'] = 'release-test'
+        yield
+
+    def test_close_does_not_finish_pluto(self, mock_neptune_backend, pluto_config_env):
+        mock_pluto_run = mock.MagicMock()
+        mock_pluto_run.config = {}
+        mock_pluto_run.finish = mock.MagicMock()
+
+        with mock.patch('pluto.init', return_value=mock_pluto_run):
+            from neptune_scale import Run
+
+            run = Run(experiment_name='close-noop-test')
+            run.close()
+
+            mock_pluto_run.finish.assert_not_called()
+
+    def test_exit_does_not_finish_pluto(self, mock_neptune_backend, pluto_config_env):
+        mock_pluto_run = mock.MagicMock()
+        mock_pluto_run.config = {}
+        mock_pluto_run.finish = mock.MagicMock()
+
+        with mock.patch('pluto.init', return_value=mock_pluto_run):
+            from neptune_scale import Run
+
+            with Run(experiment_name='exit-noop-test'):
+                pass
+
+            mock_pluto_run.finish.assert_not_called()
+
+    def test_terminate_finishes_pluto(self, mock_neptune_backend, pluto_config_env):
+        """terminate() is the explicit force-quit path and finalises pluto."""
+        mock_pluto_run = mock.MagicMock()
+        mock_pluto_run.config = {}
+        mock_pluto_run.finish = mock.MagicMock()
+
+        with mock.patch('pluto.init', return_value=mock_pluto_run):
+            from neptune_scale import Run
+
+            run = Run(experiment_name='terminate-finish-test')
+            run.terminate()
+
+            mock_pluto_run.finish.assert_called_once()
+
+    def test_atexit_finishes_pluto(self, mock_neptune_backend, pluto_config_env):
+        """The atexit handler is the canonical clean-shutdown path."""
+        mock_pluto_run = mock.MagicMock()
+        mock_pluto_run.config = {}
+        mock_pluto_run.finish = mock.MagicMock()
+
+        with mock.patch('pluto.init', return_value=mock_pluto_run):
+            from neptune_scale import Run
+
+            run = Run(experiment_name='atexit-finish-test')
+            run._atexit_cleanup_pluto()
+
+            mock_pluto_run.finish.assert_called_once()
+
+
 class TestNeptuneSeededRandom:
     """Test that Neptune compat layer isolates random state from user seeding."""
 


### PR DESCRIPTION
## Summary

Lightning's `NeptuneLogger.finalize` invokes `Run.close()` from inside the Trainer exception path (e.g. on CUDA OOM). The previous behavior also finished the pluto run from `close()`, tearing down stdout/stderr capture and the sync process before the framework had finished unwinding — losing the OOM traceback that triggered finalize in the first place, and marking the run **COMPLETED instead of FAILED** because Lightning's status arg was not propagated.

`NeptuneRunWrapper.close()` and `__exit__` are now no-ops for pluto. The run is finalised by:

- `terminate()` — explicit force-quit by the caller
- `_atexit_cleanup_pluto` — interpreter shutdown (5s timeout)

`sys.excepthook` (registered in `Op.__init__`) flips `_op_status` to FAILED before atexit fires when an exception propagates, so the eventual server-side status is correct without `close()` doing it.

Hang-protection via `_finish_pluto_with_timeout` still applies — it just fires from atexit instead of from `close()`.

## Why this matters

Real-world repro from a user training run:

1. ~09:35:18: CUDA OOM in `adam.step()` at training step 6 (right after the first validation)
2. Lightning catches → `_interrupt(exception)` → `logger.finalize(\"failed\")` for each logger
3. The user's custom `NeptuneLogger.finalize` calls `self._run_instance.close()` → `pluto.compat.neptune.close()` → `pluto_run.finish()` (under previous behavior). Sync drains, pluto torn down.
4. Lightning continues unwinding for ~33s — every line written to stdout/stderr (including the formatted traceback) bypasses pluto's now-removed ConsoleHandler and only reaches the container logs.
5. ~09:35:51: traceback finally printed; never reaches the UI. Run shows COMPLETED on the server.

With this PR, step 3 becomes a no-op for pluto. Pluto stays alive through Lightning's unwind, captures the traceback, and the excepthook → atexit path marks the run FAILED.

## Tests

- New `TestPlutoNotReleasedFromCloseOrExit` class (4 tests) documenting the new contract:
  - `close()` does not call `pluto_run.finish()`
  - `__exit__` does not call `pluto_run.finish()`
  - `terminate()` still calls `finish()` (force-quit path)
  - `_atexit_cleanup_pluto` still calls `finish()` (clean-shutdown path)
- These are auto-skipped in CI since `neptune-scale` was removed from dev deps (per existing `pytest.importorskip` at module level), but they document the intent for anyone running with `neptune-scale` installed.
- All existing `test_neptune_compat.py` tests still pass: behavioral asserts that previously verified close-with-timeout are now trivially satisfied (close returns instantly because finish is never called); idempotency and double-cleanup tests still hold (only the atexit path calls finish, which fires once).

## Out of scope

- Lightning's `\"failed\"` status arg passed to `finalize()` is still discarded by the user's NeptuneLogger override. Routing this through to `Op.close(code=...)` / `Op.finish(code=...)` is a separate small followup but isn't required for this PR — the excepthook handles the FAILED case correctly.
- Capturing logs from Python loggers configured before `pluto.init()` (e.g. `httpx`, framework-internal loggers that hold refs to the pre-patch `sys.stdout`) is a separate enhancement.

## Test plan

- [ ] CI passes on this PR
- [ ] Smoke test on staging: re-run the OOM repro config (`val_at_step_5,val_oom_repro,trainer.devices=1,trainer.val_check_interval=5,trainer.max_steps=10`) and verify (a) traceback appears in run logs, (b) run status is FAILED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)