### PR TITLE
Fix SQLite WAL locking on network filesystems with jittered backoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,9 +304,34 @@ Environment variables use the `PLUTO_*` prefix. The old `MLOP_*` prefix is suppo
 **Configuration:**
 - `PLUTO_DEBUG_LEVEL` - Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 - `PLUTO_URL_APP`, `PLUTO_URL_API`, `PLUTO_URL_INGEST`, `PLUTO_URL_PY` - Server URLs
+- `PLUTO_DIR` - Staging directory for local state, including the WAL-mode sync
+  SQLite DB (alternative to `pluto.init(dir="...")`). Point this at node-local
+  storage when the working directory is on a network filesystem — see
+  "Network filesystems" below.
 
 **Deprecated (still supported with warnings):**
-- `MLOP_API_TOKEN`, `MLOP_PROJECT`, `MLOP_DEBUG_LEVEL`, `MLOP_URL_*`
+- `MLOP_API_TOKEN`, `MLOP_PROJECT`, `MLOP_DEBUG_LEVEL`, `MLOP_URL_*`, `MLOP_DIR`
+
+### Network Filesystems (NFS/Lustre/SMB) and SQLite WAL
+
+The sync DB uses SQLite WAL mode (`pluto/sync/store.py`), which relies on POSIX
+byte-range locking plus a shared `-shm` mmap. These don't work reliably on
+network filesystems, where the lock handoff degrades into `SQLITE_PROTOCOL`
+("locking protocol") races — surfacing as repeated `Transient SQLite error
+(will retry): locking protocol` warnings and badly throttled logging.
+
+- **Fix:** put the staging dir on node-local disk via `pluto.init(dir=...)` or
+  `PLUTO_DIR` (e.g. `/tmp`, node-local NVMe). `init()` emits a one-time warning
+  (Linux-only, best-effort) when it detects the staging dir on a network mount;
+  detection lives in `pluto/_fs.py` (`is_network_fs` / `get_fs_type`, parsed
+  from `/proc/self/mountinfo`).
+- **Resilience:** `_retry_on_locked` (`pluto/sync/store.py`) treats `locked`,
+  `locking protocol`, and `busy` as transient and retries with bounded
+  exponential backoff *plus jitter* (jitter avoids the training and sync
+  processes backing off in lockstep). `busy_timeout` is kept short
+  (`DEFAULT_BUSY_TIMEOUT_MS`) on purpose: it sits *under* the app-level retry,
+  so a long timeout stacks per attempt and stalls writes (this stacking is what
+  caused a ~50s/batch regression).
 
 ### Testing Notes
 - Tests run against production server by default

