### PR TITLE
Improve wandb-to-pluto project resolution with kwarg fallback

### DIFF
--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -16,9 +16,12 @@ Configuration:
     - PLUTO_API_KEY: Pluto API token (always required). In
       DISABLE_WANDB_LOGGING=true mode, WANDB_API_KEY may be reused
       instead.
-    - A project name: PLUTO_PROJECT if set, otherwise WANDB_PROJECT
-      is used as a fallback. This means if you already have
-      WANDB_PROJECT set for wandb, you don't need to set
+    - A project name: PLUTO_PROJECT if set, otherwise (in order)
+      the `project` kwarg to wandb.init(), the WANDB_PROJECT env
+      var, or the project attribute on the resolved wandb run.
+      This means if you already pass project= to wandb.init() (or
+      via a framework wrapper like Lightning's WandbLogger), or
+      have WANDB_PROJECT set for wandb, you don't need to set
       PLUTO_PROJECT separately.
 
     Optional:
@@ -622,19 +625,26 @@ def _make_patched_init(original_init, wandb_module):
         pluto_config = _get_pluto_config_from_env()
 
         # Project name fallback (works in ALL modes): if PLUTO_PROJECT
-        # isn't set, use WANDB_PROJECT. This makes PLUTO_PROJECT fully
-        # optional — users who already have WANDB_PROJECT from their
-        # existing wandb setup don't have to duplicate it.
+        # isn't set, fall back to (in order): the explicit `project`
+        # kwarg passed to wandb.init(), the `WANDB_PROJECT` env var,
+        # or finally the project attribute on the resolved wandb run.
+        # This makes PLUTO_PROJECT fully optional — frameworks like
+        # Lightning's WandbLogger pass project as a kwarg and may never
+        # set WANDB_PROJECT, so kwargs must be consulted too.
         #
         # If pluto_config is None here, it means PLUTO_PROJECT wasn't set
         # (that's the only reason _get_pluto_config_from_env returns None).
-        # We build a fresh config from WANDB_PROJECT and re-read the
-        # other PLUTO_* env vars (api key, urls) since the helper bailed
-        # before reading them.
+        # We build a fresh config from the resolved project and re-read
+        # the other PLUTO_* env vars (api key, urls) since the helper
+        # bailed before reading them.
         if pluto_config is None:
-            wandb_project = os.environ.get('WANDB_PROJECT')
-            if wandb_project:
-                pluto_config = {'project': wandb_project}
+            resolved_project = (
+                kwargs.get('project')
+                or os.environ.get('WANDB_PROJECT')
+                or getattr(wandb_run, 'project', None)
+            )
+            if resolved_project:
+                pluto_config = {'project': resolved_project}
                 if api_key := os.environ.get('PLUTO_API_KEY'):
                     pluto_config['api_key'] = api_key
                 for env_var, cfg_key in (
@@ -645,8 +655,8 @@ def _make_patched_init(original_init, wandb_module):
                     if v := os.environ.get(env_var):
                         pluto_config[cfg_key] = v
                 logger.info(
-                    'pluto.compat.wandb: using WANDB_PROJECT as Pluto project '
-                    '(PLUTO_PROJECT not set)'
+                    f'pluto.compat.wandb: using "{resolved_project}" as Pluto '
+                    f'project (PLUTO_PROJECT not set)'
                 )
 
         # Migration shortcut (disabled-mode only): in DISABLE_WANDB_LOGGING

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -1,0 +1,166 @@
+"""
+Unit tests for the wandb-to-pluto compatibility shim.
+
+These tests focus on argument-resolution logic in `_make_patched_init`
+without requiring a real wandb install or a real Pluto backend. wandb
+and pluto are both swapped for `MagicMock`s so we can assert on the
+arguments forwarded to `pluto.init`.
+"""
+
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+
+from pluto.compat import wandb as wandb_compat
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Strip any project / api-key env vars that could mask kwarg resolution."""
+    for var in (
+        'PLUTO_PROJECT',
+        'MLOP_PROJECT',
+        'WANDB_PROJECT',
+        'PLUTO_API_KEY',
+        'MLOP_API_KEY',
+        'WANDB_NAME',
+        'WANDB_TAGS',
+        'WANDB_NOTES',
+        'WANDB_RUN_GROUP',
+        'WANDB_JOB_TYPE',
+        'PLUTO_RUN_ID',
+        'DISABLE_WANDB_LOGGING',
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_fake_wandb_run(run_id='wid-1', name='run-1', project=None):
+    """Build a MagicMock that looks like a wandb.Run."""
+    run = MagicMock()
+    run.id = run_id
+    run.name = name
+    run.tags = None
+    run.notes = None
+    run.config = {}
+    run.project = project
+    return run
+
+
+def _invoke_patched_init(wandb_run, fake_pluto, init_kwargs):
+    """
+    Run `_make_patched_init` against mock wandb / pluto modules.
+
+    Returns the kwargs that the shim forwarded to `pluto.init`, or
+    None if pluto.init was never called.
+    """
+    fake_wandb_module = MagicMock()
+    original_init = MagicMock(return_value=wandb_run)
+    patched = wandb_compat._make_patched_init(original_init, fake_wandb_module)
+
+    with mock.patch.object(wandb_compat, '_safe_import_pluto', return_value=fake_pluto):
+        result = patched(**init_kwargs)
+
+    if fake_pluto.init.called:
+        return result, fake_pluto.init.call_args.kwargs
+    return result, None
+
+
+def test_project_kwarg_is_used_when_no_env_vars_set(clean_env):
+    """
+    Lightning's `WandbLogger(project="my-project", ...)` forwards
+    `project=` to wandb.init. With neither PLUTO_PROJECT nor
+    WANDB_PROJECT set, the shim must still pick up the kwarg.
+    """
+    fake_pluto = MagicMock()
+    fake_pluto.init.return_value = MagicMock(id=42)
+    wandb_run = _make_fake_wandb_run()
+
+    _, forwarded = _invoke_patched_init(
+        wandb_run,
+        fake_pluto,
+        {'project': 'my-project', 'entity': 'my-team'},
+    )
+
+    assert forwarded is not None, 'pluto.init should have been called'
+    assert forwarded['project'] == 'my-project'
+
+
+def test_pluto_project_env_takes_precedence_over_kwarg(clean_env, monkeypatch):
+    """PLUTO_PROJECT env var wins over the wandb.init kwarg."""
+    monkeypatch.setenv('PLUTO_PROJECT', 'env-project')
+
+    fake_pluto = MagicMock()
+    fake_pluto.init.return_value = MagicMock(id=42)
+    wandb_run = _make_fake_wandb_run()
+
+    _, forwarded = _invoke_patched_init(
+        wandb_run,
+        fake_pluto,
+        {'project': 'kwarg-project'},
+    )
+
+    assert forwarded['project'] == 'env-project'
+
+
+def test_kwarg_takes_precedence_over_wandb_project_env(clean_env, monkeypatch):
+    """
+    With PLUTO_PROJECT unset, the explicit kwarg should win over
+    WANDB_PROJECT — kwargs are more specific than env-level defaults.
+    """
+    monkeypatch.setenv('WANDB_PROJECT', 'env-wandb-project')
+
+    fake_pluto = MagicMock()
+    fake_pluto.init.return_value = MagicMock(id=42)
+    wandb_run = _make_fake_wandb_run()
+
+    _, forwarded = _invoke_patched_init(
+        wandb_run,
+        fake_pluto,
+        {'project': 'kwarg-project'},
+    )
+
+    assert forwarded['project'] == 'kwarg-project'
+
+
+def test_wandb_project_env_used_when_no_kwarg(clean_env, monkeypatch):
+    """If no project kwarg is given, fall back to WANDB_PROJECT."""
+    monkeypatch.setenv('WANDB_PROJECT', 'env-wandb-project')
+
+    fake_pluto = MagicMock()
+    fake_pluto.init.return_value = MagicMock(id=42)
+    wandb_run = _make_fake_wandb_run()
+
+    _, forwarded = _invoke_patched_init(wandb_run, fake_pluto, {})
+
+    assert forwarded['project'] == 'env-wandb-project'
+
+
+def test_falls_back_to_wandb_run_project_attribute(clean_env):
+    """
+    Final fallback: read `project` from the resolved wandb run object.
+    Some wandb integrations don't pass project explicitly but the
+    underlying Run still ends up with one set.
+    """
+    fake_pluto = MagicMock()
+    fake_pluto.init.return_value = MagicMock(id=42)
+    wandb_run = _make_fake_wandb_run(project='run-attr-project')
+
+    _, forwarded = _invoke_patched_init(wandb_run, fake_pluto, {})
+
+    assert forwarded['project'] == 'run-attr-project'
+
+
+def test_no_project_anywhere_skips_pluto_init(clean_env):
+    """
+    With nothing set — no env var, no kwarg, no run attribute — the
+    shim must not call pluto.init and must return the original wandb
+    run unwrapped (wandb-only mode).
+    """
+    fake_pluto = MagicMock()
+    wandb_run = _make_fake_wandb_run(project=None)
+
+    result, forwarded = _invoke_patched_init(wandb_run, fake_pluto, {})
+
+    assert forwarded is None
+    assert result is wandb_run


### PR DESCRIPTION
## Description

Enhance the wandb compatibility shim to support more flexible project name resolution. Previously, the shim only checked `PLUTO_PROJECT` and `WANDB_PROJECT` environment variables. This change adds support for resolving the project from the `project` kwarg passed to `wandb.init()`, which is important for framework integrations like Lightning's `WandbLogger` that pass project as an explicit argument rather than relying on environment variables.

### Changes

- **Project resolution order**: Now checks in order:
  1. `PLUTO_PROJECT` environment variable (highest priority)
  2. `project` kwarg passed to `wandb.init()`
  3. `WANDB_PROJECT` environment variable
  4. `project` attribute on the resolved wandb run object (fallback)

- **Updated documentation**: Clarified the project resolution logic in the module docstring to reflect the new kwarg support.

- **Improved logging**: Made the log message more informative by showing which project value was actually resolved.

### Testing

Added comprehensive unit tests in `tests/test_wandb_compat.py` covering:
- Project kwarg resolution when no env vars are set
- Environment variable precedence (`PLUTO_PROJECT` > kwarg > `WANDB_PROJECT`)
- Kwarg precedence over `WANDB_PROJECT` env var
- Fallback to `WANDB_PROJECT` when no kwarg provided
- Fallback to wandb run's project attribute
- Graceful handling when no project is found anywhere (wandb-only mode)

All tests use mocks to avoid requiring real wandb or Pluto installations.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] New unit tests for project resolution logic

https://claude.ai/code/session_01Gnrv8wmP8nDvbaZoVfJwAn