### PR TITLE
Add wandb-style run group support to SDK

### DIFF
--- a/pluto/api.py
+++ b/pluto/api.py
@@ -46,7 +46,7 @@ def make_compat_start_v1(config, settings, info, tags=None):
         'loggerSettings': json.dumps(clean_dict(settings.to_dict())),
         'systemMetadata': json.dumps(info) if info is not None else None,
         'tags': tags if tags else None,
-        'group': getattr(settings, '_group', None) or None,
+        'group': settings._group or None,
         'createdAt': settings.compat.get('createdAt'),
         'updatedAt': settings.compat.get('updatedAt'),
     }

--- a/pluto/api.py
+++ b/pluto/api.py
@@ -46,6 +46,7 @@ def make_compat_start_v1(config, settings, info, tags=None):
         'loggerSettings': json.dumps(clean_dict(settings.to_dict())),
         'systemMetadata': json.dumps(info) if info is not None else None,
         'tags': tags if tags else None,
+        'group': getattr(settings, '_group', None) or None,
         'createdAt': settings.compat.get('createdAt'),
         'updatedAt': settings.compat.get('updatedAt'),
     }

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -718,15 +718,13 @@ def _make_patched_init(original_init, wandb_module):
                 or os.environ.get('WANDB_NOTES')
                 or getattr(wandb_run, 'notes', None)
             )
-            # WANDB_RUN_GROUP and WANDB_JOB_TYPE: wandb-specific concepts
-            # with no direct Pluto equivalent. We surface them as tags so
-            # they're searchable in the Pluto UI. These are documented at
-            # https://docs.wandb.ai/guides/track/environment-variables
+            # WANDB_RUN_GROUP maps to Pluto's native run group (forwarded to
+            # pluto.init(group=...) below). WANDB_JOB_TYPE has no direct Pluto
+            # equivalent, so we surface it as a tag so it's searchable in the
+            # Pluto UI. https://docs.wandb.ai/guides/track/environment-variables
             wandb_group = kwargs.get('group') or os.environ.get('WANDB_RUN_GROUP')
             wandb_job_type = kwargs.get('job_type') or os.environ.get('WANDB_JOB_TYPE')
             extra_tags = []
-            if wandb_group:
-                extra_tags.append(f'group:{wandb_group}')
             if wandb_job_type:
                 extra_tags.append(f'job_type:{wandb_job_type}')
             if extra_tags:
@@ -768,6 +766,8 @@ def _make_patched_init(original_init, wandb_module):
                 pluto_init_kwargs['config']['_wandb_notes'] = notes
             if tags:
                 pluto_init_kwargs['tags'] = list(tags)
+            if wandb_group:
+                pluto_init_kwargs['group'] = wandb_group
             if run_id:
                 pluto_init_kwargs['run_id'] = run_id
 