--- a/pluto/_fs.py
+++ b/pluto/_fs.py
@@ -1,0 +1,85 @@
+"""Filesystem detection helpers.
+
+Pluto stages local state — most importantly the WAL-mode SQLite database used
+to hand data from the training process to the sync process — under the run
+directory. SQLite's WAL locking relies on POSIX byte-range locks plus a shared
+-shm mmap, neither of which behaves reliably on network filesystems (NFS,
+Lustre, SMB/CIFS, ...). On those mounts the lock handoff degrades into
+SQLITE_PROTOCOL ("locking protocol") races that show up as repeated lock
+retries and can badly throttle logging.
+
+These helpers let `init()` detect that situation up front and tell the user to
+point the staging dir (``pluto.init(dir=...)`` / ``PLUTO_DIR``) at node-local
+storage. Detection is best-effort and Linux-only — on any other platform, or if
+the mount table can't be read, we return ``None``/``False`` and stay silent
+rather than risk a false alarm.
+"""
+
+import os
+from typing import Optional
+
+# Filesystem type prefixes (as reported in /proc/self/mountinfo) whose locking
+# semantics are unreliable for WAL-mode SQLite. Matched as prefixes so that
+# e.g. both "nfs" and "nfs4", or "fuse.sshfs", are covered.
+_NETWORK_FS_PREFIXES = (
+    'nfs',
+    'cifs',
+    'smb',
+    'lustre',
+    'gpfs',
+    'ceph',
+    'glusterfs',
+    'afs',
+    'ncpfs',
+    'fuse.sshfs',
+    'fuse.glusterfs',
+    'beegfs',
+)
+
+
+def get_fs_type(path: str) -> Optional[str]:
+    """Return the filesystem type backing ``path``, or ``None`` if unknown.
+
+    Linux-only: reads ``/proc/self/mountinfo`` and returns the type of the
+    most specific (longest) mount point that is a prefix of ``path``. The path
+    need not exist yet — matching is done on the resolved path string, so a
+    not-yet-created run directory still resolves to its parent mount. Returns
+    ``None`` on non-Linux platforms or if the mount table can't be parsed.
+    """
+    try:
+        target = os.path.realpath(path)
+        best_mount = ''
+        best_type: Optional[str] = None
+        with open('/proc/self/mountinfo', 'r') as f:
+            for line in f:
+                # Format: "<id> <pid> <maj:min> <root> <mountpoint> <opts> \
+                #          [optional fields] - <fstype> <source> <superopts>"
+                left, sep, right = line.partition(' - ')
+                if not sep:
+                    continue
+                left_fields = left.split()
+                right_fields = right.split()
+                if len(left_fields) < 5 or not right_fields:
+                    continue
+                mount_point = left_fields[4]
+                fstype = right_fields[0]
+                # Longest mount point that is a path-prefix of target wins.
+                if target == mount_point or target.startswith(
+                    mount_point.rstrip('/') + '/'
+                ):
+                    if len(mount_point) >= len(best_mount):
+                        best_mount = mount_point
+                        best_type = fstype
+        return best_type
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def is_network_fs(path: str) -> bool:
+    """True if ``path`` appears to live on a network filesystem.
+
+    Best-effort and conservative: returns ``False`` when the filesystem type
+    can't be determined (e.g. non-Linux), so callers never warn spuriously.
+    """
+    fstype = get_fs_type(path)
+    return fstype is not None and fstype.lower().startswith(_NETWORK_FS_PREFIXES)

--- a/pluto/_fs.py
+++ b/pluto/_fs.py
@@ -16,7 +16,18 @@ rather than risk a false alarm.
 """
 
 import os
+import re
 from typing import Optional
+
+# /proc/self/mountinfo escapes space, tab, newline and backslash in paths and
+# fstypes as octal sequences (\040, \011, \012, \134). Decode them so prefix
+# matching works for mount points that contain such characters.
+_OCTAL_ESCAPE = re.compile(r'\\([0-7]{3})')
+
+
+def _unescape_mountinfo(field: str) -> str:
+    return _OCTAL_ESCAPE.sub(lambda m: chr(int(m.group(1), 8)), field)
+
 
 # Filesystem type prefixes (as reported in /proc/self/mountinfo) whose locking
 # semantics are unreliable for WAL-mode SQLite. Matched as prefixes so that
@@ -61,8 +72,8 @@ def get_fs_type(path: str) -> Optional[str]:
                 right_fields = right.split()
                 if len(left_fields) < 5 or not right_fields:
                     continue
-                mount_point = left_fields[4]
-                fstype = right_fields[0]
+                mount_point = _unescape_mountinfo(left_fields[4])
+                fstype = _unescape_mountinfo(right_fields[0])
                 # Longest mount point that is a path-prefix of target wins.
                 if target == mount_point or target.startswith(
                     mount_point.rstrip('/') + '/'

--- a/pluto/init.py
+++ b/pluto/init.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional, Union
 import pluto
 
 from . import sentry as _sentry
+from ._fs import get_fs_type, is_network_fs
 from .op import Op
 from .sets import Settings, _classify_run_id, _is_display_id, setup
 from .util import deep_merge, gen_id, get_char, to_native_config
@@ -56,6 +57,35 @@ class OpInit:
 
     def setup(self, settings) -> None:
         self.settings = settings
+
+
+def _warn_if_network_staging_dir(settings: Settings) -> None:
+    """Warn once if the sync DB will live on a network filesystem.
+
+    WAL-mode SQLite locking is unreliable on NFS/Lustre/SMB and degrades into
+    "locking protocol" retries that throttle logging. Detection is best-effort
+    and Linux-only; on other platforms this is a no-op (see pluto/_fs.py).
+    """
+    # The sync DB lives under settings.dir unless explicitly overridden.
+    db_path = settings.sync_process_db_path
+    staging_dir = os.path.dirname(db_path) if db_path else settings.dir
+    try:
+        if not is_network_fs(staging_dir):
+            return
+        fstype = get_fs_type(staging_dir) or 'network'
+        logger.warning(
+            '%s: pluto staging directory %r is on a network filesystem (%s). '
+            'WAL-mode SQLite locking is unreliable there and can cause '
+            '"locking protocol" retries that slow down logging. Point it at '
+            'node-local storage via pluto.init(dir=...) or the PLUTO_DIR '
+            'environment variable (e.g. /tmp).',
+            tag,
+            staging_dir,
+            fstype,
+        )
+    except Exception as e:
+        # Detection must never break init().
+        logger.debug('%s: network-fs check skipped: %s', tag, e)
 
 
 def init(
@@ -159,6 +189,7 @@ def init(
 
     settings = setup(settings)
     settings.dir = dir if dir else settings.dir
+    _warn_if_network_staging_dir(settings)
     settings.project = get_char(project) if project else settings.project
     settings._op_name = (
         get_char(name) if name else gen_id()

--- a/pluto/init.py
+++ b/pluto/init.py
@@ -66,9 +66,10 @@ def _warn_if_network_staging_dir(settings: Settings) -> None:
     "locking protocol" retries that throttle logging. Detection is best-effort
     and Linux-only; on other platforms this is a no-op (see pluto/_fs.py).
     """
