### PR TITLE
ci: migrate from ubuntu-latest to Ubicloud runners

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
 
     steps:
       - name: Checkout code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/mlop.yml
+++ b/.github/workflows/mlop.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     # TODO: set to trigger
     if: github.actor == 'none'
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   mypy:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/neptune-compat.yml
+++ b/.github/workflows/neptune-compat.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   neptune-compatibility:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
@@ -98,7 +98,7 @@ jobs:
           echo "Status: ${{ job.status }}"
 
   neptune-migration-examples:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -142,7 +142,7 @@ jobs:
 
   # This job serves as a status check gate
   neptune-compat-status:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     needs: [neptune-compatibility, neptune-migration-examples]
     if: always()
     steps:

--- a/.github/workflows/pypi-publish-nightly.yml
+++ b/.github/workflows/pypi-publish-nightly.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   # nightly release check from https://stackoverflow.com/a/67527144
   check-date:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
@@ -21,7 +21,7 @@ jobs:
         run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
 
   nightly-build-pypi:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     needs: check-date
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
     steps:

--- a/.github/workflows/pypi-publish-release.yml
+++ b/.github/workflows/pypi-publish-release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   release-build-pypi:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pytest-smoke.yml
+++ b/.github/workflows/pytest-smoke.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         poetry-version: ["2.1.1"]
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
 
   fork-e2e:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -120,7 +120,7 @@ jobs:
 
   distributed-tests:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
     strategy:
       matrix:
         python-version: ["3.10"]


### PR DESCRIPTION
## Summary

GitHub-hosted runners have been unreliable and slow. This swaps every `runs-on: ubuntu-latest` to an Ubicloud equivalent. Ubicloud is already configured for the org (the `k8s-multinode-test` workflow has been on `ubicloud-standard-8` for a while), so this is a pure runner swap — no infra setup needed.

## Sizing

| Tier | Spec | Jobs |
|------|------|------|
| `ubicloud-standard-2` | 2 vCPU / 8 GB | lint, mypy, docs, pypi-publish-nightly (×2), pypi-publish-release, neptune-compat-status |
| `ubicloud-standard-4` | 4 vCPU / 16 GB | mlop, neptune-compatibility, neptune-migration-examples, pytest-smoke (test, fork-e2e, distributed-tests) |
| `ubicloud-standard-8` | 8 vCPU / 32 GB | k8s-multinode-test (untouched — was already on Ubicloud) |

`standard-4` matches `ubuntu-latest`'s spec, so test jobs get a like-for-like swap. Lightweight jobs (linters, status gates, wheel builds) drop to `standard-2` for cost.

## Test plan

- [ ] CI green on this PR (every workflow that runs on PRs will exercise its new runner — lint, mypy, pytest-smoke, neptune-compat)
- [ ] Spot-check job runtimes vs the current main baseline
- [ ] Nightly publish workflow runs successfully on next schedule (or manual `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)