--- a/pluto/init.py
+++ b/pluto/init.py
@@ -65,6 +65,7 @@ def init(
     config: Union[dict, str, None] = None,
     settings: Union[Settings, Dict[str, Any], None] = None,
     tags: Union[str, list[str], None] = None,
+    group: Optional[str] = None,
     run_id: Optional[str] = None,
     resume: bool = False,
     fork_run_id: Optional[Union[int, str]] = None,
@@ -85,6 +86,9 @@ def init(
         config: Run configuration dict
         settings: Settings object or dict
         tags: Single tag or list of tags
+        group: Optional group name used to cluster related runs together in
+               the dashboard (e.g. all runs belonging to one sweep). Set once
+               at init; max 255 characters. Mirrors ``wandb.init(group=...)``.
         run_id: User-provided run ID for multi-node distributed training.
                 When multiple processes use the same run_id, they will all
                 log to the same run (Neptune-style resume). Can also be set
@@ -164,6 +168,10 @@ def init(
         get_char(name) if name else gen_id()
     )  # datetime.now().strftime("%Y%m%d"), str(int(time.time()))
     # settings._op_id = id if id else gen_id(seed=settings.project)
+
+    # Optional run group (wandb-style). Carried on settings into the
+    # create-run payload built by make_compat_start_v1.
+    settings._group = group
 
     # Classify run_id: display ID → resume, numeric → resume, other → externalId
     # Parameter takes precedence over environment variable (already handled in setup())

--- a/pluto/sets.py
+++ b/pluto/sets.py
@@ -56,6 +56,7 @@ class Settings:
     _fork_step: Optional[int] = None  # Step number to fork at
     _inherit_config: Optional[bool] = None  # Inherit parent config
     _inherit_tags: Optional[bool] = None  # Inherit parent tags (server default: False)
+    _group: Optional[str] = None  # wandb-style run group label (set at init)
 
     store_db: str = 'store.db'
     store_table_num: str = 'num'

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -387,8 +387,8 @@ def test_group_in_start_payload():
 def test_group_none_when_unset():
     """No group set → `group` is None (existing runs keep working).
 
-    A bare Settings() never assigns _group, so this also exercises the
-    getattr(settings, '_group', None) fallback in make_compat_start_v1.
+    A bare Settings() leaves _group at its class default of None, so the
+    payload's group field is None rather than absent.
     """
     settings = Settings()
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -374,6 +374,29 @@ def test_fork_parameters_omitted_when_none():
     assert 'inheritTags' not in payload
 
 
+def test_group_in_start_payload():
+    """A run group set on settings is forwarded as the `group` field."""
+    settings = Settings()
+    settings._group = 'my-sweep'
+
+    payload = json.loads(make_compat_start_v1({}, settings, None))
+
+    assert payload['group'] == 'my-sweep'
+
+
+def test_group_none_when_unset():
+    """No group set → `group` is None (existing runs keep working).
+
+    A bare Settings() never assigns _group, so this also exercises the
+    getattr(settings, '_group', None) fallback in make_compat_start_v1.
+    """
+    settings = Settings()
+
+    payload = json.loads(make_compat_start_v1({}, settings, None))
+
+    assert payload['group'] is None
+
+
 def test_fork_resolve_int():
     """Resolve fork_run_id passes through int unchanged."""
     assert _resolve_fork_run_id(12345, 'proj') == 12345

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -193,6 +193,67 @@ def test_no_project_anywhere_skips_pluto_init(clean_env):
     assert result is wandb_run
 
 
+def test_group_forwarded_natively(clean_env):
+    """wandb's group= maps to Pluto's native group= param, not a tag.
+
+    Before run groups existed in Pluto, the shim surfaced a wandb group as a
+    `group:<name>` tag. Now that pluto.init() has a real group parameter, the
+    group must be forwarded natively and must NOT leak back in as a tag.
+    """
+    fake_pluto = MagicMock()
+    fake_pluto.init.return_value = MagicMock(id=42)
+    wandb_run = _make_fake_wandb_run()
+
+    _, forwarded = _invoke_patched_init(
+        wandb_run, fake_pluto, {'project': 'p', 'group': 'my-sweep'}
+    )
+
+    assert forwarded is not None, 'pluto.init should have been called'
+    assert forwarded.get('group') == 'my-sweep'
+    assert 'group:my-sweep' not in (forwarded.get('tags') or [])
+
+
+def test_group_from_wandb_run_group_env(clean_env, monkeypatch):
+    """WANDB_RUN_GROUP maps to the native group= param when no kwarg is given."""
+    monkeypatch.setenv('WANDB_RUN_GROUP', 'env-sweep')
+
+    fake_pluto = MagicMock()
+    fake_pluto.init.return_value = MagicMock(id=42)
+    wandb_run = _make_fake_wandb_run()
+
+    _, forwarded = _invoke_patched_init(wandb_run, fake_pluto, {'project': 'p'})
+
+    assert forwarded is not None, 'pluto.init should have been called'
+    assert forwarded.get('group') == 'env-sweep'
+
+
+def test_job_type_stays_a_tag_and_is_not_a_group(clean_env):
+    """job_type has no Pluto equivalent → still a tag, never a group."""
+    fake_pluto = MagicMock()
+    fake_pluto.init.return_value = MagicMock(id=42)
+    wandb_run = _make_fake_wandb_run()
+
+    _, forwarded = _invoke_patched_init(
+        wandb_run, fake_pluto, {'project': 'p', 'job_type': 'eval'}
+    )
+
+    assert forwarded is not None, 'pluto.init should have been called'
+    assert 'job_type:eval' in (forwarded.get('tags') or [])
+    assert 'group' not in forwarded
+
+
+def test_no_group_means_no_group_kwarg(clean_env):
+    """When no group is given anywhere, group= is not forwarded to pluto.init."""
+    fake_pluto = MagicMock()
+    fake_pluto.init.return_value = MagicMock(id=42)
+    wandb_run = _make_fake_wandb_run()
+
+    _, forwarded = _invoke_patched_init(wandb_run, fake_pluto, {'project': 'p'})
+
+    assert forwarded is not None, 'pluto.init should have been called'
+    assert 'group' not in forwarded
+
+
 def test_omegaconf_config_flows_through_shim_and_serializes(clean_env, monkeypatch):
     """End-to-end shape of the real report: a Hydra user calls
     ``wandb.init(config=dict(OmegaConf.load(...)))``.


### PR DESCRIPTION
## Summary

Surfaces a `group` parameter on `pluto.init()` and forwards it into the create-run payload, mirroring `wandb.init(group=...)`. This is the SDK follow-up to [server-private#483](https://github.com/Trainy-ai/server-private/pull/483), which added the `Runs.group` column and made `POST /api/runs/create` accept a `group` field.

A group is a single optional string label on a run; runs sharing a label are clustered together in the dashboard (e.g. all runs in one sweep). Set once at init, like wandb.

```python
pluto.init(project="my-proj", group="resnet-sweep")
```

## Changes

- **`pluto/init.py`** — new `group: Optional[str] = None` param on `init()`, stored on `settings._group`.
- **`pluto/api.py`** — include `group` in the `make_compat_start_v1` create-run payload (next to `tags`).
- **`pluto/compat/wandb.py`** — forward wandb's `group=` / `WANDB_RUN_GROUP` to the **native** `group=` param. Previously the shim had no Pluto equivalent and surfaced it as a `group:<name>` tag; that workaround is removed. `job_type` still becomes a tag (no Pluto equivalent).
- **tests** — `test_basic.py`: payload includes group / is `None` when unset. `test_wandb_compat.py`: shim forwards group natively, from env var, keeps `job_type` as a tag, and omits group when unset.

## Behavior change to note

wandb users who previously got a `group:<name>` **tag** will now get a real Pluto **group** instead. This is the intended upgrade, but flagging it in case anything downstream keyed off that tag.

## Test plan

- `pytest tests/test_basic.py -k group tests/test_wandb_compat.py` — 6 new tests pass; full `test_wandb_compat.py` is 12/12.
- `ruff check` + `ruff format --check` (pinned 0.4.10) clean on all touched files.
- **Verified live** against a dev backend running #483: `pluto.init(..., group="sweep-alpha")` created a run and `runs.group` persisted `sweep-alpha` in Postgres.

## Not included (deliberately)

- No dynamic `run.set_group()` (changing group mid-run). wandb is init-only too; can add later via `POST /api/runs/group/update` if needed.
- Docs: the wandb-migration guide lives outside this repo (docs.trainy.ai) and should be updated separately to map `wandb.init(group=...)` → `pluto.init(group=...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and payload field with tests; the only migration note is wandb users losing the old `group:<name>` tag in favor of native grouping.
> 
> **Overview**
> Adds **wandb-style run grouping** to the SDK: `pluto.init(..., group="...")` stores the label on `settings._group` and **`make_compat_start_v1`** sends it as `group` on create-run (alongside `tags`).
> 
> The **wandb compat shim** no longer encodes `group` / `WANDB_RUN_GROUP` as a `group:<name>` tag; it forwards them to native `group=`. **`job_type`** still becomes a `job_type:...` tag. Unset group stays **`null`** in the payload so older runs are unchanged.
> 
> **Behavior change:** wandb migrations that relied on the `group:<name>` tag now get a real Pluto group instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51de008fc106ef03208e14a2005e6b0d17e7d405. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->