-    # The sync DB lives under settings.dir unless explicitly overridden.
+    # The sync DB lives under the run dir (settings.get_dir()) unless an
+    # explicit path override is set.
     db_path = settings.sync_process_db_path
-    staging_dir = os.path.dirname(db_path) if db_path else settings.dir
+    staging_dir = os.path.dirname(db_path) if db_path else settings.get_dir()
     try:
         if not is_network_fs(staging_dir):
             return
@@ -189,12 +190,15 @@ def init(
 
     settings = setup(settings)
     settings.dir = dir if dir else settings.dir
-    _warn_if_network_staging_dir(settings)
     settings.project = get_char(project) if project else settings.project
     settings._op_name = (
         get_char(name) if name else gen_id()
     )  # datetime.now().strftime("%Y%m%d"), str(int(time.time()))
     # settings._op_id = id if id else gen_id(seed=settings.project)
+
+    # Warn (once) if the sync DB will live on a network filesystem. Done after
+    # project/_op_name are set so get_dir() resolves the real run directory.
+    _warn_if_network_staging_dir(settings)
 
     # Classify run_id: display ID → resume, numeric → resume, other → externalId
     # Parameter takes precedence over environment variable (already handled in setup())

--- a/pluto/sets.py
+++ b/pluto/sets.py
@@ -304,6 +304,16 @@ def setup(settings: Union[Settings, Dict[str, Any], None] = None) -> Settings:
     if env_project is not None and 'project' not in settings_dict:
         new_settings.project = env_project
 
+    # Read PLUTO_DIR environment variable (with MLOP_DIR fallback)
+    # Controls where pluto stages local state, including the WAL-mode SQLite
+    # sync DB. Point this at node-local storage when the working directory is on
+    # a network filesystem (NFS/Lustre/SMB) — WAL locking is unreliable there
+    # and degrades into "locking protocol" retries (see pluto/sync/store.py).
+    # Only apply if not already set via function parameters.
+    env_dir = _get_env_with_deprecation('PLUTO_DIR', 'MLOP_DIR')
+    if env_dir is not None and 'dir' not in settings_dict:
+        new_settings.dir = os.path.abspath(os.path.expanduser(env_dir))
+
     # Read PLUTO_THREAD_JOIN_TIMEOUT_SECONDS environment variable
     # Only apply if not already set via function parameters
     env_timeout = _get_env_with_deprecation(

--- a/pluto/sync/store.py
+++ b/pluto/sync/store.py
@@ -331,6 +331,7 @@ class SyncStore:
 
             self.conn.commit()
 
+    @_retry_on_locked
     def register_run(
         self,
         run_id: str,
@@ -371,6 +372,7 @@ class SyncStore:
             )
         self._record_write(start)
 
+    @_retry_on_locked
     def mark_run_finished(self, run_id: str) -> None:
         """Mark a run as finished (training complete, flush pending)."""
         with self._lock:
@@ -383,6 +385,7 @@ class SyncStore:
                 (time.time(), run_id),
             )
 
+    @_retry_on_locked
     def mark_run_synced(self, run_id: str) -> None:
         """Mark a run as fully synced (all data uploaded)."""
         with self._lock:
@@ -802,6 +805,7 @@ class SyncStore:
                 params,
             )
 
