### PR TITLE
Remove git push from PyPI release workflow

### DIFF
--- a/.github/workflows/pypi-publish-release.yml
+++ b/.github/workflows/pypi-publish-release.yml
@@ -9,6 +9,11 @@ on:
         description: 'Version to publish (e.g. 0.1.0). Required for manual trigger.'
         required: true
 
+# Minimal token scope: the job only checks out code and publishes via
+# PYPI_TOKEN. contents:read is all that's needed; everything else off.
+permissions:
+  contents: read
+
 jobs:
   release-build-pypi:
     runs-on: ubicloud-standard-2

--- a/.github/workflows/pypi-publish-release.yml
+++ b/.github/workflows/pypi-publish-release.yml
@@ -9,10 +9,9 @@ on:
         description: 'Version to publish (e.g. 0.1.0). Required for manual trigger.'
         required: true
 
-# Minimal token scope: the job only checks out code and publishes via
-# PYPI_TOKEN. contents:read is all that's needed; everything else off.
-permissions:
-  contents: read
+# pluto is a public repo, so checkout needs no token scope and the job
+# publishes via PYPI_TOKEN. Deny the GITHUB_TOKEN everything.
+permissions: {}
 
 jobs:
   release-build-pypi:

--- a/.github/workflows/pypi-publish-release.yml
+++ b/.github/workflows/pypi-publish-release.yml
@@ -9,18 +9,13 @@ on:
         description: 'Version to publish (e.g. 0.1.0). Required for manual trigger.'
         required: true
 
-permissions:
-  contents: write
-
 jobs:
   release-build-pypi:
     runs-on: ubicloud-standard-2
     steps:
       - uses: actions/checkout@v4
         with:
-          # Fetch full history so we can push the version bump commit back
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -46,15 +41,6 @@ jobs:
           VERSION=${{ steps.version.outputs.version }}
           sed -i "0,/version = \".*\"/s//version = \"${VERSION}\"/" pyproject.toml
           sed -i "s/__version__ = '.*'/__version__ = '${VERSION}'/g" pluto/__init__.py
-
-      - name: Commit version bump to main
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml pluto/__init__.py
-          git diff --cached --quiet && echo "No version changes needed" || \
-            (git commit -m "Bump version to ${VERSION}" && git push origin main)
 
       - name: Update version placeholders for build
         run: |


### PR DESCRIPTION
## Description

This PR removes the automatic git commit and push of version bumps from the PyPI release workflow. The changes improve security and simplify the release process:

**Key changes:**
- Set `permissions: {}` to deny all GITHUB_TOKEN scopes (the job publishes via PYPI_TOKEN instead)
- Removed the `token: ${{ secrets.GITHUB_TOKEN }}` parameter from checkout (not needed for read-only access to main)
- Removed the "Commit version bump to main" step that was committing and pushing version changes back to the repository

**Rationale:**
- The repository is public, so checkout requires no token scope
- Publishing is handled via PYPI_TOKEN, not GITHUB_TOKEN
- Removing the git push step simplifies the workflow and reduces the scope of permissions needed
- Version bumps are now only applied locally during the build process

## Testing

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Manual verification of workflow syntax (no breaking changes to workflow structure)

https://claude.ai/code/session_01RgoYZ4B1CWUZBGoMx25pjb