### PR TITLE
fix(compat/wandb): activate auto-shim from pluto login, not just env vars

### DIFF
--- a/.github/workflows/pytest-smoke.yml
+++ b/.github/workflows/pytest-smoke.yml
@@ -37,6 +37,9 @@ jobs:
           poetry install --with dev --extras full
           pip install -e ".[dev,full]"
           poetry run pip install pytest-cov
+          # Deploy the wandb auto-activation .pth — poetry-core's editable
+          # install doesn't copy it into site-packages on its own.
+          bash dev-install.sh
           pluto login ${{ secrets.MLOP_API_TOKEN }}
 
       - name: Run pytest smoke tests

--- a/.github/workflows/pytest-smoke.yml
+++ b/.github/workflows/pytest-smoke.yml
@@ -14,6 +14,13 @@ on:
 jobs:
   test:
     strategy:
+      # Run every Python version even if one fails. The smoke tests hit the
+      # production Pluto server and intermittently flake on cold-start /
+      # transient connectivity (ConnectionError, RemoteProtocolError). With
+      # fail-fast: true (the default) one flaky version cancels all others
+      # and forces a re-run that may flake on a different version, costing
+      # multiple cycles to get every version green simultaneously.
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         poetry-version: ["2.1.1"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@ poetry install --with dev --extras full
 # poetry-core's editable install doesn't copy data files, so the wandb
 # import hook never fires in dev without this. Run once after install.
 bash dev-install.sh
+# If you test from a non-poetry env (conda, pyenv, system python), override
+# the target interpreter — e.g. for base conda:
+#   PYTHON=python bash dev-install.sh
 ```
 
 ### Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,11 @@ pip install -e ".[dev,full]"
 
 # Or using poetry
 poetry install --with dev --extras full
+
+# Deploy the wandb auto-activation .pth into site-packages.
+# poetry-core's editable install doesn't copy data files, so the wandb
+# import hook never fires in dev without this. Run once after install.
+bash dev-install.sh
 ```
 
 ### Testing

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -11,7 +11,10 @@
 set -eo pipefail
 
 SRC="$(cd "$(dirname "$0")" && pwd)/zzzz_pluto_wandb_hook.pth"
-SITE=$(poetry run python -c "import site; print(site.getsitepackages()[0])")
+# sysconfig.get_path('purelib') is more reliable than site.getsitepackages()[0]
+# — the latter's first entry isn't guaranteed to be the active install target
+# on all platforms (e.g. user-site or sometimes Windows/conda layouts).
+SITE=$(poetry run python -c "import sysconfig; print(sysconfig.get_path('purelib'))")
 DEST="$SITE/zzzz_pluto_wandb_hook.pth"
 
 ln -sf "$SRC" "$DEST"

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Deploy zzzz_pluto_wandb_hook.pth into the active venv's site-packages.
+# Deploy zzzz_pluto_wandb_hook.pth into a Python env's site-packages.
 #
 # poetry-core's editable install only emits a single pluto_ml.pth pointing
 # at the source dir; it doesn't copy other .pth files declared in
@@ -7,15 +7,23 @@
 # fires in editable installs, so `import wandb` is not patched and dev
 # behavior diverges from production wheels.
 #
-# Run this once after `poetry install`. Safe to re-run; idempotent.
+# Defaults to `poetry run python` so the standard poetry workflow works
+# with no args. Override with PYTHON to target a different interpreter:
+#
+#   bash dev-install.sh                   # poetry venv
+#   PYTHON=python bash dev-install.sh     # currently active env (conda etc.)
+#   PYTHON=/path/to/python bash dev-install.sh
+#
+# Run once per env you test from. Safe to re-run; idempotent.
 set -eo pipefail
 
+PYTHON_CMD="${PYTHON:-poetry run python}"
 SRC="$(cd "$(dirname "$0")" && pwd)/zzzz_pluto_wandb_hook.pth"
 # sysconfig.get_path('purelib') is more reliable than site.getsitepackages()[0]
 # — the latter's first entry isn't guaranteed to be the active install target
 # on all platforms (e.g. user-site or sometimes Windows/conda layouts).
-SITE=$(poetry run python -c "import sysconfig; print(sysconfig.get_path('purelib'))")
+SITE=$($PYTHON_CMD -c "import sysconfig; print(sysconfig.get_path('purelib'))")
 DEST="$SITE/zzzz_pluto_wandb_hook.pth"
 
 ln -sf "$SRC" "$DEST"
-echo "Linked $DEST -> $SRC"
+echo "Linked $DEST -> $SRC (via: $PYTHON_CMD)"

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Deploy zzzz_pluto_wandb_hook.pth into the active venv's site-packages.
+#
+# poetry-core's editable install only emits a single pluto_ml.pth pointing
+# at the source dir; it doesn't copy other .pth files declared in
+# tool.poetry.packages. Without this symlink the wandb-import hook never
+# fires in editable installs, so `import wandb` is not patched and dev
+# behavior diverges from production wheels.
+#
+# Run this once after `poetry install`. Safe to re-run; idempotent.
+set -eo pipefail
+
+SRC="$(cd "$(dirname "$0")" && pwd)/zzzz_pluto_wandb_hook.pth"
+SITE=$(poetry run python -c "import site; print(site.getsitepackages()[0])")
+DEST="$SITE/zzzz_pluto_wandb_hook.pth"
+
+ln -sf "$SRC" "$DEST"
+echo "Linked $DEST -> $SRC"

--- a/pluto/__main__.py
+++ b/pluto/__main__.py
@@ -64,10 +64,25 @@ def _cmd_sync(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    # Build settings dict with URLs
+    # Build settings dict with URLs.
+    # Settings.to_dict() only iterates __annotations__, so the URLs
+    # populated by update_url() (url_num, url_message, url_file, ...) are
+    # NOT included. Without this every uploader call no-ops on
+    # `if not self.url_X: return`, the records get marked SUCCESS in the
+    # local DB, and nothing reaches the server. Restore them explicitly.
     settings = Settings()
     settings.update_host()
     settings_dict = settings.to_dict()
+    settings_dict.update(
+        {
+            'url_num': settings.url_num,
+            'url_data': settings.url_data,
+            'url_file': settings.url_file,
+            'url_message': settings.url_message,
+            'url_update_config': settings.url_update_config,
+            'url_update_tags': settings.url_update_tags,
+        }
+    )
     settings_dict['_auth'] = auth
 
     # Read run info from each database and populate settings

--- a/pluto/_wandb_hook.py
+++ b/pluto/_wandb_hook.py
@@ -35,22 +35,32 @@ _hint_emitted = False
 # Mirrors pluto.auth.LOGIN_MARKER_PATH. Duplicated as a literal here so this
 # module stays import-free of the rest of pluto at .pth load time.
 _LOGIN_MARKER_PATH = os.path.expanduser('~/.pluto/.login_ok')
-# keyrings.alt.file.PlaintextKeyring storage path (Linux/Windows fallback when
-# no system keyring is available). The file is shared across services, so we
-# parse it as INI to confirm a [pluto] section exists. macOS uses Keychain;
-# the marker file above covers macOS and post-upgrade Linux users.
-_KEYRING_CFG_PATH = os.path.expanduser('~/.local/share/python_keyring/keyring_pass.cfg')
+
+
+def _keyring_cfg_path() -> str:
+    """
+    keyrings.alt.file.PlaintextKeyring storage location, mirrored from
+    keyring.util.platform_ so we don't have to import keyring at .pth load
+    time. macOS uses Keychain by default (the marker above covers Mac); this
+    only matters for Linux/Windows users on the file-based fallback.
+    """
+    if sys.platform == 'win32':
+        root = os.environ.get('LOCALAPPDATA') or os.environ.get('ProgramData') or '.'
+        return os.path.join(root, 'Python Keyring', 'keyring_pass.cfg')
+    base = os.environ.get('XDG_DATA_HOME') or os.path.expanduser('~/.local/share')
+    return os.path.join(base, 'python_keyring', 'keyring_pass.cfg')
 
 
 def _keyring_cfg_has_pluto() -> bool:
     """Backward compat: detect a `pluto login` done before the marker existed."""
-    if not os.path.exists(_KEYRING_CFG_PATH):
+    path = _keyring_cfg_path()
+    if not os.path.exists(path):
         return False
     try:
         import configparser
 
         cp = configparser.RawConfigParser()
-        cp.read(_KEYRING_CFG_PATH, encoding='utf-8')
+        cp.read(path, encoding='utf-8')
         return cp.has_section('pluto')
     except Exception:
         return False

--- a/pluto/_wandb_hook.py
+++ b/pluto/_wandb_hook.py
@@ -104,17 +104,24 @@ def _emit_discoverability_hint() -> None:
         return
     _hint_emitted = True
     if _has_partial_pluto_signal():
-        logger.warning(
+        msg = (
             'pluto.compat.wandb: Pluto config detected but no API key found. '
             'Run `pluto login` (or set PLUTO_API_KEY) to enable dual-logging '
             'to Pluto. Continuing with wandb-only logging.'
         )
     else:
-        logger.warning(
+        msg = (
             'pluto.compat.wandb: pluto-ml is installed but no Pluto credentials '
             'found. Run `pluto login` (or set PLUTO_API_KEY) to enable '
             'dual-logging to Pluto. Continuing with wandb-only logging.'
         )
+    # logger.warning lets structured-logging consumers (Sentry etc.) capture it,
+    # but the hint also goes through plain stderr so it's never lost to a
+    # misconfigured logging setup or a test framework that intercepts the
+    # logging stream (Python 3.12 was observed to drop the logger output in
+    # subprocess-pytest contexts on CI).
+    logger.warning(msg)
+    print(msg, file=sys.stderr, flush=True)
 
 
 class _PlutoWandbFinder:

--- a/pluto/_wandb_hook.py
+++ b/pluto/_wandb_hook.py
@@ -1,30 +1,110 @@
 """
 Import hook that intercepts `import wandb` to enable dual-logging to Pluto.
 
-This module is designed to be loaded via a .pth file at Python startup.
-It registers a sys.meta_path finder that, when `import wandb` is executed,
-loads the real wandb package and then monkey-patches it to dual-log to Pluto.
+Loaded via a .pth file at Python startup. Registers a sys.meta_path finder
+that, when `import wandb` is executed, loads the real wandb package and then
+monkey-patches it to dual-log to Pluto.
 
-Activation (needs both an API key and a project name):
-    API key (required):
-      - PLUTO_API_KEY: Pluto API token, OR
-      - WANDB_API_KEY as a fallback when DISABLE_WANDB_LOGGING=true
-        (user reuses the wandb env var to hold a Pluto token)
-    Project name (required):
-      - PLUTO_PROJECT, OR
-      - WANDB_PROJECT as a fallback (works in all modes)
+Activation:
+    The hook itself installs unconditionally when pluto-ml is on the path —
+    installing the package is the user's opt-in signal. Whether the
+    patches actually fire is decided later, when `import wandb` runs:
 
-Optional:
-    - DISABLE_WANDB_LOGGING=true: Skip real wandb, log to Pluto only
+      - Credentials available (any of: PLUTO_API_KEY env var, WANDB_API_KEY
+        when DISABLE_WANDB_LOGGING=true, the marker written by `pluto login`,
+        or the keyring file written by `pluto login`) → patches applied,
+        wandb dual-logs to Pluto.
+      - No credentials → a one-time discoverability hint is logged
+        (pointing at `pluto login` / PLUTO_API_KEY) and wandb runs unpatched.
+
+Project name is no longer required at install time; the runtime falls back
+to the `project=` kwarg on wandb.init, then WANDB_PROJECT, then the resolved
+wandb run's project attribute.
 """
 
 import importlib
 import logging
+import os
 import sys
 
 logger = logging.getLogger(__name__)
 
 _hook_installed = False
+_hint_emitted = False
+
+# Mirrors pluto.auth.LOGIN_MARKER_PATH. Duplicated as a literal here so this
+# module stays import-free of the rest of pluto at .pth load time.
+_LOGIN_MARKER_PATH = os.path.expanduser('~/.pluto/.login_ok')
+# keyrings.alt.file.PlaintextKeyring storage path (Linux/Windows fallback when
+# no system keyring is available). The file is shared across services, so we
+# parse it as INI to confirm a [pluto] section exists. macOS uses Keychain;
+# the marker file above covers macOS and post-upgrade Linux users.
+_KEYRING_CFG_PATH = os.path.expanduser('~/.local/share/python_keyring/keyring_pass.cfg')
+
+
+def _keyring_cfg_has_pluto() -> bool:
+    """Backward compat: detect a `pluto login` done before the marker existed."""
+    if not os.path.exists(_KEYRING_CFG_PATH):
+        return False
+    try:
+        import configparser
+
+        cp = configparser.RawConfigParser()
+        cp.read(_KEYRING_CFG_PATH, encoding='utf-8')
+        return cp.has_section('pluto')
+    except Exception:
+        return False
+
+
+def _has_pluto_credentials() -> bool:
+    """True if some Pluto auth source is available without prompting."""
+    if os.environ.get('PLUTO_API_KEY'):
+        return True
+    wandb_disabled = os.environ.get('DISABLE_WANDB_LOGGING', '').lower() in (
+        'true',
+        '1',
+        'yes',
+    )
+    if wandb_disabled and os.environ.get('WANDB_API_KEY'):
+        return True
+    if os.path.exists(_LOGIN_MARKER_PATH):
+        return True
+    if _keyring_cfg_has_pluto():
+        return True
+    return False
+
+
+def _has_partial_pluto_signal() -> bool:
+    """True if the user set a Pluto env var but has no auth — partial config."""
+    return any(
+        os.environ.get(v)
+        for v in (
+            'PLUTO_PROJECT',
+            'PLUTO_URL_APP',
+            'PLUTO_URL_API',
+            'PLUTO_URL_INGEST',
+        )
+    )
+
+
+def _emit_discoverability_hint() -> None:
+    """Log a one-time hint when wandb is imported but Pluto isn't activated."""
+    global _hint_emitted
+    if _hint_emitted:
+        return
+    _hint_emitted = True
+    if _has_partial_pluto_signal():
+        logger.warning(
+            'pluto.compat.wandb: Pluto config detected but no API key found. '
+            'Run `pluto login` (or set PLUTO_API_KEY) to enable dual-logging '
+            'to Pluto. Continuing with wandb-only logging.'
+        )
+    else:
+        logger.warning(
+            'pluto.compat.wandb: pluto-ml is installed but no Pluto credentials '
+            'found. Run `pluto login` (or set PLUTO_API_KEY) to enable '
+            'dual-logging to Pluto. Continuing with wandb-only logging.'
+        )
 
 
 class _PlutoWandbFinder:
@@ -39,8 +119,10 @@ class _PlutoWandbFinder:
     On first `import wandb`, this finder:
     1. Temporarily removes itself from sys.meta_path (to avoid recursion)
     2. Loads the real wandb package via normal import machinery
-    3. Applies monkey-patches to wandb.init/wandb.log/etc. for dual-logging
-    4. Re-inserts itself (for future imports, though wandb is now cached in sys.modules)
+    3. Decides whether to patch based on credential availability:
+       - Credentials present → applies dual-logging monkey-patches
+       - No credentials → emits a one-time discoverability hint
+    4. Re-inserts itself (for future imports, though wandb is now cached)
     """
 
     _patching = False
@@ -67,19 +149,22 @@ class _PlutoWandbFinder:
                 # Always re-insert ourselves
                 sys.meta_path.insert(0, self)
 
-            # Apply the dual-logging patches
-            try:
-                from pluto.compat.wandb import apply_wandb_patches
+            if _has_pluto_credentials():
+                try:
+                    from pluto.compat.wandb import apply_wandb_patches
 
-                apply_wandb_patches(real_wandb)
-                logger.info(
-                    'pluto._wandb_hook: Successfully patched wandb for dual-logging'
-                )
-            except Exception as e:
-                logger.warning(
-                    f'pluto._wandb_hook: Failed to apply wandb patches: {e}. '
-                    f'wandb will work normally without Pluto dual-logging.'
-                )
+                    apply_wandb_patches(real_wandb)
+                    logger.info(
+                        'pluto._wandb_hook: Successfully patched wandb for '
+                        'dual-logging'
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f'pluto._wandb_hook: Failed to apply wandb patches: {e}. '
+                        f'wandb will work normally without Pluto dual-logging.'
+                    )
+            else:
+                _emit_discoverability_hint()
 
             return real_wandb
         finally:
@@ -90,62 +175,42 @@ def install():
     """
     Register the wandb import hook on sys.meta_path.
 
-    Activation requires:
-      - An API key: PLUTO_API_KEY (always), OR WANDB_API_KEY if
-        DISABLE_WANDB_LOGGING=true (migration shortcut — user reuses
-        the wandb env var to hold a Pluto token).
-      - A project name: PLUTO_PROJECT, OR WANDB_PROJECT as a fallback
-        (works in all modes; saves users from setting the same value
-        in two env vars).
-
-    PLUTO_API_KEY is the user's explicit opt-in signal — if it's not
-    set, the hook never activates even if WANDB_PROJECT is present.
-    This means wandb users who happen to have pluto-ml installed but
-    never set a Pluto API key see no behavior change.
+    Always installs the finder when called — credential resolution is
+    deferred until `import wandb` actually runs (see _PlutoWandbFinder).
+    This ensures users who run `pluto login` after Python starts (or who
+    pass `project=` only as a kwarg) still get dual-logging, and that
+    users with no Pluto config see a discoverability hint instead of
+    silent inactivity.
 
     Safe to call multiple times.
     """
-    import os
-
     global _hook_installed
 
     if _hook_installed:
         return
 
-    wandb_disabled = os.environ.get('DISABLE_WANDB_LOGGING', '').lower() in (
-        'true',
-        '1',
-        'yes',
-    )
-    # API key: PLUTO_API_KEY preferred; WANDB_API_KEY only in disabled mode.
-    have_api_key = bool(os.environ.get('PLUTO_API_KEY')) or (
-        wandb_disabled and bool(os.environ.get('WANDB_API_KEY'))
-    )
-    # Project name: PLUTO_PROJECT preferred; WANDB_PROJECT fallback always.
-    have_project = bool(os.environ.get('PLUTO_PROJECT')) or bool(
-        os.environ.get('WANDB_PROJECT')
-    )
-    if not (have_api_key and have_project):
-        return
-
-    # Don't install if wandb is already imported (too late to intercept)
+    # If wandb is already imported, the finder is too late. Try to patch in
+    # place if credentials are available; otherwise log the hint.
     if 'wandb' in sys.modules:
-        logger.warning(
-            'pluto._wandb_hook: wandb already imported before hook installation. '
-            'Attempting to patch existing wandb module.'
-        )
-        try:
-            from pluto.compat.wandb import apply_wandb_patches
-
-            apply_wandb_patches(sys.modules['wandb'])
-        except Exception as e:
+        if _has_pluto_credentials():
             logger.warning(
-                f'pluto._wandb_hook: Failed to patch already-imported wandb: {e}'
+                'pluto._wandb_hook: wandb already imported before hook '
+                'installation. Attempting to patch existing wandb module.'
             )
+            try:
+                from pluto.compat.wandb import apply_wandb_patches
+
+                apply_wandb_patches(sys.modules['wandb'])
+            except Exception as e:
+                logger.warning(
+                    f'pluto._wandb_hook: Failed to patch already-imported '
+                    f'wandb: {e}'
+                )
+        else:
+            _emit_discoverability_hint()
         _hook_installed = True
         return
 
-    # Install the finder
     finder = _PlutoWandbFinder()
     sys.meta_path.insert(0, finder)
     _hook_installed = True
@@ -153,8 +218,9 @@ def install():
 
 def uninstall():
     """Remove the wandb import hook (for testing)."""
-    global _hook_installed
+    global _hook_installed, _hint_emitted
     sys.meta_path[:] = [
         f for f in sys.meta_path if not isinstance(f, _PlutoWandbFinder)
     ]
     _hook_installed = False
+    _hint_emitted = False

--- a/pluto/_wandb_hook.py
+++ b/pluto/_wandb_hook.py
@@ -104,24 +104,17 @@ def _emit_discoverability_hint() -> None:
         return
     _hint_emitted = True
     if _has_partial_pluto_signal():
-        msg = (
+        logger.warning(
             'pluto.compat.wandb: Pluto config detected but no API key found. '
             'Run `pluto login` (or set PLUTO_API_KEY) to enable dual-logging '
             'to Pluto. Continuing with wandb-only logging.'
         )
     else:
-        msg = (
+        logger.warning(
             'pluto.compat.wandb: pluto-ml is installed but no Pluto credentials '
             'found. Run `pluto login` (or set PLUTO_API_KEY) to enable '
             'dual-logging to Pluto. Continuing with wandb-only logging.'
         )
-    # logger.warning lets structured-logging consumers (Sentry etc.) capture it,
-    # but the hint also goes through plain stderr so it's never lost to a
-    # misconfigured logging setup or a test framework that intercepts the
-    # logging stream (Python 3.12 was observed to drop the logger output in
-    # subprocess-pytest contexts on CI).
-    logger.warning(msg)
-    print(msg, file=sys.stderr, flush=True)
 
 
 class _PlutoWandbFinder:

--- a/pluto/_wandb_hook.py
+++ b/pluto/_wandb_hook.py
@@ -23,6 +23,7 @@ wandb run's project attribute.
 """
 
 import importlib
+import importlib.util
 import logging
 import os
 import sys
@@ -117,68 +118,81 @@ def _emit_discoverability_hint() -> None:
         )
 
 
+def _patch_or_hint(wandb_module) -> None:
+    """Apply dual-logging patches if creds present, else log discoverability hint."""
+    if _has_pluto_credentials():
+        try:
+            from pluto.compat.wandb import apply_wandb_patches
+
+            apply_wandb_patches(wandb_module)
+            logger.info(
+                'pluto._wandb_hook: Successfully patched wandb for dual-logging'
+            )
+        except Exception as e:
+            logger.warning(
+                f'pluto._wandb_hook: Failed to apply wandb patches: {e}. '
+                f'wandb will work normally without Pluto dual-logging.'
+            )
+    else:
+        _emit_discoverability_hint()
+
+
+class _PatchingLoader:
+    """
+    Wraps wandb's real loader so we can run dual-logging patches *after* the
+    real loader fully initializes the wandb module. This is the spec-based
+    equivalent of the old find_module/load_module approach — required because
+    Python 3.12 deprecated the legacy API and stopped reliably calling it
+    when only find_module is implemented.
+    """
+
+    def __init__(self, real_loader):
+        self._real_loader = real_loader
+
+    def create_module(self, spec):
+        if hasattr(self._real_loader, 'create_module'):
+            return self._real_loader.create_module(spec)
+        return None  # default module creation
+
+    def exec_module(self, module):
+        # Let wandb's real loader populate the module first.
+        self._real_loader.exec_module(module)
+        # Now wandb is fully imported and `module is sys.modules['wandb']`,
+        # so monkey-patching `module.init` patches `wandb.init` for callers.
+        _patch_or_hint(module)
+
+
 class _PlutoWandbFinder:
     """
     Meta path finder that intercepts `import wandb` to apply dual-logging patches.
 
-    Uses find_module/load_module (not the newer find_spec/exec_module from PEP 451)
-    because the spec-based API doesn't cleanly support "load the real package, then
-    patch it" — exec_module runs on a partially-initialized module object, causing
-    circular import issues with wandb's internal imports.
+    Implements the modern `find_spec` API (Python 3.4+, required on 3.12+ where
+    legacy `find_module` is no longer reliably dispatched). We delegate to other
+    finders to locate the real wandb spec, then wrap its loader with
+    `_PatchingLoader` so our hook runs after wandb finishes importing.
 
-    On first `import wandb`, this finder:
-    1. Temporarily removes itself from sys.meta_path (to avoid recursion)
-    2. Loads the real wandb package via normal import machinery
-    3. Decides whether to patch based on credential availability:
-       - Credentials present → applies dual-logging monkey-patches
-       - No credentials → emits a one-time discoverability hint
-    4. Re-inserts itself (for future imports, though wandb is now cached)
+    The previous find_module/load_module implementation worked on 3.10/3.11 but
+    was silently bypassed on 3.12 — observed empirically as `_emit_discoverability_hint`
+    never being called and patches never applying.
     """
 
     _patching = False
 
-    def find_module(self, fullname, path=None):
-        # Only intercept top-level `import wandb`, and only once
-        if fullname == 'wandb' and not self._patching:
-            return self
-        return None
-
-    def load_module(self, fullname):
-        # If wandb is already in sys.modules, it's been loaded
-        if fullname in sys.modules:
-            return sys.modules[fullname]
-
-        # Prevent re-entrant calls
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname != 'wandb' or self._patching:
+            return None
+        # Re-enter the finder chain to find the real wandb spec without
+        # recursing into ourselves.
         self._patching = True
         try:
-            # Remove ourselves so the real import machinery finds the real wandb
-            sys.meta_path.remove(self)
-            try:
-                real_wandb = importlib.import_module('wandb')
-            finally:
-                # Always re-insert ourselves
-                sys.meta_path.insert(0, self)
-
-            if _has_pluto_credentials():
-                try:
-                    from pluto.compat.wandb import apply_wandb_patches
-
-                    apply_wandb_patches(real_wandb)
-                    logger.info(
-                        'pluto._wandb_hook: Successfully patched wandb for '
-                        'dual-logging'
-                    )
-                except Exception as e:
-                    logger.warning(
-                        f'pluto._wandb_hook: Failed to apply wandb patches: {e}. '
-                        f'wandb will work normally without Pluto dual-logging.'
-                    )
-            else:
-                _emit_discoverability_hint()
-
-            return real_wandb
+            real_spec = importlib.util.find_spec('wandb')
         finally:
             self._patching = False
+        if real_spec is None or real_spec.loader is None:
+            return None
+        # Wrap the real loader so exec_module triggers our patches afterward.
+        real_spec.loader = _PatchingLoader(real_spec.loader)
+        return real_spec
 
 
 def install():

--- a/pluto/auth.py
+++ b/pluto/auth.py
@@ -1,5 +1,6 @@
 import getpass
 import logging
+import os
 import sys
 import webbrowser
 
@@ -12,6 +13,30 @@ from .util import ANSI, import_lib, print_url
 
 tlogger = logging.getLogger('auth')
 tag = 'Authentication'
+
+# Marker file written after a successful `pluto login`. The wandb compat
+# layer's import hook (pluto/_wandb_hook.py) checks for this so a user who
+# has only run `pluto login` (no PLUTO_API_KEY env var) still gets dual-
+# logging activated. Stat-only check; never read.
+LOGIN_MARKER_PATH = os.path.expanduser('~/.pluto/.login_ok')
+
+
+def _write_login_marker() -> None:
+    try:
+        os.makedirs(os.path.dirname(LOGIN_MARKER_PATH), exist_ok=True)
+        with open(LOGIN_MARKER_PATH, 'w'):
+            pass
+    except OSError as e:
+        tlogger.debug('%s: failed to write login marker: %s', tag, e)
+
+
+def _remove_login_marker() -> None:
+    try:
+        os.remove(LOGIN_MARKER_PATH)
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        tlogger.debug('%s: failed to remove login marker: %s', tag, e)
 
 
 def login(settings=None, retry=False):
@@ -56,6 +81,7 @@ def login(settings=None, retry=False):
         body = r.json()
         tlogger.info(f'{tag}: logged in as {body["organization"]["slug"]}')
         keyring.set_password(f'{settings.tag}', f'{settings.tag}', f'{settings._auth}')
+        _write_login_marker()
         teardown_logger(tlogger)
     except Exception as e:
         # If _auth was already provided (e.g. via env var or keyring), don't
@@ -103,6 +129,7 @@ def login(settings=None, retry=False):
             keyring.set_password(
                 f'{settings.tag}', f'{settings.tag}', f'{settings._auth}'
             )
+            _write_login_marker()
         except Exception as e:
             tlogger.critical(
                 '%s: failed to save key to system keyring service: %s', tag, e
@@ -124,5 +151,6 @@ def logout(settings=None):
         tlogger.warning(
             '%s: failed to delete key from system keyring service: %s', tag, e
         )
+    _remove_login_marker()
     tlogger.info(f'{tag}: logged out')
     teardown_logger(tlogger)

--- a/pluto/compat/neptune.py
+++ b/pluto/compat/neptune.py
@@ -305,8 +305,18 @@ class NeptuneRunWrapper:
                 else None
             )
 
-            # Determine if this is an intentional resume (explicit run_id kwarg)
-            pluto_resume = bool(explicit_kwarg_run_id)
+            # Determine if this is an intentional resume.
+            # - explicit kwarg run_id: user-provided, e.g. for restarting a run.
+            # - PLUTO_RUN_ID env var: cross-rank coordination signal for DDP.
+            #   Without resume=True for the env-var path, ranks 1+ call
+            #   pluto.init with the same externalId, the server returns
+            #   resumed=True, and op.py raises "Run with externalId X already
+            #   exists". The exception is caught by our broad except below
+            #   and silently sets self._pluto_run = None — so only rank 0
+            #   installs the console-capture ConsoleHandler and only rank 0
+            #   logs ever reach the run. The user sees "all rank 1+ logs
+            #   missing in the UI" with no obvious error in stdout.
+            pluto_resume = bool(explicit_kwarg_run_id) or bool(env_run_id)
 
             # Apply precedence: PLUTO_RUN_ID > explicit kwarg > Neptune auto
             run_id = env_run_id or explicit_kwarg_run_id or neptune_run_id

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -4,25 +4,28 @@ Wandb-to-Pluto compatibility layer for seamless dual-logging.
 This module monkey-patches wandb.init() so that every wandb Run also logs
 to Pluto. It can be activated in two ways:
 
-1. Automatic (zero code changes): Set PLUTO_PROJECT + PLUTO_API_KEY env vars
-   and pip install pluto-ml. The .pth file triggers the import hook which
-   calls apply_wandb_patches().
+1. Automatic (zero code changes): pip install pluto-ml. The .pth file
+   triggers the import hook which calls apply_wandb_patches() once Pluto
+   credentials are available (see Configuration below).
 
 2. Explicit import: `import pluto.compat.wandb` at the top of your script.
    This patches wandb directly (like the Neptune compat layer).
 
 Configuration:
-    Required:
-    - PLUTO_API_KEY: Pluto API token (always required). In
-      DISABLE_WANDB_LOGGING=true mode, WANDB_API_KEY may be reused
-      instead.
-    - A project name: PLUTO_PROJECT if set, otherwise (in order)
-      the `project` kwarg to wandb.init(), the WANDB_PROJECT env
-      var, or the project attribute on the resolved wandb run.
-      This means if you already pass project= to wandb.init() (or
-      via a framework wrapper like Lightning's WandbLogger), or
-      have WANDB_PROJECT set for wandb, you don't need to set
-      PLUTO_PROJECT separately.
+    Authentication (one of the following):
+    - Run `pluto login` to store a token in the system keyring.
+    - Set PLUTO_API_KEY (Pluto API token).
+    - In DISABLE_WANDB_LOGGING=true mode only, WANDB_API_KEY may be
+      reused as the Pluto token (migration shortcut).
+
+    Project name (one of the following, checked in order):
+    - PLUTO_PROJECT env var
+    - the `project` kwarg passed to wandb.init()
+    - WANDB_PROJECT env var
+    - the project attribute on the resolved wandb run
+    If you already pass project= to wandb.init() (or via a framework
+    wrapper like Lightning's WandbLogger) or have WANDB_PROJECT set,
+    you don't need to set PLUTO_PROJECT separately.
 
     Optional:
     - PLUTO_URL_APP: Pluto app URL (for self-hosted)
@@ -32,7 +35,8 @@ Configuration:
 
 Hard Requirements:
     - MUST NOT break existing wandb functionality under ANY condition
-    - If Pluto is down/misconfigured, silently continue with wandb only
+    - If Pluto is down/misconfigured, log a warning and continue with
+      wandb only — never raise.
     - Zero impact on wandb's behavior, return values, or exceptions
 """
 
@@ -672,10 +676,11 @@ def _make_patched_init(original_init, wandb_module):
                 )
 
         if pluto_config is None:
-            logger.info(
-                'pluto.compat.wandb: no project name available '
-                '(set PLUTO_PROJECT or WANDB_PROJECT), '
-                'continuing with wandb-only logging'
+            logger.warning(
+                'pluto.compat.wandb: cannot dual-log to Pluto — no project '
+                'name resolvable (none of: PLUTO_PROJECT, project= kwarg, '
+                'WANDB_PROJECT, wandb run project). Continuing with wandb-'
+                'only logging.'
             )
             return wandb_run
 

--- a/pluto/log.py
+++ b/pluto/log.py
@@ -1,5 +1,6 @@
 import builtins
 import logging
+import os
 import sys
 import time
 
@@ -70,6 +71,16 @@ class ConsoleHandler:
         # like just whitespace or a single character, so treating each
         # call as a complete line shreds tracebacks into one-char "lines".
         self._partial_line: str = ''
+        # When running under torchrun, prepend the rank to captured lines
+        # so the Pluto UI can distinguish rank N from rank M without the
+        # user having to wrap every print() themselves. RANK is set by
+        # torchrun in every child process; absent → no prefix (so single-
+        # process and non-torch jobs keep their existing log format).
+        # Note: only the captured copy is prefixed, not the pass-through
+        # to self.stream — that lets torchrun add its own [defaultN]:
+        # prefix to the terminal stream without double-prefixing.
+        rank = os.environ.get('RANK')
+        self._rank_prefix = f'[rank{rank}] ' if rank is not None else ''
 
     def _flush_log_buffer(self) -> None:
         """Flush buffered console log lines to the sync store in one batch."""
@@ -89,6 +100,8 @@ class ConsoleHandler:
             return
         self.count += 1
         timestamp_ms = int(time.time() * 1000)
+        if self._rank_prefix:
+            line = self._rank_prefix + line
         if self.sync_manager is not None:
             sanitized_line = self.sanitizer.sanitize(line) if self.sanitizer else line
             log_type = logging._levelToName.get(self.level, 'INFO')

--- a/pluto/log.py
+++ b/pluto/log.py
@@ -65,6 +65,11 @@ class ConsoleHandler:
         self.sanitizer = sanitizer
         self._log_buffer: list = []
         self._last_flush = 0.0
+        # Carry-over for partial writes that don't end at a line boundary.
+        # Python's traceback printer (and rich) call write() with chunks
+        # like just whitespace or a single character, so treating each
+        # call as a complete line shreds tracebacks into one-char "lines".
+        self._partial_line: str = ''
 
     def _flush_log_buffer(self) -> None:
         """Flush buffered console log lines to the sync store in one batch."""
@@ -78,30 +83,50 @@ class ConsoleHandler:
         self._log_buffer.clear()
         self._last_flush = time.time()
 
+    def _emit_line(self, line: str) -> None:
+        """Log one complete line through the sync buffer + the python logger."""
+        if not line:  # do not log empty lines
+            return
+        self.count += 1
+        timestamp_ms = int(time.time() * 1000)
+        if self.sync_manager is not None:
+            sanitized_line = self.sanitizer.sanitize(line) if self.sanitizer else line
+            log_type = logging._levelToName.get(self.level, 'INFO')
+            self._log_buffer.append(
+                (sanitized_line, log_type, timestamp_ms, self.count)
+            )
+        self.logger.log(self.level, line)
+
     def write(self, buf: str) -> None:
-        for line in buf.splitlines():
-            if line:  # do not log empty lines
-                self.count += 1
-                timestamp_ms = int(time.time() * 1000)
-                if self.sync_manager is not None:
-                    sanitized_line = (
-                        self.sanitizer.sanitize(line) if self.sanitizer else line
-                    )
-                    log_type = logging._levelToName.get(self.level, 'INFO')
-                    self._log_buffer.append(
-                        (sanitized_line, log_type, timestamp_ms, self.count)
-                    )
-                self.logger.log(self.level, line)
+        # Pass-through to the real stream first so terminal output is not
+        # delayed by our line buffering.
+        self.stream.write(buf)
+        self.stream.flush()
+
+        # Accumulate partial writes and only emit on real '\n' boundaries.
+        # Splitting on '\n' specifically (not splitlines()) avoids breaking
+        # on \v, \f, \x1c-\x1e, \x85, U+2028, U+2029 — chars that rich and
+        # other styled-output libs use as internal segment separators.
+        self._partial_line += buf
+        if '\n' not in self._partial_line:
+            return
+        *complete, self._partial_line = self._partial_line.split('\n')
+        for line in complete:
+            self._emit_line(line)
         # Flush the buffer if it's large enough or old enough
         if self._log_buffer and (
             len(self._log_buffer) >= self._FLUSH_SIZE
             or time.time() - self._last_flush >= self._FLUSH_INTERVAL
         ):
             self._flush_log_buffer()
-        self.stream.write(buf)
-        self.stream.flush()
 
     def flush(self):
+        # Emit any trailing partial line so we don't drop output that
+        # never got a terminating newline (e.g. a final print(..., end='')
+        # before interpreter shutdown).
+        if self._partial_line:
+            self._emit_line(self._partial_line)
+            self._partial_line = ''
         self._flush_log_buffer()
         self.stream.flush()
 

--- a/pluto/sync/process.py
+++ b/pluto/sync/process.py
@@ -567,6 +567,20 @@ def _sync_main(
     except Exception as e:
         log.error(f'Sync process error: {e}', exc_info=True)
     finally:
+        # If we exited the loop because of SIGTERM/SIGINT (vs an exception),
+        # drain pending records before tearing down. torchrun gives ~30s
+        # before SIGKILL and pluto's shutdown_timeout defaults to 30s, so
+        # we have time — without this any records still in SQLite are left
+        # behind and require a manual `pluto sync` to recover.
+        if shutdown_requested['value']:
+            log.info(
+                f'Shutdown signal received, draining pending records '
+                f'(up to {shutdown_timeout}s)'
+            )
+            try:
+                _flush_remaining(store, uploader, log, shutdown_timeout, max_retries)
+            except Exception as drain_err:
+                log.warning(f'Drain on shutdown failed: {drain_err}')
         uploader.close()
         store.close()
         log.info('Sync process exiting')

--- a/tests/test_log_console_handler.py
+++ b/tests/test_log_console_handler.py
@@ -1,0 +1,203 @@
+"""
+Unit tests for pluto.log.ConsoleHandler line buffering.
+
+The previous implementation called write() once per call and ran
+splitlines() over the buffer, which:
+  1. Treated each write() as a complete line — so a traceback emitted
+     via many partial writes (one for the whitespace, one for the code,
+     one for the carets, etc.) showed up as one log entry per write,
+     producing per-character "lines" in the UI.
+  2. Used splitlines(), which splits on \v \f \x1c \x1d \x1e \x85
+     U+2028 U+2029 in addition to \n — chars that rich's styled output
+     emits as internal segment separators, so rich-styled tracebacks
+     also got chopped at non-newline boundaries.
+
+These tests pin both behaviors.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from unittest import mock
+
+import pytest
+
+from pluto.log import ConsoleHandler
+
+
+@pytest.fixture
+def harness():
+    """Build a ConsoleHandler wired to fakes that capture every emit.
+
+    The handler clears its internal buffer right after passing it to
+    enqueue_console_batch, so a plain MagicMock would record an empty
+    list. We snapshot via side_effect into a separate sink instead.
+    """
+    sync_manager = mock.MagicMock()
+    enqueued: list[list[tuple]] = []
+
+    def _snapshot(batch):
+        enqueued.append(list(batch))
+
+    sync_manager.enqueue_console_batch = mock.MagicMock(side_effect=_snapshot)
+    sync_manager._enqueued = enqueued
+
+    underlying = io.StringIO()
+    log = logging.getLogger('test_console_handler')
+    log.setLevel(logging.DEBUG)
+    log.handlers.clear()
+    handler = ConsoleHandler(
+        logger=log,
+        sync_manager=sync_manager,
+        level=logging.INFO,
+        stream=underlying,
+        type='stdout',
+    )
+    return handler, sync_manager, underlying
+
+
+def _emitted_lines(sync_manager) -> list[str]:
+    """Return every line text that was enqueued, across all batches."""
+    return [line for batch in sync_manager._enqueued for (line, *_rest) in batch]
+
+
+def _drain(handler) -> None:
+    """Force any pending buffer to be emitted (mirrors interpreter shutdown)."""
+    handler.flush()
+
+
+class TestPartialWriteCoalescing:
+    def test_three_partial_writes_become_one_line(self, harness):
+        handler, sync_manager, _ = harness
+        # This is the exact pattern Python's traceback printer / rich produces:
+        # leading whitespace, then the code, then the newline as separate writes.
+        handler.write('    ')
+        handler.write('main()')
+        handler.write('\n')
+        _drain(handler)
+        assert _emitted_lines(sync_manager) == ['    main()']
+
+    def test_carets_arriving_per_character_become_one_line(self, harness):
+        handler, sync_manager, _ = harness
+        # Rich/3.12 enhanced tracebacks can emit the caret-marker line
+        # one character at a time.  Pre-fix this produced one log entry
+        # per character, the bug the user reported.
+        for ch in '           ^^^^^^^^^^^^^^^':
+            handler.write(ch)
+        handler.write('\n')
+        _drain(handler)
+        assert _emitted_lines(sync_manager) == ['           ^^^^^^^^^^^^^^^']
+
+    def test_newline_in_middle_of_buffer_still_works(self, harness):
+        handler, sync_manager, _ = harness
+        handler.write('abc\ndef')  # one complete line, one partial
+        handler.write('ghi\n')  # finishes the partial
+        _drain(handler)
+        assert _emitted_lines(sync_manager) == ['abc', 'defghi']
+
+    def test_consecutive_newlines_only_skip_empties(self, harness):
+        handler, sync_manager, _ = harness
+        handler.write('one\n\ntwo\n')
+        _drain(handler)
+        # The empty line between 'one' and 'two' is dropped (existing behavior).
+        assert _emitted_lines(sync_manager) == ['one', 'two']
+
+    def test_trailing_partial_emitted_on_flush(self, harness):
+        handler, sync_manager, _ = harness
+        handler.write('no_newline_here')
+        # Without flush, nothing emits — we don't know if more is coming.
+        assert _emitted_lines(sync_manager) == []
+        handler.flush()
+        assert _emitted_lines(sync_manager) == ['no_newline_here']
+
+    def test_underlying_stream_gets_full_buf_immediately(self, harness):
+        handler, _sync, underlying = harness
+        # Pass-through to the real terminal must NOT wait for a newline,
+        # otherwise progress bars / partial prints freeze the terminal.
+        handler.write('partial')
+        assert underlying.getvalue() == 'partial'
+        handler.write(' more\n')
+        assert underlying.getvalue() == 'partial more\n'
+
+
+class TestNonNewlineSeparatorsArePreserved:
+    """splitlines() splits on too many chars; we only want \\n.
+
+    The old impl called buf.splitlines(), which silently broke output on
+    \v \f \x1c-\x1e \x85 U+2028 U+2029. Rich uses some of those as
+    segment separators when emitting styled output, so styled tracebacks
+    got chopped mid-line. Switching to '\\n'-only split fixes that.
+    """
+
+    @pytest.mark.parametrize(
+        'sep_char,name',
+        [
+            ('\v', 'VT'),
+            ('\f', 'FF'),
+            ('\x1c', 'FS'),
+            ('\x1d', 'GS'),
+            ('\x1e', 'RS'),
+            ('\x85', 'NEL'),
+            (' ', 'LSEP'),
+            (' ', 'PSEP'),
+        ],
+    )
+    def test_unicode_or_control_separator_does_not_split(self, harness, sep_char, name):
+        handler, sync_manager, _ = harness
+        handler.write(f'left{sep_char}right\n')
+        _drain(handler)
+        assert _emitted_lines(sync_manager) == [
+            f'left{sep_char}right'
+        ], f'{name} ({sep_char!r}) should not split a logical line'
+
+
+class TestSyncManagerBatching:
+    def test_complete_lines_only_enqueued_after_newline(self, harness):
+        handler, sync_manager, _ = harness
+        handler.write('hello')
+        # No newline yet → nothing enqueued
+        sync_manager.enqueue_console_batch.assert_not_called()
+        handler.write(' world\n')
+        # The batch flush is gated on size/time too, so force-flush:
+        handler.flush()
+        sync_manager.enqueue_console_batch.assert_called()
+        assert _emitted_lines(sync_manager) == ['hello world']
+
+    def test_no_sync_manager_still_logs_to_python_logger(self):
+        underlying = io.StringIO()
+        log = logging.getLogger('test_console_handler_no_sync')
+        log.handlers.clear()
+        log.setLevel(logging.DEBUG)
+        captured: list[logging.LogRecord] = []
+        log.addHandler(_ListHandler(captured))
+        handler = ConsoleHandler(
+            logger=log,
+            sync_manager=None,
+            level=logging.INFO,
+            stream=underlying,
+            type='stdout',
+        )
+        handler.write('hello\n')
+        handler.flush()
+        assert [r.getMessage() for r in captured] == ['hello']
+
+
+class TestSanitizerStillRuns:
+    def test_sanitizer_is_invoked_on_complete_lines(self, harness):
+        handler, sync_manager, _ = harness
+        handler.sanitizer = mock.MagicMock()
+        handler.sanitizer.sanitize.side_effect = lambda s: s.replace('mlpi_xxx', '***')
+        handler.write('api_key=mlpi_xxx ')
+        handler.write('here\n')
+        handler.flush()
+        assert _emitted_lines(sync_manager) == ['api_key=*** here']
+
+
+class _ListHandler(logging.Handler):
+    def __init__(self, sink):
+        super().__init__()
+        self.sink = sink
+
+    def emit(self, record):
+        self.sink.append(record)

--- a/tests/test_log_console_handler.py
+++ b/tests/test_log_console_handler.py
@@ -194,6 +194,90 @@ class TestSanitizerStillRuns:
         assert _emitted_lines(sync_manager) == ['api_key=*** here']
 
 
+class TestRankPrefix:
+    """When RANK env is set (torchrun), captured lines get a [rankN] prefix.
+
+    Pluto's stdout capture sits inside the child process before lines
+    reach the OS pipe that torchrun reads, so the [defaultN]: prefix
+    torchrun adds in the parent never makes it to the SyncStore. Reading
+    RANK directly from the child's env gives every captured line a tag
+    so DDP runs aren't a confusing single stream of unattributed lines
+    in the Pluto UI. The pass-through to the underlying stream stays
+    unprefixed so torchrun's own prefixing isn't doubled in the
+    terminal.
+    """
+
+    def _build_handler(self, sync_manager, stream):
+        log = logging.getLogger('test_console_handler_rank')
+        log.handlers.clear()
+        log.setLevel(logging.DEBUG)
+        return ConsoleHandler(
+            logger=log,
+            sync_manager=sync_manager,
+            level=logging.INFO,
+            stream=stream,
+            type='stdout',
+        )
+
+    def _capturing_sync_manager(self):
+        sync_manager = mock.MagicMock()
+        enqueued: list[list[tuple]] = []
+        sync_manager.enqueue_console_batch = mock.MagicMock(
+            side_effect=lambda batch: enqueued.append(list(batch))
+        )
+        sync_manager._enqueued = enqueued
+        return sync_manager
+
+    def test_rank_env_var_prefixes_captured_lines(self, monkeypatch):
+        monkeypatch.setenv('RANK', '1')
+        sync_manager = self._capturing_sync_manager()
+        underlying = io.StringIO()
+        handler = self._build_handler(sync_manager, underlying)
+        handler.write('starting fit\n')
+        handler.flush()
+        assert _emitted_lines(sync_manager) == ['[rank1] starting fit']
+
+    def test_no_rank_env_var_means_no_prefix(self, monkeypatch):
+        """Single-process runs (or anything not under torchrun) keep their format."""
+        monkeypatch.delenv('RANK', raising=False)
+        sync_manager = self._capturing_sync_manager()
+        underlying = io.StringIO()
+        handler = self._build_handler(sync_manager, underlying)
+        handler.write('hello\n')
+        handler.flush()
+        assert _emitted_lines(sync_manager) == ['hello']
+
+    def test_underlying_stream_is_not_prefixed(self, monkeypatch):
+        """The pass-through to terminal/OS-pipe must stay unprefixed.
+
+        torchrun reads from the OS pipe and adds its own [defaultN]:
+        prefix in the parent. If we prefixed the underlying stream too,
+        the terminal would show [default0]: [rank0] ... — double tag.
+        """
+        monkeypatch.setenv('RANK', '0')
+        sync_manager = self._capturing_sync_manager()
+        underlying = io.StringIO()
+        handler = self._build_handler(sync_manager, underlying)
+        handler.write('hello\n')
+        handler.flush()
+        assert underlying.getvalue() == 'hello\n'  # exactly the input, no prefix
+        assert _emitted_lines(sync_manager) == ['[rank0] hello']
+
+    def test_prefix_applied_per_line_not_per_write(self, monkeypatch):
+        """Multiple lines in one write each get their own prefix."""
+        monkeypatch.setenv('RANK', '2')
+        sync_manager = self._capturing_sync_manager()
+        underlying = io.StringIO()
+        handler = self._build_handler(sync_manager, underlying)
+        handler.write('one\ntwo\nthree\n')
+        handler.flush()
+        assert _emitted_lines(sync_manager) == [
+            '[rank2] one',
+            '[rank2] two',
+            '[rank2] three',
+        ]
+
+
 class _ListHandler(logging.Handler):
     def __init__(self, sink):
         super().__init__()

--- a/tests/test_neptune_compat.py
+++ b/tests/test_neptune_compat.py
@@ -812,6 +812,134 @@ class TestNeptuneCompatFallbackBehavior:
             assert url == 'neptune://disabled'
 
 
+class TestNeptuneCompatPlutoRunIdResume:
+    """Regression: PLUTO_RUN_ID env var must trigger resume=True for DDP coordination.
+
+    When PLUTO_RUN_ID is set across ranks (the documented coordination
+    mechanism for multi-rank jobs to share a single Pluto run), every rank
+    calls pluto.init with the same externalId. Rank 0 creates the run;
+    rank 1+ should resume it. Without resume=True, op.py raises
+    "Run with externalId X already exists" because the user did not
+    explicitly opt into resume — the broad except in NeptuneRunWrapper
+    swallows the error and sets self._pluto_run = None, so rank 1+ never
+    install console capture and only rank 0's logs reach the run.
+
+    The user-visible symptom is "logs from rank 1+ missing in the UI"
+    with no obvious error in stdout.
+    """
+
+    @pytest.fixture
+    def pluto_config_env(self, clean_env):
+        os.environ['PLUTO_PROJECT'] = 'ddp-test'
+        # PLUTO_RUN_ID is the cross-rank coordination signal.
+        os.environ['PLUTO_RUN_ID'] = 'ddp-shared-run-id-001'
+        yield
+        os.environ.pop('PLUTO_RUN_ID', None)
+
+    def test_pluto_run_id_env_var_passes_resume_true(
+        self, mock_neptune_backend, pluto_config_env
+    ):
+        """PLUTO_RUN_ID set → pluto.init called with resume=True.
+
+        Pre-fix: pluto_resume = bool(explicit_kwarg_run_id) only — env
+        var doesn't count → resume=False → rank 1+ raise on duplicate
+        create.
+        """
+        captured_kwargs: list[dict] = []
+
+        def _capture(**kwargs):
+            captured_kwargs.append(kwargs)
+            return mock.MagicMock(config={})
+
+        with mock.patch('pluto.init', side_effect=_capture):
+            from neptune_scale import Run
+
+            run = Run(experiment_name='ddp-rank-test')
+            run.close()
+
+        assert captured_kwargs, 'pluto.init was not called'
+        kw = captured_kwargs[0]
+        assert kw.get('run_id') == 'ddp-shared-run-id-001', (
+            f'PLUTO_RUN_ID should win the precedence chain. '
+            f'Got run_id={kw.get("run_id")!r}'
+        )
+        assert kw.get('resume') is True, (
+            f'PLUTO_RUN_ID is the DDP cross-rank coordination signal, so '
+            f'resume must be True or rank 1+ blow up. Got resume={kw.get("resume")!r}'
+        )
+        assert run._pluto_run is not None, (
+            'rank-1 simulation: when pluto.init succeeds the wrapper must '
+            'retain a non-None _pluto_run so console capture stays wired'
+        )
+
+    def test_two_ranks_both_succeed_with_pluto_run_id(
+        self, mock_neptune_backend, pluto_config_env
+    ):
+        """Simulate two ranks: both NeptuneRunWrapper instances must succeed.
+
+        Mocks pluto.init to behave like the server: the first call returns
+        a fresh run, the second call (same externalId without resume=True)
+        would raise per op.py:362-369. With the fix, rank 1's call carries
+        resume=True so pluto.init does not raise and rank 1's wrapper has
+        a working _pluto_run.
+        """
+        call_count = {'n': 0}
+
+        def _server_simulation(**kwargs):
+            call_count['n'] += 1
+            # The actual op.py raises this exact pattern when resumed=True
+            # comes back from the server but the caller did not opt in.
+            if call_count['n'] >= 2 and not kwargs.get('resume'):
+                raise RuntimeError(
+                    f"Run with externalId '{kwargs.get('run_id')}' already exists. "
+                    'Pass resume=True to pluto.init() to intentionally reattach.'
+                )
+            return mock.MagicMock(config={})
+
+        with mock.patch('pluto.init', side_effect=_server_simulation):
+            from neptune_scale import Run
+
+            rank0 = Run(experiment_name='ddp-rank-test')
+            rank1 = Run(experiment_name='ddp-rank-test')
+
+        assert rank0._pluto_run is not None, 'rank 0 should always succeed'
+        assert rank1._pluto_run is not None, (
+            'rank 1 must also have a working pluto run. If this is None it '
+            'means the compat layer let pluto.init raise and silently '
+            'caught the exception, leaving rank 1 with no console capture.'
+        )
+
+    def test_no_pluto_run_id_keeps_old_resume_behavior(
+        self, mock_neptune_backend, clean_env
+    ):
+        """Without PLUTO_RUN_ID, resume should remain False unless explicitly requested.
+
+        Guards against the fix accidentally turning every Neptune-only
+        run into a resume attempt. resume=False is the correct default
+        for fresh single-rank runs.
+        """
+        os.environ['PLUTO_PROJECT'] = 'single-rank-test'
+        os.environ.pop('PLUTO_RUN_ID', None)
+        captured_kwargs: list[dict] = []
+
+        def _capture(**kwargs):
+            captured_kwargs.append(kwargs)
+            return mock.MagicMock(config={})
+
+        with mock.patch('pluto.init', side_effect=_capture):
+            from neptune_scale import Run
+
+            run = Run(experiment_name='single-rank')
+            run.close()
+
+        assert captured_kwargs, 'pluto.init was not called'
+        kw = captured_kwargs[0]
+        assert kw.get('resume') is False, (
+            f'No PLUTO_RUN_ID and no explicit run_id kwarg → resume must '
+            f'stay False. Got resume={kw.get("resume")!r}'
+        )
+
+
 class TestNeptuneCompatAPIForwarding:
     """Test that unknown Neptune API methods are forwarded correctly."""
 

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -484,13 +484,25 @@ class TestCmdSync:
         assert 'failed to sync' in captured.out.lower()
 
     def _mock_settings(self):
-        """Create a mock Settings whose to_dict() returns JSON-serializable data."""
+        """Create a mock Settings whose to_dict() returns JSON-serializable data.
+
+        Also stub the url_* attributes accessed by _cmd_sync after to_dict()
+        as plain strings, so subsequent json.dumps(settings_dict) does not
+        choke on MagicMock instances when --background mode serialises the
+        dict for the subprocess.
+        """
         mock_settings = MagicMock()
         mock_settings.to_dict.return_value = {
             'tag': 'pluto',
             'project': 'pluto',
             'host': 'https://pluto.trainy.ai',
         }
+        mock_settings.url_num = 'https://example/ingest/metrics'
+        mock_settings.url_data = 'https://example/ingest/data'
+        mock_settings.url_file = 'https://example/files'
+        mock_settings.url_message = 'https://example/ingest/logs'
+        mock_settings.url_update_config = 'https://example/api/runs/config/update'
+        mock_settings.url_update_tags = 'https://example/api/runs/tags/update'
         return mock_settings
 
     def test_background_mode_spawns_subprocess(self, tmp_path, capsys):
@@ -568,6 +580,197 @@ class TestCmdSync:
 
         captured = capsys.readouterr()
         assert 'Warning' in captured.err or 'No pending records' in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Tests: end-to-end `pluto sync` actually POSTs to the right ingest URLs.
+#
+# Pre-existing tests in TestCmdSync mock retry_sync and never observe what
+# URL the uploader actually posts to. That left a silent-data-loss bug
+# uncaught: Settings.to_dict() only iterates __annotations__, so the URL
+# fields populated by update_url() (url_message, url_num, url_data,
+# url_file, url_update_config, url_update_tags) were missing from the
+# settings_dict the CLI handed to retry_sync. _SyncUploader then
+# defaulted self.url_console / self.url_num / etc. to '' and every
+# upload_*_batch method returned early on `if not self.url_X: return`.
+# The local DB recorded SUCCESS for records that never left the host.
+#
+# These tests exercise the full _cmd_sync → retry_sync → uploader
+# stack against a fake httpx.Client that records every POST, so any
+# regression where a URL silently goes empty causes an assertion
+# failure rather than a fake-success.
+# ---------------------------------------------------------------------------
+
+
+class _FakeHttpResponse:
+    def __init__(self, status_code: int = 200):
+        self.status_code = status_code
+        self.text = ''
+        self.headers: dict = {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f'HTTP {self.status_code}')
+
+
+class _RecordingHttpClient:
+    """Stand-in for httpx.Client that records every POST it receives.
+
+    Each call appends (url, body, headers) to .posts. Always returns 200.
+    """
+
+    def __init__(self, *_args, **_kwargs):
+        self.posts: list[tuple[str, bytes, dict]] = []
+
+    def post(self, url, content=None, data=None, headers=None, **_kwargs):
+        body = content if content is not None else data
+        self.posts.append((url, body, dict(headers or {})))
+        return _FakeHttpResponse(200)
+
+    def close(self) -> None:
+        pass
+
+
+class TestCmdSyncEndToEndUploads:
+    """End-to-end: _cmd_sync should actually POST records to the ingest service."""
+
+    def _make_args(self, **kwargs):
+        defaults = {
+            'path': None,
+            'dir': None,
+            'background': False,
+            'timeout': 60.0,
+            'verbose': False,
+        }
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+
+    def _make_db_with_mixed_records(self, tmp_path):
+        """Sync DB with one CONSOLE record and one METRIC record pending."""
+        pluto_dir = tmp_path / '.pluto' / 'project-x' / 'run-x'
+        pluto_dir.mkdir(parents=True)
+        db_path = pluto_dir / 'sync.db'
+        s = SyncStore(str(db_path))
+        s.register_run('run-x', 'project-x', op_id=137383)
+        ts = int(time.time() * 1000)
+        s.enqueue(
+            'run-x',
+            RecordType.CONSOLE,
+            {'message': 'hello world', 'logType': 'INFO', 'lineNumber': 1},
+            ts,
+        )
+        s.enqueue(
+            'run-x',
+            RecordType.METRIC,
+            {'loss': 0.5},
+            ts,
+            step=1,
+        )
+        s.close()
+        return str(db_path)
+
+    def test_console_records_actually_posted_to_ingest_logs_url(self, tmp_path):
+        """Regression: pluto sync used to silently no-op CONSOLE uploads.
+
+        Settings.to_dict() returned a dict missing url_message, so
+        _SyncUploader.url_console was '' and upload_console_batch
+        returned early without sending anything. Local DB still marked
+        the records SUCCESS — the records were lost without an error.
+
+        Assert: a POST goes to the configured /ingest/logs URL with
+        the console record in the NDJSON body.
+        """
+        from pluto.__main__ import _cmd_sync
+
+        db_path = self._make_db_with_mixed_records(tmp_path)
+        args = self._make_args(path=db_path)
+        recording_client = _RecordingHttpClient()
+
+        with (
+            patch('pluto.__main__._get_auth_token', return_value='tok'),
+            patch('httpx.Client', return_value=recording_client),
+        ):
+            _cmd_sync(args)
+
+        log_posts = [
+            (url, body)
+            for (url, body, _hdr) in recording_client.posts
+            if url.endswith('/ingest/logs')
+        ]
+        assert log_posts, (
+            'pluto sync did not POST any console records to /ingest/logs. '
+            'urls actually posted to: '
+            f'{[u for (u, _b, _h) in recording_client.posts]}'
+        )
+        assert b'hello world' in log_posts[0][1]
+
+    def test_all_url_fields_present_in_settings_passed_to_uploader(self, tmp_path):
+        """Regression for Settings.to_dict() __annotations__ gap.
+
+        If any of url_num / url_data / url_file / url_message /
+        url_update_config / url_update_tags is missing from the
+        settings_dict passed to retry_sync, the corresponding
+        uploader.url_X attribute defaults to '' and that record type's
+        upload silently no-ops.
+        """
+        from pluto.__main__ import _cmd_sync
+
+        db_path = self._make_db_with_mixed_records(tmp_path)
+        args = self._make_args(path=db_path)
+        captured: dict = {}
+
+        def _capture(**kwargs):
+            captured.update(kwargs)
+            return True
+
+        with (
+            patch('pluto.__main__._get_auth_token', return_value='tok'),
+            patch('pluto.sync.process.retry_sync', side_effect=_capture),
+        ):
+            _cmd_sync(args)
+
+        sd = captured['settings_dict']
+        for key in (
+            'url_num',
+            'url_data',
+            'url_file',
+            'url_message',
+            'url_update_config',
+            'url_update_tags',
+        ):
+            assert sd.get(key), (
+                f'{key!r} missing or empty in settings_dict passed to '
+                f'retry_sync — corresponding uploads will silently no-op. '
+                f'Got: {sd.get(key)!r}'
+            )
+
+    def test_run_id_header_uses_numeric_op_id(self, tmp_path):
+        """X-Run-Id must be the numeric op_id (137383), not the string run_id.
+
+        ingest's LogEnrichment::from_headers does
+        header.parse::<u64>().unwrap_or(0), so a non-numeric value
+        would silently land all records under runId=0 in ClickHouse —
+        invisible to any later query.
+        """
+        from pluto.__main__ import _cmd_sync
+
+        db_path = self._make_db_with_mixed_records(tmp_path)
+        args = self._make_args(path=db_path)
+        recording_client = _RecordingHttpClient()
+
+        with (
+            patch('pluto.__main__._get_auth_token', return_value='tok'),
+            patch('httpx.Client', return_value=recording_client),
+        ):
+            _cmd_sync(args)
+
+        assert recording_client.posts, 'no posts recorded'
+        for _url, _body, headers in recording_client.posts:
+            run_id_hdr = headers.get('X-Run-Id') or headers.get('x-run-id')
+            assert run_id_hdr == '137383', (
+                f'X-Run-Id must be the numeric op_id; got {run_id_hdr!r}. '
+                'A non-numeric value would parse to 0 server-side.'
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_sigterm_drain.py
+++ b/tests/test_sync_sigterm_drain.py
@@ -1,0 +1,271 @@
+"""
+Integration test for SIGTERM-shutdown drain in pluto.sync._sync_main.
+
+Pre-fix _sync_main's SIGTERM handler set shutdown_requested=True, the
+loop exited, and the `finally` closed the uploader and store WITHOUT
+flushing any pending records. Anything still in SQLite at the moment
+SIGTERM arrived was left behind and required a manual `pluto sync`
+to recover. In DDP runs that crash, this is the common case: torchrun
+sends SIGTERM to the surviving rank's process group, the sync
+subprocess gets ~30s before SIGKILL — but pluto exited in ~100ms
+without using any of it.
+
+This test spawns the real `python -m pluto.sync` subprocess against a
+local recording HTTP server, enqueues records into its DB, sends
+SIGTERM, and verifies the records actually POST before the subprocess
+exits. With the fix in place this passes; without it, the records
+never reach the local server and the assertion fires.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+from pluto.sync.store import RecordType, SyncStore
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _RecordingHandler(http.server.BaseHTTPRequestHandler):
+    """Captures every POST body in handler.server.posts (path -> [body, ...])."""
+
+    def do_POST(self):  # noqa: N802 — http.server convention
+        length = int(self.headers.get('Content-Length', '0') or 0)
+        body = self.rfile.read(length) if length else b''
+        self.server.posts.setdefault(self.path, []).append(body)
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(b'{"ok": true}')
+
+    def log_message(self, *_args, **_kwargs):
+        # Silence the default per-request stderr spam.
+        pass
+
+
+@pytest.fixture
+def recording_server():
+    """Background HTTP server that records POST bodies per path."""
+    port = _free_port()
+    server = http.server.HTTPServer(('127.0.0.1', port), _RecordingHandler)
+    server.posts = {}  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server, port
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=5)
+
+
+def _seed_db_with_pending(db_path: str, n_console: int = 5) -> int:
+    """Create a SyncStore at db_path with n pending CONSOLE records."""
+    store = SyncStore(db_path)
+    store.register_run('run-x', 'project-x', op_id=42)
+    ts_ms = int(time.time() * 1000)
+    for i in range(n_console):
+        store.enqueue(
+            'run-x',
+            RecordType.CONSOLE,
+            {'message': f'line-{i}', 'logType': 'INFO', 'lineNumber': i},
+            ts_ms,
+        )
+    store.close()
+    return n_console
+
+
+def _spawn_sync_subprocess(db_path: str, settings_dict: dict) -> subprocess.Popen:
+    """Spawn `python -m pluto.sync` with the given DB path and settings."""
+    return subprocess.Popen(
+        [
+            sys.executable,
+            '-m',
+            'pluto.sync',
+            '--db-path',
+            db_path,
+            '--settings',
+            json.dumps(settings_dict),
+            '--parent-pid',
+            str(os.getpid()),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool:
+    """Poll predicate up to timeout; return True if it ever became truthy."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+def test_sigterm_drains_pending_records_before_exit(tmp_path, recording_server):
+    """SIGTERM during a run with pending records must trigger a final drain.
+
+    Spawns the real sync subprocess, enqueues 5 console records, sends
+    SIGTERM, and waits for the process to exit. Asserts the recording
+    server received POSTs to /ingest/logs covering all 5 records before
+    the subprocess shut down. Pre-fix this fails because _sync_main's
+    SIGTERM path skipped _flush_remaining entirely and the records
+    stayed in SQLite.
+    """
+    server, port = recording_server
+    base_url = f'http://127.0.0.1:{port}'
+
+    db_path = str(tmp_path / 'sync.db')
+    n = _seed_db_with_pending(db_path, n_console=5)
+
+    settings = {
+        '_auth': 'tok',
+        '_op_id': 42,
+        '_op_name': 'run-x',
+        'project': 'project-x',
+        'tag': 'pluto',
+        'url_num': f'{base_url}/ingest/metrics',
+        'url_data': f'{base_url}/ingest/data',
+        'url_file': f'{base_url}/files',
+        'url_message': f'{base_url}/ingest/logs',
+        'url_update_config': f'{base_url}/api/runs/config/update',
+        'url_update_tags': f'{base_url}/api/runs/tags/update',
+        # Short shutdown timeout so the test finishes quickly even if the
+        # drain has nothing to do; still long enough for a localhost POST.
+        'sync_process_shutdown_timeout': 5.0,
+        'sync_process_flush_interval': 60.0,  # Long → drain only happens on shutdown
+        'sync_process_orphan_timeout': 60.0,
+        'sync_process_retry_max': 1,
+        'sync_process_batch_size': 50,
+        'sync_process_file_batch_size': 10,
+    }
+
+    proc = _spawn_sync_subprocess(db_path, settings)
+    try:
+        # Wait for the subprocess to start its main loop. It logs
+        # 'Sync process started' immediately after registering signal
+        # handlers and opening the store, so a short delay is enough.
+        # We don't want to read stderr in a blocking way (would race
+        # with subprocess termination), so just give it a beat.
+        time.sleep(1.0)
+        assert proc.poll() is None, (
+            'sync subprocess died before SIGTERM. stderr: '
+            f'{proc.stderr.read().decode(errors="replace") if proc.stderr else "?"}'
+        )
+
+        proc.send_signal(signal.SIGTERM)
+
+        # The fix gives the drain up to shutdown_timeout (5s here) plus
+        # close overhead. Cap our wait at 15s so a regression doesn't
+        # hang the test suite.
+        try:
+            stdout, stderr = proc.communicate(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+            pytest.fail(
+                f'Sync subprocess did not exit within 15s of SIGTERM. '
+                f'stderr: {stderr.decode(errors="replace")[:2000]}'
+            )
+
+        # Sanity: the subprocess actually got the signal and ran the
+        # shutdown path, not crashed mid-startup.
+        stderr_text = stderr.decode(errors='replace')
+        assert 'Sync process exiting' in stderr_text, (
+            f'Sync subprocess exited but did not run the shutdown finally '
+            f'block. stderr:\n{stderr_text[:3000]}'
+        )
+
+        log_posts = server.posts.get('/ingest/logs', [])
+        assert log_posts, (
+            'sync subprocess exited on SIGTERM without POSTing any '
+            'pending console records. This is the pre-fix bug: the '
+            'finally block tore down the uploader without calling '
+            f'_flush_remaining. server.posts={dict(server.posts)} '
+            f'stderr:\n{stderr_text[:3000]}'
+        )
+
+        # All 5 line-N messages should appear somewhere across the POST
+        # bodies (NDJSON, batched in any order/grouping).
+        all_log_bytes = b''.join(log_posts)
+        for i in range(n):
+            assert f'line-{i}'.encode() in all_log_bytes, (
+                f'line-{i} missing from posted bodies. '
+                f'Got {len(log_posts)} log POSTs totaling '
+                f'{len(all_log_bytes)} bytes.'
+            )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def test_clean_exit_with_no_pending_does_not_block(tmp_path, recording_server):
+    """SIGTERM with empty queue should still exit promptly (no hang).
+
+    Guards against the drain path waiting for batches that will never
+    arrive. The drain helper has its own timeout but if a future
+    refactor accidentally blocks on something else, this catches it.
+    """
+    server, port = recording_server
+    base_url = f'http://127.0.0.1:{port}'
+
+    db_path = str(tmp_path / 'sync.db')
+    # Register a run but enqueue nothing.
+    s = SyncStore(db_path)
+    s.register_run('run-empty', 'project-x', op_id=43)
+    s.close()
+
+    settings = {
+        '_auth': 'tok',
+        '_op_id': 43,
+        '_op_name': 'run-empty',
+        'project': 'project-x',
+        'tag': 'pluto',
+        'url_num': f'{base_url}/ingest/metrics',
+        'url_data': f'{base_url}/ingest/data',
+        'url_file': f'{base_url}/files',
+        'url_message': f'{base_url}/ingest/logs',
+        'url_update_config': f'{base_url}/api/runs/config/update',
+        'url_update_tags': f'{base_url}/api/runs/tags/update',
+        'sync_process_shutdown_timeout': 5.0,
+        'sync_process_flush_interval': 60.0,
+        'sync_process_orphan_timeout': 60.0,
+    }
+
+    proc = _spawn_sync_subprocess(db_path, settings)
+    try:
+        time.sleep(1.0)
+        assert proc.poll() is None
+        start = time.time()
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            pytest.fail('Sync subprocess hung on SIGTERM with empty queue')
+        elapsed = time.time() - start
+        # Drain helper checks emptiness up front and returns fast.
+        # 8s is a generous bound for a local subprocess teardown.
+        assert elapsed < 8.0, f'Sync took {elapsed:.1f}s to exit on SIGTERM'
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)

--- a/tests/test_wandb_hook_unit.py
+++ b/tests/test_wandb_hook_unit.py
@@ -1,0 +1,346 @@
+"""
+Unit tests for pluto._wandb_hook helpers.
+
+These run in-process (no subprocess) so the lines actually get instrumented
+by pytest-cov. The integration tests in test_wandb_pth_integration.py
+validate the wired-up startup path; these cover the credential resolution,
+discoverability hint, and finder/loader plumbing in isolation.
+"""
+
+import logging
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from pluto import _wandb_hook
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(monkeypatch):
+    """Reset hook state, finder list, and remove any cached wandb in sys.modules."""
+    _wandb_hook.uninstall()
+    _wandb_hook._hint_emitted = False
+    monkeypatch.delitem(sys.modules, 'wandb', raising=False)
+    yield
+    _wandb_hook.uninstall()
+    _wandb_hook._hint_emitted = False
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Strip every Pluto/Wandb env var so tests start from a known baseline."""
+    for k in list(os.environ):
+        if k.startswith(('PLUTO_', 'WANDB_')) or k == 'DISABLE_WANDB_LOGGING':
+            monkeypatch.delenv(k, raising=False)
+    return monkeypatch
+
+
+class TestKeyringCfgPath:
+    def test_linux_uses_xdg_data_home(self, clean_env):
+        clean_env.setattr(sys, 'platform', 'linux')
+        clean_env.setenv('XDG_DATA_HOME', '/custom/xdg')
+        path = _wandb_hook._keyring_cfg_path()
+        assert path == '/custom/xdg/python_keyring/keyring_pass.cfg'
+
+    def test_linux_falls_back_to_local_share(self, clean_env):
+        clean_env.setattr(sys, 'platform', 'linux')
+        clean_env.delenv('XDG_DATA_HOME', raising=False)
+        path = _wandb_hook._keyring_cfg_path()
+        assert path.endswith('/.local/share/python_keyring/keyring_pass.cfg')
+
+    def test_windows_uses_localappdata(self, clean_env):
+        # os.path.join uses the host's separator; assert components instead of literal.
+        clean_env.setattr(sys, 'platform', 'win32')
+        clean_env.setenv('LOCALAPPDATA', 'C:\\Users\\me\\AppData\\Local')
+        path = _wandb_hook._keyring_cfg_path()
+        assert path.startswith('C:\\Users\\me\\AppData\\Local')
+        assert 'Python Keyring' in path
+        assert path.endswith('keyring_pass.cfg')
+
+    def test_windows_falls_back_to_programdata(self, clean_env):
+        clean_env.setattr(sys, 'platform', 'win32')
+        clean_env.delenv('LOCALAPPDATA', raising=False)
+        clean_env.setenv('ProgramData', 'C:\\ProgramData')
+        path = _wandb_hook._keyring_cfg_path()
+        assert path.startswith('C:\\ProgramData')
+        assert 'Python Keyring' in path
+        assert path.endswith('keyring_pass.cfg')
+
+
+class TestKeyringCfgHasPluto:
+    def test_returns_false_when_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            _wandb_hook, '_keyring_cfg_path', lambda: str(tmp_path / 'absent.cfg')
+        )
+        assert _wandb_hook._keyring_cfg_has_pluto() is False
+
+    def test_returns_true_when_pluto_section_present(self, tmp_path, monkeypatch):
+        cfg = tmp_path / 'keyring_pass.cfg'
+        cfg.write_text('[pluto]\napi_key = mlpi_xyz\n')
+        monkeypatch.setattr(_wandb_hook, '_keyring_cfg_path', lambda: str(cfg))
+        assert _wandb_hook._keyring_cfg_has_pluto() is True
+
+    def test_returns_false_when_pluto_section_absent(self, tmp_path, monkeypatch):
+        cfg = tmp_path / 'keyring_pass.cfg'
+        cfg.write_text('[other]\nfoo = bar\n')
+        monkeypatch.setattr(_wandb_hook, '_keyring_cfg_path', lambda: str(cfg))
+        assert _wandb_hook._keyring_cfg_has_pluto() is False
+
+    def test_returns_false_on_malformed_file(self, tmp_path, monkeypatch):
+        cfg = tmp_path / 'keyring_pass.cfg'
+        cfg.write_bytes(b'\xff\xfe\x00\x00garbage no section')
+        monkeypatch.setattr(_wandb_hook, '_keyring_cfg_path', lambda: str(cfg))
+        assert _wandb_hook._keyring_cfg_has_pluto() is False
+
+
+class TestHasPlutoCredentials:
+    def test_pluto_api_key_env_satisfies(self, clean_env, tmp_path):
+        clean_env.setenv('PLUTO_API_KEY', 'mlpi_test')
+        clean_env.setattr(_wandb_hook, '_LOGIN_MARKER_PATH', str(tmp_path / 'absent'))
+        clean_env.setattr(
+            _wandb_hook, '_keyring_cfg_path', lambda: str(tmp_path / 'absent.cfg')
+        )
+        assert _wandb_hook._has_pluto_credentials() is True
+
+    def test_login_marker_satisfies(self, clean_env, tmp_path):
+        marker = tmp_path / '.login_ok'
+        marker.touch()
+        clean_env.setattr(_wandb_hook, '_LOGIN_MARKER_PATH', str(marker))
+        clean_env.setattr(
+            _wandb_hook, '_keyring_cfg_path', lambda: str(tmp_path / 'absent.cfg')
+        )
+        assert _wandb_hook._has_pluto_credentials() is True
+
+    def test_keyring_with_pluto_section_satisfies(self, clean_env, tmp_path):
+        cfg = tmp_path / 'keyring_pass.cfg'
+        cfg.write_text('[pluto]\napi_key = mlpi_xyz\n')
+        clean_env.setattr(_wandb_hook, '_LOGIN_MARKER_PATH', str(tmp_path / 'absent'))
+        clean_env.setattr(_wandb_hook, '_keyring_cfg_path', lambda: str(cfg))
+        assert _wandb_hook._has_pluto_credentials() is True
+
+    def test_wandb_api_key_with_disable_flag_satisfies(self, clean_env, tmp_path):
+        clean_env.setenv('WANDB_API_KEY', 'mlpi_via_wandb_var')
+        clean_env.setenv('DISABLE_WANDB_LOGGING', 'true')
+        clean_env.setattr(_wandb_hook, '_LOGIN_MARKER_PATH', str(tmp_path / 'absent'))
+        clean_env.setattr(
+            _wandb_hook, '_keyring_cfg_path', lambda: str(tmp_path / 'absent.cfg')
+        )
+        assert _wandb_hook._has_pluto_credentials() is True
+
+    def test_wandb_api_key_without_disable_flag_does_not_satisfy(
+        self, clean_env, tmp_path
+    ):
+        clean_env.setenv('WANDB_API_KEY', 'wandb_only')
+        clean_env.setattr(_wandb_hook, '_LOGIN_MARKER_PATH', str(tmp_path / 'absent'))
+        clean_env.setattr(
+            _wandb_hook, '_keyring_cfg_path', lambda: str(tmp_path / 'absent.cfg')
+        )
+        assert _wandb_hook._has_pluto_credentials() is False
+
+    def test_no_signals_means_no_credentials(self, clean_env, tmp_path):
+        clean_env.setattr(_wandb_hook, '_LOGIN_MARKER_PATH', str(tmp_path / 'absent'))
+        clean_env.setattr(
+            _wandb_hook, '_keyring_cfg_path', lambda: str(tmp_path / 'absent.cfg')
+        )
+        assert _wandb_hook._has_pluto_credentials() is False
+
+
+class TestHasPartialPlutoSignal:
+    @pytest.mark.parametrize(
+        'var', ['PLUTO_PROJECT', 'PLUTO_URL_APP', 'PLUTO_URL_API', 'PLUTO_URL_INGEST']
+    )
+    def test_each_partial_var_triggers(self, clean_env, var):
+        clean_env.setenv(var, 'value')
+        assert _wandb_hook._has_partial_pluto_signal() is True
+
+    def test_no_pluto_vars_means_no_signal(self, clean_env):
+        assert _wandb_hook._has_partial_pluto_signal() is False
+
+
+class TestEmitDiscoverabilityHint:
+    def test_partial_config_message_when_pluto_var_set(self, clean_env, caplog):
+        clean_env.setenv('PLUTO_PROJECT', 'p')
+        with caplog.at_level(logging.WARNING, logger='pluto._wandb_hook'):
+            _wandb_hook._emit_discoverability_hint()
+        assert any(
+            'Pluto config detected but no API key' in r.message for r in caplog.records
+        )
+
+    def test_generic_hint_when_no_pluto_vars(self, clean_env, caplog):
+        with caplog.at_level(logging.WARNING, logger='pluto._wandb_hook'):
+            _wandb_hook._emit_discoverability_hint()
+        assert any('no Pluto credentials found' in r.message for r in caplog.records)
+
+    def test_only_emits_once(self, clean_env, caplog):
+        with caplog.at_level(logging.WARNING, logger='pluto._wandb_hook'):
+            _wandb_hook._emit_discoverability_hint()
+            _wandb_hook._emit_discoverability_hint()
+            _wandb_hook._emit_discoverability_hint()
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+
+
+class TestPatchOrHint:
+    def test_applies_patches_when_credentials_present(self, clean_env, tmp_path):
+        clean_env.setenv('PLUTO_API_KEY', 'mlpi_test')
+        clean_env.setattr(_wandb_hook, '_LOGIN_MARKER_PATH', str(tmp_path / 'absent'))
+        clean_env.setattr(
+            _wandb_hook, '_keyring_cfg_path', lambda: str(tmp_path / 'absent.cfg')
+        )
+        wandb_mod = ModuleType('wandb')
+        with mock.patch('pluto.compat.wandb.apply_wandb_patches') as apply:
+            _wandb_hook._patch_or_hint(wandb_mod)
+        apply.assert_called_once_with(wandb_mod)
+
+    def test_emits_hint_when_no_credentials(self, clean_env, tmp_path, caplog):
+        clean_env.setattr(_wandb_hook, '_LOGIN_MARKER_PATH', str(tmp_path / 'absent'))
+        clean_env.setattr(
+            _wandb_hook, '_keyring_cfg_path', lambda: str(tmp_path / 'absent.cfg')
+        )
+        wandb_mod = ModuleType('wandb')
+        with caplog.at_level(logging.WARNING, logger='pluto._wandb_hook'):
+            _wandb_hook._patch_or_hint(wandb_mod)
+        assert any('no Pluto credentials' in r.message for r in caplog.records)
+
+    def test_logs_warning_when_patches_raise(self, clean_env, tmp_path, caplog):
+        clean_env.setenv('PLUTO_API_KEY', 'mlpi_test')
+        clean_env.setattr(_wandb_hook, '_LOGIN_MARKER_PATH', str(tmp_path / 'absent'))
+        clean_env.setattr(
+            _wandb_hook, '_keyring_cfg_path', lambda: str(tmp_path / 'absent.cfg')
+        )
+        wandb_mod = ModuleType('wandb')
+        with (
+            mock.patch(
+                'pluto.compat.wandb.apply_wandb_patches',
+                side_effect=RuntimeError('boom'),
+            ),
+            caplog.at_level(logging.WARNING, logger='pluto._wandb_hook'),
+        ):
+            _wandb_hook._patch_or_hint(wandb_mod)
+        assert any('Failed to apply wandb patches' in r.message for r in caplog.records)
+
+
+class TestPatchingLoader:
+    def test_exec_module_runs_real_loader_then_patches(self, clean_env, tmp_path):
+        clean_env.setenv('PLUTO_API_KEY', 'mlpi_test')
+        clean_env.setattr(_wandb_hook, '_LOGIN_MARKER_PATH', str(tmp_path / 'absent'))
+        clean_env.setattr(
+            _wandb_hook, '_keyring_cfg_path', lambda: str(tmp_path / 'absent.cfg')
+        )
+        real_loader = mock.MagicMock()
+        loader = _wandb_hook._PatchingLoader(real_loader)
+        wandb_mod = ModuleType('wandb')
+        with mock.patch('pluto.compat.wandb.apply_wandb_patches') as apply:
+            loader.exec_module(wandb_mod)
+        real_loader.exec_module.assert_called_once_with(wandb_mod)
+        apply.assert_called_once_with(wandb_mod)
+
+    def test_create_module_delegates_when_supported(self):
+        real_loader = mock.MagicMock()
+        sentinel = object()
+        real_loader.create_module.return_value = sentinel
+        loader = _wandb_hook._PatchingLoader(real_loader)
+        spec = SimpleNamespace(name='wandb')
+        assert loader.create_module(spec) is sentinel
+        real_loader.create_module.assert_called_once_with(spec)
+
+    def test_create_module_returns_none_when_real_has_no_create(self):
+        class _LoaderWithoutCreate:
+            def exec_module(self, module):
+                pass
+
+        loader = _wandb_hook._PatchingLoader(_LoaderWithoutCreate())
+        assert loader.create_module(SimpleNamespace(name='wandb')) is None
+
+
+class TestFinder:
+    def test_returns_none_for_other_modules(self):
+        finder = _wandb_hook._PlutoWandbFinder()
+        assert finder.find_spec('numpy') is None
+
+    def test_returns_none_when_re_entered(self):
+        finder = _wandb_hook._PlutoWandbFinder()
+        finder._patching = True
+        assert finder.find_spec('wandb') is None
+
+    def test_returns_none_when_real_wandb_not_findable(self):
+        finder = _wandb_hook._PlutoWandbFinder()
+        with mock.patch('importlib.util.find_spec', return_value=None):
+            assert finder.find_spec('wandb') is None
+
+    def test_returns_none_when_real_spec_has_no_loader(self):
+        finder = _wandb_hook._PlutoWandbFinder()
+        spec = SimpleNamespace(loader=None)
+        with mock.patch('importlib.util.find_spec', return_value=spec):
+            assert finder.find_spec('wandb') is None
+
+    def test_wraps_real_loader_with_patching_loader(self):
+        finder = _wandb_hook._PlutoWandbFinder()
+        real_loader = mock.MagicMock()
+        spec = SimpleNamespace(loader=real_loader)
+        with mock.patch('importlib.util.find_spec', return_value=spec):
+            wrapped = finder.find_spec('wandb')
+        assert wrapped is spec
+        assert isinstance(spec.loader, _wandb_hook._PatchingLoader)
+        assert spec.loader._real_loader is real_loader
+
+
+class TestInstall:
+    def test_registers_finder_on_meta_path(self):
+        _wandb_hook.install()
+        assert any(isinstance(f, _wandb_hook._PlutoWandbFinder) for f in sys.meta_path)
+
+    def test_idempotent(self):
+        _wandb_hook.install()
+        _wandb_hook.install()
+        _wandb_hook.install()
+        finders = [
+            f for f in sys.meta_path if isinstance(f, _wandb_hook._PlutoWandbFinder)
+        ]
+        assert len(finders) == 1
+
+    def test_already_imported_with_creds_patches_in_place(
+        self, clean_env, tmp_path, monkeypatch
+    ):
+        clean_env.setenv('PLUTO_API_KEY', 'mlpi_test')
+        clean_env.setattr(_wandb_hook, '_LOGIN_MARKER_PATH', str(tmp_path / 'absent'))
+        clean_env.setattr(
+            _wandb_hook, '_keyring_cfg_path', lambda: str(tmp_path / 'absent.cfg')
+        )
+        fake = ModuleType('wandb')
+        monkeypatch.setitem(sys.modules, 'wandb', fake)
+        with mock.patch('pluto.compat.wandb.apply_wandb_patches') as apply:
+            _wandb_hook.install()
+        apply.assert_called_once_with(fake)
+        # Finder should NOT be added when wandb is already imported.
+        assert not any(
+            isinstance(f, _wandb_hook._PlutoWandbFinder) for f in sys.meta_path
+        )
+
+    def test_already_imported_without_creds_emits_hint(
+        self, clean_env, tmp_path, monkeypatch, caplog
+    ):
+        clean_env.setattr(_wandb_hook, '_LOGIN_MARKER_PATH', str(tmp_path / 'absent'))
+        clean_env.setattr(
+            _wandb_hook, '_keyring_cfg_path', lambda: str(tmp_path / 'absent.cfg')
+        )
+        fake = ModuleType('wandb')
+        monkeypatch.setitem(sys.modules, 'wandb', fake)
+        with caplog.at_level(logging.WARNING, logger='pluto._wandb_hook'):
+            _wandb_hook.install()
+        assert any('no Pluto credentials' in r.message for r in caplog.records)
+
+
+class TestUninstall:
+    def test_removes_finder_and_resets_state(self):
+        _wandb_hook.install()
+        assert any(isinstance(f, _wandb_hook._PlutoWandbFinder) for f in sys.meta_path)
+        _wandb_hook.uninstall()
+        assert not any(
+            isinstance(f, _wandb_hook._PlutoWandbFinder) for f in sys.meta_path
+        )
+        assert _wandb_hook._hook_installed is False
+        assert _wandb_hook._hint_emitted is False

--- a/tests/test_wandb_pth_integration.py
+++ b/tests/test_wandb_pth_integration.py
@@ -72,11 +72,18 @@ def empty_home(tmp_path):
 
 
 def _run_subprocess(code: str, env_overrides: dict) -> subprocess.CompletedProcess:
-    """Run `python -c code` with PLUTO_*/WANDB_* stripped, then overrides applied."""
+    """Run `python -c code` in a clean env with overrides applied.
+
+    Strips PLUTO_*/WANDB_* (test isolation) and COVERAGE_*/PYTEST_* (so the
+    subprocess isn't a pytest-cov-instrumented child — that injection has
+    been observed to swallow logger output to the captured stderr pipe on
+    Python 3.12 in CI).
+    """
+    skip_prefixes = ('PLUTO_', 'WANDB_', 'COVERAGE_', 'PYTEST_')
     env = {
         k: v
         for k, v in os.environ.items()
-        if not k.startswith(('PLUTO_', 'WANDB_')) and k != 'DISABLE_WANDB_LOGGING'
+        if not k.startswith(skip_prefixes) and k != 'DISABLE_WANDB_LOGGING'
     }
     # Preserve any inherited PYTHONPATH so pluto/site-packages still resolves
     if 'PYTHONPATH' in env_overrides and 'PYTHONPATH' in os.environ:

--- a/tests/test_wandb_pth_integration.py
+++ b/tests/test_wandb_pth_integration.py
@@ -134,21 +134,27 @@ def test_import_wandb_emits_discoverability_hint_with_no_credentials(
     fake_wandb, empty_home
 ):
     """No credentials at all → WARNING hint, wandb left unpatched."""
+    # Diagnostic pings around `import wandb` so a CI failure tells us whether
+    # stderr capture itself is broken or whether the logger output is dropped.
     code = (
-        'import logging; '
+        'import logging, sys; '
         'logging.basicConfig(level=logging.WARNING); '
-        'import wandb; ' + _CHECK_PATCHED
+        'sys.stderr.write("DIAG-PRE\\n"); sys.stderr.flush(); '
+        'import wandb; '
+        'sys.stderr.write("DIAG-POST\\n"); sys.stderr.flush(); '
+        + _CHECK_PATCHED
     )
     result = _run_subprocess(
         code,
         {'HOME': empty_home, 'PYTHONPATH': fake_wandb},
     )
-    assert (
-        'NOT_PATCHED' in result.stdout
-    ), f'wandb should not be patched. stdout={result.stdout!r}'
-    assert (
-        'no Pluto credentials found' in result.stderr
-    ), f'discoverability hint missing. stderr={result.stderr!r}'
+    assert 'NOT_PATCHED' in result.stdout, (
+        f'wandb should not be patched. stdout={result.stdout!r} '
+        f'stderr={result.stderr!r}'
+    )
+    assert 'no Pluto credentials found' in result.stderr, (
+        f'discoverability hint missing. stderr={result.stderr!r}'
+    )
     assert 'pluto login' in result.stderr
 
 

--- a/tests/test_wandb_pth_integration.py
+++ b/tests/test_wandb_pth_integration.py
@@ -18,6 +18,7 @@ import os
 import site
 import subprocess
 import sys
+import sysconfig
 import textwrap
 
 import pytest
@@ -29,10 +30,12 @@ _CHECK_PATCHED = (
 
 
 def _pth_deployed() -> bool:
-    for d in site.getsitepackages():
-        if os.path.exists(os.path.join(d, 'zzzz_pluto_wandb_hook.pth')):
-            return True
-    return False
+    # Check both sysconfig.purelib (where dev-install.sh deploys it) and
+    # site.getsitepackages() (defensively, in case of unusual layouts).
+    candidates = [sysconfig.get_path('purelib'), *site.getsitepackages()]
+    return any(
+        os.path.exists(os.path.join(d, 'zzzz_pluto_wandb_hook.pth')) for d in candidates
+    )
 
 
 pytestmark = pytest.mark.skipif(

--- a/tests/test_wandb_pth_integration.py
+++ b/tests/test_wandb_pth_integration.py
@@ -1,0 +1,176 @@
+"""
+Integration tests for the .pth-based wandb auto-activation hook.
+
+Each test runs in a fresh subprocess so we exercise the real Python startup
+path: site.py → zzzz_pluto_wandb_hook.pth → pluto._wandb_hook.install() →
+finder on sys.meta_path → import wandb → apply_wandb_patches.
+
+These tests caught nothing in CI before they existed: the unit tests in
+test_wandb_compat.py call patched_init directly with mocks, so the .pth and
+import-hook layers were entirely uncovered. PR #85 (the original wandb
+shim) shipped without any test that would notice if the .pth stopped firing.
+
+Skipped if zzzz_pluto_wandb_hook.pth isn't deployed in site-packages — for
+editable installs that means running `bash dev-install.sh` first.
+"""
+
+import os
+import site
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+_CHECK_PATCHED = (
+    "print('PATCHED' if 'patched_init' in wandb.init.__qualname__ "
+    "else 'NOT_PATCHED')"
+)
+
+
+def _pth_deployed() -> bool:
+    for d in site.getsitepackages():
+        if os.path.exists(os.path.join(d, 'zzzz_pluto_wandb_hook.pth')):
+            return True
+    return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _pth_deployed(),
+    reason='zzzz_pluto_wandb_hook.pth not in site-packages '
+    '(run `bash dev-install.sh` for editable installs)',
+)
+
+
+@pytest.fixture
+def fake_wandb(tmp_path):
+    """A minimal wandb stand-in that satisfies apply_wandb_patches."""
+    pkg_dir = tmp_path / 'fake_pkgs'
+    pkg_dir.mkdir()
+    (pkg_dir / 'wandb.py').write_text(
+        textwrap.dedent("""
+            def init(*args, **kwargs):
+                return None
+            def log(*args, **kwargs):
+                pass
+            def finish(*args, **kwargs):
+                pass
+        """)
+    )
+    return str(pkg_dir)
+
+
+@pytest.fixture
+def empty_home(tmp_path):
+    """A clean HOME with no login marker and no keyring file."""
+    h = tmp_path / 'home'
+    h.mkdir()
+    return str(h)
+
+
+def _run_subprocess(code: str, env_overrides: dict) -> subprocess.CompletedProcess:
+    """Run `python -c code` with PLUTO_*/WANDB_* stripped, then overrides applied."""
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith(('PLUTO_', 'WANDB_')) and k != 'DISABLE_WANDB_LOGGING'
+    }
+    # Preserve any inherited PYTHONPATH so pluto/site-packages still resolves
+    if 'PYTHONPATH' in env_overrides and 'PYTHONPATH' in os.environ:
+        env_overrides['PYTHONPATH'] = (
+            env_overrides['PYTHONPATH'] + os.pathsep + os.environ['PYTHONPATH']
+        )
+    env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, '-c', code],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_pth_registers_finder_at_startup(empty_home):
+    """The .pth runs install() unconditionally; the finder must be on meta_path."""
+    code = (
+        'import sys; '
+        'names = [type(f).__name__ for f in sys.meta_path]; '
+        "print('FOUND' if '_PlutoWandbFinder' in names "
+        "else 'MISSING:' + ','.join(names))"
+    )
+    result = _run_subprocess(code, {'HOME': empty_home})
+    assert (
+        'FOUND' in result.stdout
+    ), f'finder not registered. stdout={result.stdout!r} stderr={result.stderr!r}'
+
+
+def test_import_wandb_patches_when_credentials_present(fake_wandb, empty_home):
+    """PLUTO_API_KEY in env satisfies _has_pluto_credentials → patches apply."""
+    code = 'import wandb; ' + _CHECK_PATCHED
+    result = _run_subprocess(
+        code,
+        {
+            'HOME': empty_home,
+            'PYTHONPATH': fake_wandb,
+            'PLUTO_API_KEY': 'fake-test-key',
+        },
+    )
+    assert (
+        'PATCHED' in result.stdout
+    ), f'wandb not patched. stdout={result.stdout!r} stderr={result.stderr!r}'
+
+
+def test_import_wandb_emits_discoverability_hint_with_no_credentials(
+    fake_wandb, empty_home
+):
+    """No credentials at all → WARNING hint, wandb left unpatched."""
+    code = (
+        'import logging; '
+        'logging.basicConfig(level=logging.WARNING); '
+        'import wandb; ' + _CHECK_PATCHED
+    )
+    result = _run_subprocess(
+        code,
+        {'HOME': empty_home, 'PYTHONPATH': fake_wandb},
+    )
+    assert (
+        'NOT_PATCHED' in result.stdout
+    ), f'wandb should not be patched. stdout={result.stdout!r}'
+    assert (
+        'no Pluto credentials found' in result.stderr
+    ), f'discoverability hint missing. stderr={result.stderr!r}'
+    assert 'pluto login' in result.stderr
+
+
+def test_import_wandb_emits_partial_config_warning(fake_wandb, empty_home):
+    """PLUTO_PROJECT without auth → 'config detected but no API key' WARNING."""
+    code = (
+        'import logging; '
+        'logging.basicConfig(level=logging.WARNING); '
+        'import wandb; ' + _CHECK_PATCHED
+    )
+    result = _run_subprocess(
+        code,
+        {
+            'HOME': empty_home,
+            'PYTHONPATH': fake_wandb,
+            'PLUTO_PROJECT': 'partial-project',
+        },
+    )
+    assert 'NOT_PATCHED' in result.stdout
+    assert (
+        'Pluto config detected but no API key' in result.stderr
+    ), f'partial-config warning missing. stderr={result.stderr!r}'
+
+
+def test_login_marker_satisfies_credential_check(fake_wandb, empty_home):
+    """A `pluto login` marker file alone (no env vars) should activate patches."""
+    marker_dir = os.path.join(empty_home, '.pluto')
+    os.makedirs(marker_dir)
+    open(os.path.join(marker_dir, '.login_ok'), 'w').close()
+    code = 'import wandb; ' + _CHECK_PATCHED
+    result = _run_subprocess(code, {'HOME': empty_home, 'PYTHONPATH': fake_wandb})
+    assert 'PATCHED' in result.stdout, (
+        f'login marker should activate patches. stdout={result.stdout!r} '
+        f'stderr={result.stderr!r}'
+    )

--- a/tests/test_wandb_pth_integration.py
+++ b/tests/test_wandb_pth_integration.py
@@ -134,16 +134,29 @@ def test_import_wandb_emits_discoverability_hint_with_no_credentials(
     fake_wandb, empty_home
 ):
     """No credentials at all → WARNING hint, wandb left unpatched."""
-    # Diagnostic pings around `import wandb` so a CI failure tells us whether
-    # stderr capture itself is broken or whether the logger output is dropped.
-    code = (
-        'import logging, sys; '
-        'logging.basicConfig(level=logging.WARNING); '
-        'sys.stderr.write("DIAG-PRE\\n"); sys.stderr.flush(); '
-        'import wandb; '
-        'sys.stderr.write("DIAG-POST\\n"); sys.stderr.flush(); '
-        + _CHECK_PATCHED
-    )
+    # Diagnostic dump around `import wandb` so a CI failure tells us
+    # whether stderr identity changed, whether root logger has unexpected
+    # handlers, and whether the _hint_emitted flag was already set
+    # (meaning the hint already fired during .pth execution).
+    code = textwrap.dedent("""
+        import logging, sys
+        logging.basicConfig(level=logging.WARNING)
+        sys.stderr.write(f'DIAG-PRE: stderr_id={id(sys.stderr)} '
+                         f'handlers={logging.getLogger().handlers!r}\\n')
+        sys.stderr.flush()
+        import wandb
+        from pluto import _wandb_hook as _wh
+        sys.stderr.write(
+            f'DIAG-POST: stderr_id={id(sys.stderr)} '
+            f'root_handlers={logging.getLogger().handlers!r} '
+            f'pluto_handlers={logging.getLogger("pluto").handlers!r} '
+            f'wh_handlers={logging.getLogger("pluto._wandb_hook").handlers!r} '
+            f'hint_emitted={_wh._hint_emitted} '
+            f'has_creds={_wh._has_pluto_credentials()} '
+            f'has_partial={_wh._has_partial_pluto_signal()}\\n'
+        )
+        sys.stderr.flush()
+    """).strip() + '\n' + _CHECK_PATCHED
     result = _run_subprocess(
         code,
         {'HOME': empty_home, 'PYTHONPATH': fake_wandb},

--- a/tests/test_wandb_pth_integration.py
+++ b/tests/test_wandb_pth_integration.py
@@ -116,25 +116,7 @@ def test_pth_registers_finder_at_startup(empty_home):
 
 def test_import_wandb_patches_when_credentials_present(fake_wandb, empty_home):
     """PLUTO_API_KEY in env satisfies _has_pluto_credentials → patches apply."""
-    # Same diagnostic prelude as the no-creds test so we can A/B compare:
-    # if this test gets _hint_emitted=False AND patches still apply, it
-    # means load_module isn't being called and patches happen via some
-    # other path (install() in-place patching, etc.).
-    code = textwrap.dedent("""
-        import logging, sys
-        logging.basicConfig(level=logging.WARNING)
-        import wandb
-        from pluto import _wandb_hook as _wh
-        # write to stdout so the diag shows even when the test passes
-        print(
-            f'DIAG-CREDS-POST: '
-            f'finder_in_meta={any("PlutoWandb" in type(f).__name__ for f in sys.meta_path)} '
-            f'hint_emitted={_wh._hint_emitted} '
-            f'hook_installed={_wh._hook_installed} '
-            f'has_creds={_wh._has_pluto_credentials()} '
-            f'wandb_init_qualname={wandb.init.__qualname__!r}'
-        )
-    """).strip() + '\n' + _CHECK_PATCHED
+    code = 'import wandb; ' + _CHECK_PATCHED
     result = _run_subprocess(
         code,
         {
@@ -143,50 +125,30 @@ def test_import_wandb_patches_when_credentials_present(fake_wandb, empty_home):
             'PLUTO_API_KEY': 'fake-test-key',
         },
     )
-    # Force failure so we always see the diag in CI logs
-    assert False, (
-        f'(forced) DIAG capture: stdout={result.stdout!r} stderr={result.stderr!r}'
-    )
+    assert (
+        'PATCHED' in result.stdout
+    ), f'wandb not patched. stdout={result.stdout!r} stderr={result.stderr!r}'
 
 
 def test_import_wandb_emits_discoverability_hint_with_no_credentials(
     fake_wandb, empty_home
 ):
     """No credentials at all → WARNING hint, wandb left unpatched."""
-    # Diagnostic dump around `import wandb` so a CI failure tells us
-    # whether stderr identity changed, whether root logger has unexpected
-    # handlers, and whether the _hint_emitted flag was already set
-    # (meaning the hint already fired during .pth execution).
-    code = textwrap.dedent("""
-        import logging, sys
-        logging.basicConfig(level=logging.WARNING)
-        sys.stderr.write(f'DIAG-PRE: stderr_id={id(sys.stderr)} '
-                         f'handlers={logging.getLogger().handlers!r}\\n')
-        sys.stderr.flush()
-        import wandb
-        from pluto import _wandb_hook as _wh
-        sys.stderr.write(
-            f'DIAG-POST: stderr_id={id(sys.stderr)} '
-            f'root_handlers={logging.getLogger().handlers!r} '
-            f'pluto_handlers={logging.getLogger("pluto").handlers!r} '
-            f'wh_handlers={logging.getLogger("pluto._wandb_hook").handlers!r} '
-            f'hint_emitted={_wh._hint_emitted} '
-            f'has_creds={_wh._has_pluto_credentials()} '
-            f'has_partial={_wh._has_partial_pluto_signal()}\\n'
-        )
-        sys.stderr.flush()
-    """).strip() + '\n' + _CHECK_PATCHED
+    code = (
+        'import logging; '
+        'logging.basicConfig(level=logging.WARNING); '
+        'import wandb; ' + _CHECK_PATCHED
+    )
     result = _run_subprocess(
         code,
         {'HOME': empty_home, 'PYTHONPATH': fake_wandb},
     )
-    assert 'NOT_PATCHED' in result.stdout, (
-        f'wandb should not be patched. stdout={result.stdout!r} '
-        f'stderr={result.stderr!r}'
-    )
-    assert 'no Pluto credentials found' in result.stderr, (
-        f'discoverability hint missing. stderr={result.stderr!r}'
-    )
+    assert (
+        'NOT_PATCHED' in result.stdout
+    ), f'wandb should not be patched. stdout={result.stdout!r}'
+    assert (
+        'no Pluto credentials found' in result.stderr
+    ), f'discoverability hint missing. stderr={result.stderr!r}'
     assert 'pluto login' in result.stderr
 
 

--- a/tests/test_wandb_pth_integration.py
+++ b/tests/test_wandb_pth_integration.py
@@ -116,7 +116,25 @@ def test_pth_registers_finder_at_startup(empty_home):
 
 def test_import_wandb_patches_when_credentials_present(fake_wandb, empty_home):
     """PLUTO_API_KEY in env satisfies _has_pluto_credentials → patches apply."""
-    code = 'import wandb; ' + _CHECK_PATCHED
+    # Same diagnostic prelude as the no-creds test so we can A/B compare:
+    # if this test gets _hint_emitted=False AND patches still apply, it
+    # means load_module isn't being called and patches happen via some
+    # other path (install() in-place patching, etc.).
+    code = textwrap.dedent("""
+        import logging, sys
+        logging.basicConfig(level=logging.WARNING)
+        import wandb
+        from pluto import _wandb_hook as _wh
+        # write to stdout so the diag shows even when the test passes
+        print(
+            f'DIAG-CREDS-POST: '
+            f'finder_in_meta={any("PlutoWandb" in type(f).__name__ for f in sys.meta_path)} '
+            f'hint_emitted={_wh._hint_emitted} '
+            f'hook_installed={_wh._hook_installed} '
+            f'has_creds={_wh._has_pluto_credentials()} '
+            f'wandb_init_qualname={wandb.init.__qualname__!r}'
+        )
+    """).strip() + '\n' + _CHECK_PATCHED
     result = _run_subprocess(
         code,
         {
@@ -125,9 +143,10 @@ def test_import_wandb_patches_when_credentials_present(fake_wandb, empty_home):
             'PLUTO_API_KEY': 'fake-test-key',
         },
     )
-    assert (
-        'PATCHED' in result.stdout
-    ), f'wandb not patched. stdout={result.stdout!r} stderr={result.stderr!r}'
+    # Force failure so we always see the diag in CI logs
+    assert False, (
+        f'(forced) DIAG capture: stdout={result.stdout!r} stderr={result.stderr!r}'
+    )
 
 
 def test_import_wandb_emits_discoverability_hint_with_no_credentials(

--- a/tests/test_wandb_pth_integration.py
+++ b/tests/test_wandb_pth_integration.py
@@ -74,12 +74,11 @@ def empty_home(tmp_path):
 def _run_subprocess(code: str, env_overrides: dict) -> subprocess.CompletedProcess:
     """Run `python -c code` in a clean env with overrides applied.
 
-    Strips PLUTO_*/WANDB_* (test isolation) and COVERAGE_*/PYTEST_* (so the
-    subprocess isn't a pytest-cov-instrumented child — that injection has
-    been observed to swallow logger output to the captured stderr pipe on
-    Python 3.12 in CI).
+    Strips PLUTO_*/WANDB_* for test isolation. COVERAGE_*/PYTEST_* are
+    preserved so pytest-cov instruments the subprocess and the .pth →
+    install() → _PlutoWandbFinder paths show up in coverage reports.
     """
-    skip_prefixes = ('PLUTO_', 'WANDB_', 'COVERAGE_', 'PYTEST_')
+    skip_prefixes = ('PLUTO_', 'WANDB_')
     env = {
         k: v
         for k, v in os.environ.items()

--- a/zzzz_pluto_wandb_hook.pth
+++ b/zzzz_pluto_wandb_hook.pth
@@ -1,1 +1,1 @@
-import os; _dw=os.environ.get('DISABLE_WANDB_LOGGING','').lower() in ('true','1','yes'); _k=os.environ.get('PLUTO_API_KEY') or (_dw and os.environ.get('WANDB_API_KEY')); _p=os.environ.get('PLUTO_PROJECT') or os.environ.get('WANDB_PROJECT'); _k and _p and __import__('pluto._wandb_hook')._wandb_hook.install()
+import pluto._wandb_hook; pluto._wandb_hook.install()


### PR DESCRIPTION
## Summary

The `.pth`-based wandb auto-activation only checked `PLUTO_API_KEY` and `PLUTO_PROJECT` env vars. A user who'd run `pluto login` (token in keyring) and passed `project=` only as a kwarg to `wandb.init` was invisible to the install gate, so the shim never activated. To make matters worse, every bail-out was silent — no signal that dual-logging wasn't happening, just wandb-only output.

Reproduces with:
```python
import wandb
with wandb.init(project="my-project", config={...}) as run:
    run.log({"accuracy": 0.9})
```
Pre-fix: 100% wandb output, no Pluto run created. Post-fix: dual-log works.

## Changes

**Activation logic** (`pluto/_wandb_hook.py`, `zzzz_pluto_wandb_hook.pth`)
- Drop install-time gate on `PLUTO_PROJECT` — runtime already falls back to the kwarg, `WANDB_PROJECT`, or `wandb_run.project`.
- Treat `pluto login` (keyring/marker) as a valid auth signal alongside `PLUTO_API_KEY`.
- Always install the import-hook finder; defer credential resolution until `import wandb` runs.

**Auth marker** (`pluto/auth.py`)
- `pluto login` now writes `~/.pluto/.login_ok`; `pluto logout` removes it. Cross-platform stat-only check that lets the hook detect login without importing `keyring` at every Python startup.

**Logging** (`pluto/_wandb_hook.py`, `pluto/compat/wandb.py`)
- WARNING on every bail-out (once per process):
  - No config at all → discoverability hint pointing at `pluto login` / `PLUTO_API_KEY`.
  - Partial config (e.g. `PLUTO_PROJECT` set but no auth) → specific reason.
- Upgraded the runtime "no project resolvable" log from INFO to WARNING.
- Dropped misleading "PLUTO_API_KEY always required" docstrings.

**Test coverage** (`tests/test_wandb_pth_integration.py` — new)
- 5 subprocess-based integration tests exercise the `.pth` → finder → patch flow end-to-end. Uses a fake `wandb` module on `PYTHONPATH` so it stays hermetic and fast (~2s for all 5).
- The hook layer was previously **entirely uncovered** — only `patched_init` was tested. PR #85 shipped without any test that would notice if the `.pth` stopped firing.

**CI** (`.github/workflows/pytest-smoke.yml`, `dev-install.sh`, `CLAUDE.md`)
- New `dev-install.sh` symlinks `zzzz_pluto_wandb_hook.pth` into the venv's site-packages. Needed because `poetry-core`'s editable install only emits a single `pluto_ml.pth` and doesn't copy data files — meaning the wandb auto-activation has been a no-op in CI and editable dev installs since day one.
- CI now runs `bash dev-install.sh` before pytest, so the new integration tests actually exercise the production code path.
- `CLAUDE.md` updated with the post-install step for contributors.

## Test plan

- [x] `poetry run pytest tests/test_wandb_compat.py tests/test_wandb_pth_integration.py -v` — 11/11 pass
- [x] `bash format.sh` — ruff + mypy clean
- [x] Verified `bash dev-install.sh` deploys the `.pth` and a fresh interpreter shows `_PlutoWandbFinder` on `sys.meta_path`
- [x] Verified discoverability WARNING fires once when no creds, partial-config WARNING fires when only `PLUTO_PROJECT` is set
- [ ] CI green
- [ ] Manual repro: run the user's wandb script after `pluto login` (no env vars) and confirm Pluto run appears in web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)