+    @_retry_on_locked
     def update_file_presigned_url(self, file_id: int, url: str) -> None:
         """Store presigned URL for a file."""
         with self._lock:

--- a/pluto/sync/store.py
+++ b/pluto/sync/store.py
@@ -9,6 +9,7 @@ SIGKILL, and other failure modes.
 import json
 import logging
 import os
+import random
 import sqlite3
 import threading
 import time
@@ -41,9 +42,30 @@ HEALTH_METRIC_KEYS = [
     'retry_failures',
 ]
 
-# Default number of retries for transient SQLite errors (database is locked)
-_SQLITE_RETRY_COUNT = 5
-_SQLITE_RETRY_BASE_DELAY = 0.1  # seconds
+# Bounded exponential backoff for transient SQLite errors under concurrent
+# access. Delays grow as base * 2**attempt but are capped at MAX_DELAY, and we
+# sleep a *jittered* fraction of that window ("full jitter"). Jitter matters
+# because the training process and the sync process retry independently against
+# the same DB — without it they back off in lockstep and keep colliding.
+_SQLITE_RETRY_COUNT = 6
+_SQLITE_RETRY_BASE_DELAY = 0.05  # seconds
+_SQLITE_RETRY_MAX_DELAY = 1.0  # cap on a single backoff sleep
+
+# Substrings (lowercased) that mark a sqlite3.OperationalError as transient and
+# therefore safe to retry rather than surface:
+#   "database is locked"        -> SQLITE_BUSY   (another connection holds a lock)
+#   "database table is locked"  -> SQLITE_LOCKED (table-level contention)
+#   "database is busy"          -> SQLITE_BUSY variants
+#   "locking protocol"          -> SQLITE_PROTOCOL (WAL lock-handoff race; shows
+#                                  up on slow/network filesystems like NFS where
+#                                  POSIX locking degrades). Previously this fell
+#                                  through the 'locked' check and was re-raised,
+#                                  dropping the record and logging on every hit.
+_TRANSIENT_SQLITE_SUBSTRINGS = (
+    'locked',
+    'locking protocol',
+    'database is busy',
+)
 
 # Global counters for observability — tracks cumulative retry/failure stats
 # across the process lifetime without any thread-safety overhead (GIL-protected).
@@ -53,8 +75,19 @@ _retry_stats = {
 }
 
 
+def _is_transient_sqlite_error(error: sqlite3.OperationalError) -> bool:
+    """True if the error is transient lock contention that's safe to retry."""
+    message = str(error).lower()
+    return any(sub in message for sub in _TRANSIENT_SQLITE_SUBSTRINGS)
+
+
 def _retry_on_locked(func: F) -> F:
-    """Retry a method on sqlite3.OperationalError (database is locked)."""
+    """Retry a method on transient sqlite3.OperationalError (lock contention).
+
+    Uses bounded exponential backoff with full jitter. Non-transient
+    OperationalErrors (e.g. malformed SQL, schema errors) are re-raised
+    immediately rather than retried.
+    """
 
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -63,16 +96,20 @@ def _retry_on_locked(func: F) -> F:
             try:
                 return func(*args, **kwargs)
             except sqlite3.OperationalError as e:
-                if 'locked' not in str(e).lower():
+                if not _is_transient_sqlite_error(e):
                     raise
                 last_error = e
                 _retry_stats['total_retries'] += 1
-                delay = _SQLITE_RETRY_BASE_DELAY * (2**attempt)
+                window = min(
+                    _SQLITE_RETRY_MAX_DELAY, _SQLITE_RETRY_BASE_DELAY * (2**attempt)
+                )
+                delay = random.uniform(0, window)
                 logger.debug(
-                    '%s: %s retrying after "database is locked" '
-                    '(attempt %d/%d, wait %.1fs)',
+                    '%s: %s retrying after transient SQLite error "%s" '
+                    '(attempt %d/%d, wait %.3fs)',
                     tag,
                     func.__name__,
+                    e,
                     attempt + 1,
                     _SQLITE_RETRY_COUNT,
                     delay,
@@ -158,13 +195,23 @@ class SyncStore:
 
     SCHEMA_VERSION = 1
 
+    # SQLite's own busy handler wait. Kept deliberately short because we layer
+    # application-level exponential backoff (see _retry_on_locked) on top: a
+    # long busy_timeout stacks *under* every retry attempt, so e.g. a 30s
+    # timeout x N retries can stall a single write into tens of seconds. That
+    # stacking is what throttled training to ~50s/batch on NFS. With a short
+    # timeout, control returns to the jittered backoff loop quickly instead.
+    DEFAULT_BUSY_TIMEOUT_MS = 5000
+
     def __init__(
         self,
         db_path: str,
         parent_pid: Optional[int] = None,
+        busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
     ) -> None:
         self.db_path = db_path
         self.parent_pid = parent_pid
+        self.busy_timeout_ms = busy_timeout_ms
         self._lock = threading.Lock()
 
         # Write latency tracking (running stats, no memory growth)
@@ -183,7 +230,7 @@ class SyncStore:
         )
         self.conn.execute('PRAGMA journal_mode=WAL')
         self.conn.execute('PRAGMA synchronous=NORMAL')  # Good balance of safety/speed
-        self.conn.execute('PRAGMA busy_timeout=30000')  # Wait up to 30s for locks
+        self.conn.execute(f'PRAGMA busy_timeout={int(self.busy_timeout_ms)}')
         self.conn.row_factory = sqlite3.Row
 
         self._init_schema()

--- a/tests/test_database_locking.py
+++ b/tests/test_database_locking.py
@@ -24,9 +24,58 @@ from pluto.sync.store import (
     HEALTH_METRIC_KEYS,
     RecordType,
     SyncStore,
+    _is_transient_sqlite_error,
     _retry_on_locked,
     _retry_stats,
 )
+
+
+class TestTransientErrorClassification:
+    """Which sqlite3.OperationalErrors are treated as retryable."""
+
+    @pytest.mark.parametrize(
+        'message',
+        [
+            'database is locked',
+            'database table is locked',
+            'database is busy',
+            'locking protocol',  # SQLITE_PROTOCOL — the NFS/WAL race
+            'LOCKING PROTOCOL',  # case-insensitive
+        ],
+    )
+    def test_transient_errors_are_retryable(self, message):
+        assert _is_transient_sqlite_error(sqlite3.OperationalError(message))
+
+    @pytest.mark.parametrize(
+        'message',
+        [
+            'disk I/O error',
+            'no such table: sync_queue',
+            'malformed database schema',
+        ],
+    )
+    def test_non_transient_errors_are_not_retryable(self, message):
+        assert not _is_transient_sqlite_error(sqlite3.OperationalError(message))
+
+    def test_locking_protocol_is_retried(self):
+        """A 'locking protocol' error retries instead of being re-raised.
+
+        Regression: this SQLITE_PROTOCOL message lacks the substring 'locked',
+        so it previously fell through the retry check and was dropped on the
+        first hit.
+        """
+        call_count = 0
+
+        @_retry_on_locked
+        def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise sqlite3.OperationalError('locking protocol')
+            return 'ok'
+
+        assert func() == 'ok'
+        assert call_count == 3
 
 
 class TestRetryOnLockedDecorator:
@@ -255,11 +304,25 @@ class TestSyncStoreRetryBehavior:
 
         store.close()
 
-    def test_busy_timeout_is_30_seconds(self, store):
-        """Verify busy_timeout is set to 30000ms."""
+    def test_busy_timeout_default(self, store):
+        """busy_timeout defaults to the (short) DEFAULT_BUSY_TIMEOUT_MS.
+
+        It's kept short on purpose: application-level exponential backoff
+        (@_retry_on_locked) sits on top, so a long SQLite busy_timeout just
+        stacks under every retry and stalls writes (the ~50s/batch regression).
+        """
         cursor = store.conn.execute('PRAGMA busy_timeout')
         timeout = cursor.fetchone()[0]
-        assert timeout == 30000
+        assert timeout == SyncStore.DEFAULT_BUSY_TIMEOUT_MS
+
+    def test_busy_timeout_is_configurable(self, tmp_path):
+        """busy_timeout can be overridden via the constructor."""
+        store = SyncStore(str(tmp_path / 'bt.db'), busy_timeout_ms=1234)
+        try:
+            timeout = store.conn.execute('PRAGMA busy_timeout').fetchone()[0]
+            assert timeout == 1234
+        finally:
+            store.close()
 
 
 class TestConcurrentWriteContention:

--- a/tests/test_env_vars.py
+++ b/tests/test_env_vars.py
@@ -247,3 +247,44 @@ class TestPLUTOThreadJoinTimeout:
                 for warning in w
             )
         del os.environ['MLOP_THREAD_JOIN_TIMEOUT_SECONDS']
+
+
+class TestPLUTODir:
+    def test_pluto_dir_sets_staging_dir(self):
+        """PLUTO_DIR overrides the default staging dir."""
+        os.environ['PLUTO_DIR'] = '/tmp/pluto-staging'
+        try:
+            settings = setup()
+            assert settings.dir == '/tmp/pluto-staging'
+        finally:
+            del os.environ['PLUTO_DIR']
+
+    def test_pluto_dir_expands_user(self):
+        """PLUTO_DIR expands ~ and resolves to an absolute path."""
+        os.environ['PLUTO_DIR'] = '~/pluto-runs'
+        try:
+            settings = setup()
+            assert settings.dir == os.path.abspath(os.path.expanduser('~/pluto-runs'))
+        finally:
+            del os.environ['PLUTO_DIR']
+
+    def test_param_overrides_pluto_dir(self):
+        """An explicit 'dir' in settings wins over the env var."""
+        os.environ['PLUTO_DIR'] = '/tmp/from-env'
+        try:
+            settings = setup({'dir': '/tmp/from-param'})
+            assert settings.dir == '/tmp/from-param'
+        finally:
+            del os.environ['PLUTO_DIR']
+
+    def test_deprecated_mlop_dir(self):
+        """Deprecated MLOP_DIR still works with a deprecation warning."""
+        os.environ['MLOP_DIR'] = '/tmp/mlop-staging'
+        try:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                settings = setup()
+                assert settings.dir == '/tmp/mlop-staging'
+                assert any('MLOP_DIR' in str(warning.message) for warning in w)
+        finally:
+            del os.environ['MLOP_DIR']

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,0 +1,63 @@
+"""Tests for network-filesystem detection (pluto/_fs.py)."""
+
+from unittest.mock import mock_open, patch
+
+from pluto._fs import get_fs_type, is_network_fs
+
+# A representative /proc/self/mountinfo with a local root and an NFS mount.
+_MOUNTINFO = (
+    '21 1 0:20 / / rw,relatime shared:1 - ext4 /dev/root rw\n'
+    '30 21 0:26 / /home rw,relatime shared:2 - ext4 /dev/sda1 rw\n'
+    '47 21 0:42 / /mnt/nfs rw,relatime shared:3 - nfs4 server:/export rw\n'
+    '55 47 0:42 / /mnt/nfs/sub rw,relatime shared:4 - nfs4 server:/export/sub rw\n'
+)
+
+
+def _patched(path, mountinfo=_MOUNTINFO):
+    """Run get_fs_type(path) against a mocked mountinfo, with realpath identity."""
+    with patch('pluto._fs.open', mock_open(read_data=mountinfo)):
+        with patch('os.path.realpath', side_effect=lambda p: p):
+            return get_fs_type(path)
+
+
+class TestGetFsType:
+    def test_local_path(self):
+        assert _patched('/home/user/run') == 'ext4'
+
+    def test_root_path(self):
+        assert _patched('/var/tmp/x') == 'ext4'
+
+    def test_nfs_path(self):
+        assert _patched('/mnt/nfs/project/run') == 'nfs4'
+
+    def test_longest_mount_wins(self):
+        # /mnt/nfs/sub is more specific than /mnt/nfs; both are nfs4 here, but
+        # the match must resolve to the nested mount, not the parent.
+        assert _patched('/mnt/nfs/sub/run') == 'nfs4'
+
+    def test_nonexistent_mountinfo_returns_none(self):
+        with patch('pluto._fs.open', side_effect=OSError):
+            assert get_fs_type('/whatever') is None
+
+
+class TestIsNetworkFs:
+    def test_local_is_not_network(self):
+        with patch('pluto._fs.get_fs_type', return_value='ext4'):
+            assert is_network_fs('/home/user') is False
+
+    def test_nfs_is_network(self):
+        with patch('pluto._fs.get_fs_type', return_value='nfs4'):
+            assert is_network_fs('/mnt/nfs') is True
+
+    def test_lustre_is_network(self):
+        with patch('pluto._fs.get_fs_type', return_value='lustre'):
+            assert is_network_fs('/scratch') is True
+
+    def test_fuse_sshfs_is_network(self):
+        with patch('pluto._fs.get_fs_type', return_value='fuse.sshfs'):
+            assert is_network_fs('/remote') is True
+
+    def test_unknown_fs_is_not_network(self):
+        # Undeterminable (e.g. non-Linux) must not warn.
+        with patch('pluto._fs.get_fs_type', return_value=None):
+            assert is_network_fs('/anything') is False

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -39,6 +39,14 @@ class TestGetFsType:
         with patch('pluto._fs.open', side_effect=OSError):
             assert get_fs_type('/whatever') is None
 
+    def test_octal_escaped_mount_point(self):
+        # mountinfo escapes spaces as \040; a path with a space must still match.
+        mountinfo = (
+            '21 1 0:20 / / rw - ext4 /dev/root rw\n'
+            '47 21 0:42 / /mnt/my\\040share rw - nfs4 server:/export rw\n'
+        )
+        assert _patched('/mnt/my share/run', mountinfo) == 'nfs4'
+
 
 class TestIsNetworkFs:
     def test_local_is_not_network(self):


### PR DESCRIPTION
## Summary

This PR addresses a critical performance regression where logging on network filesystems (NFS, Lustre, SMB) was throttled to ~50s/batch due to unreliable SQLite WAL locking. The fix involves three key improvements:

1. **Network filesystem detection** (`pluto/_fs.py`): New module that detects when the staging directory is on a network mount by parsing `/proc/self/mountinfo` (Linux-only, best-effort). `pluto.init()` now warns users to point `PLUTO_DIR` at node-local storage.

2. **Transient error classification** (`pluto/sync/store.py`): Extended retry logic to recognize `SQLITE_PROTOCOL` ("locking protocol") errors as transient and retryable. Previously these fell through the `'locked'` substring check and were re-raised, dropping records on every hit.

3. **Jittered exponential backoff** (`pluto/sync/store.py`): Replaced fixed delays with bounded exponential backoff (`base * 2**attempt`, capped at 1s) plus full jitter. This prevents the training and sync processes from backing off in lockstep and repeatedly colliding on the same lock. Also reduced `busy_timeout` from 30s to 5s (configurable) to avoid stacking delays under the application-level retry loop.

## Changes

### New Files
- **`pluto/_fs.py`**: Filesystem type detection via `/proc/self/mountinfo`. Exports `get_fs_type(path)` and `is_network_fs(path)`.
- **`tests/test_fs.py`**: Unit tests for filesystem detection with mocked mountinfo.

### Modified Files
- **`pluto/init.py`**: Added `_warn_if_network_staging_dir()` to emit a one-time warning when the staging directory is detected on a network filesystem.
- **`pluto/sets.py`**: Added support for `PLUTO_DIR` environment variable (with deprecated `MLOP_DIR` fallback) to override the staging directory.
- **`pluto/sync/store.py`**:
  - New `_is_transient_sqlite_error()` function to classify errors as transient (checks for `'locked'`, `'locking protocol'`, `'database is busy'`).
  - Updated `_retry_on_locked` decorator to use jittered exponential backoff instead of fixed delays.
  - Made `busy_timeout` configurable via constructor parameter; defaults to `DEFAULT_BUSY_TIMEOUT_MS = 5000` (down from hardcoded 30s).
  - Improved debug logging to show the actual error message and delay.
- **`tests/test_database_locking.py`**: Added `TestTransientErrorClassification` class with tests for error classification and a regression test for `SQLITE_PROTOCOL` retries.
- **`tests/test_env_vars.py`**: Added `TestPLUTODir` class to test `PLUTO_DIR` environment variable handling.
- **`CLAUDE.md`**: Documented the network filesystem issue, detection mechanism, and resilience strategy.

## Rationale

**Root cause**: WAL-mode SQLite relies on POSIX byte-range locks and shared `-shm` mmap, neither of which work reliably on network filesystems. Lock handoff degrades into `SQLITE_PROTOCOL` races, surfacing as repeated retries that stall writes.

**Why jitter matters**: Without jitter, the training process and sync process retry independently but with the same exponential schedule, causing them to collide repeatedly on the same lock. Full jitter (uniform random delay in `[0, window)`) breaks this synchronization.

**Why short `busy_timeout`**: SQLite's built-in busy handler waits *synchronously* before returning control. A long timeout (30s) stacks *under* every application-level retry attempt, so N retries with a 30s timeout can stall a single write into tens of seconds. A short timeout (5s) returns control quickly to the jittered backoff loop, which is more efficient.

## Testing

- Added unit tests for `get_fs_type()` and

https://claude.ai/code/session_01MxGTq9kjJSHWamBgP4vS24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot path for all metric/file writes to the sync SQLite DB (retry timing, busy_timeout, error classification); misclassification could mask real DB errors, though non-transient OperationalErrors still fail fast.
> 
> **Overview**
> Fixes **severe logging slowdown (~50s/batch)** when the WAL-mode sync SQLite DB lives on **NFS/Lustre/SMB** by steering users to node-local staging and making lock contention retries actually work.
> 
> **Detection & configuration:** New `pluto/_fs.py` resolves mount type from `/proc/self/mountinfo` (Linux, best-effort). `pluto.init()` warns if the staging path (sync DB dir or `settings.dir`) is on a network FS. **`PLUTO_DIR`** / deprecated **`MLOP_DIR`** set the staging directory via `setup()`, with explicit `dir` still winning.
> 
> **Sync store resilience (`pluto/sync/store.py`):** Transient errors now include **`locking protocol`** (SQLITE_PROTOCOL), not only messages containing `locked`. **`_retry_on_locked`** uses capped exponential backoff with **full jitter** (6 attempts, shorter base delay). **`PRAGMA busy_timeout`** defaults to **5s** (was 30s) and is **constructor-configurable**, so SQLite’s wait does not stack under each app-level retry.
> 
> Docs in **`CLAUDE.md`** describe the NFS/WAL issue and mitigations. Tests cover FS detection, `PLUTO_DIR`, transient error classification, and busy timeout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b398a98c4d9bcef9f2c9fc5d3768bb8b8df297aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->