### PR TITLE
Route string/bool values to Pluto config, handle unmapped types

### DIFF
--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -236,6 +236,13 @@ class WandbRunWrapper:
                         pluto_data[key] = value
                     elif (num := _as_scalar_number(value)) is not None:
                         pluto_data[key] = num
+                    elif (b := _as_scalar_bool(value)) is not None:
+                        # Scalar tensor/numpy whose .item() is a bool
+                        # (e.g. torch.tensor(True), np.bool_). Pluto has no
+                        # bool metric, so route to config like a plain bool
+                        # instead of dropping it as unforwardable.
+                        if self._last_logged_config.get(key, _MISSING) != b:
+                            pluto_config[key] = b
                     elif isinstance(value, str):
                         if self._last_logged_config.get(key, _MISSING) != value:
                             pluto_config[key] = value
@@ -652,6 +659,28 @@ def _as_scalar_number(value):
     if isinstance(result, bool) or not isinstance(result, (int, float)):
         return None
     return result
+
+
+def _as_scalar_bool(value):
+    """Return a python bool if value is a scalar whose ``.item()`` is a bool.
+
+    Covers tensor/numpy scalars wrapping a bool (``torch.tensor(True)``,
+    ``np.bool_(True)``) — their ``.item()`` yields a Python ``bool``. Pluto
+    has no bool metric, so these are routed to config exactly like a plain
+    ``bool`` rather than dropped as unforwardable. Plain Python ``bool`` is
+    handled earlier by the ``isinstance(value, bool)`` branch; ``str`` is
+    excluded so it can't be mistaken for a scalar.
+    """
+    if isinstance(value, (bool, str)):
+        return None
+    item = getattr(value, 'item', None)
+    if not callable(item):
+        return None
+    try:
+        result = item()
+    except Exception:
+        return None
+    return result if isinstance(result, bool) else None
 
 
 def _config_storable_value(value):

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -161,7 +161,8 @@ class WandbRunWrapper:
         """Log metrics to both wandb and Pluto.
 
         Value routing for the Pluto side:
-        - int/float, torch & numpy scalars -> Pluto metrics (time-series)
+        - int/float and any scalar exposing .item() (numpy/torch/etc.)
+          -> Pluto metrics (time-series), matching Pluto core's own log()
         - wandb media (Image/Video/Audio/Histogram/Table), and lists
           thereof -> converted Pluto media
         - str and bool -> Pluto config (latest-wins). Pluto has no
@@ -211,8 +212,8 @@ class WandbRunWrapper:
                         pluto_config[key] = value
                     elif isinstance(value, (int, float)):
                         pluto_data[key] = value
-                    elif _is_torch_tensor_scalar(value) or _is_numpy_scalar(value):
-                        pluto_data[key] = value.item()
+                    elif (num := _as_scalar_number(value)) is not None:
+                        pluto_data[key] = num
                     elif isinstance(value, str):
                         pluto_config[key] = value
                     elif isinstance(value, (list, tuple)):
@@ -531,30 +532,32 @@ def _resolve_wandb_to_pluto_run(wandb_run_id, project):
     return None
 
 
-def _is_torch_tensor_scalar(value):
-    """Check if value is a scalar torch tensor."""
-    try:
-        import torch
+def _as_scalar_number(value):
+    """Return value as a python int/float if it's a scalar number, else None.
 
-        return isinstance(value, torch.Tensor) and value.dim() == 0
-    except ImportError:
-        return False
+    Mirrors Pluto's own log() (op._process_log_item_sync), which forwards
+    anything exposing a callable ``.item()``. The shim previously only
+    accepted plain int/float and torch scalar tensors, so a value logged as
+    a numpy scalar (``np.int64``), a 0-d numpy array, or a non-torch 0-d
+    tensor was dropped here even though Pluto core would have kept it — e.g.
+    an ``epoch`` that is ``np.int64`` rather than a plain ``int``.
 
-
-def _is_numpy_scalar(value):
-    """Check if value is a numpy scalar number (e.g. np.int64, np.float32).
-
-    numpy scalars are NOT instances of Python int/float, so frameworks that
-    log ``np.int64(step)`` / ``np.float32(loss)`` would otherwise be dropped
-    by the numeric filter below — even though Pluto's own log() accepts
-    anything with .item(). Booleans are excluded (Pluto drops bool metrics).
+    bool and str are excluded (Pluto drops bool metrics; str routes to
+    config). ``.item()`` on a multi-element array/tensor raises — we treat
+    that as "not a scalar" and return None, same as Pluto would fail it.
     """
+    if isinstance(value, (bool, str)):
+        return None
+    item = getattr(value, 'item', None)
+    if not callable(item):
+        return None
     try:
-        import numpy as np
-
-        return isinstance(value, np.generic) and not isinstance(value, np.bool_)
-    except ImportError:
-        return False
+        result = item()
+    except Exception:
+        return None
+    if isinstance(result, bool) or not isinstance(result, (int, float)):
+        return None
+    return result
 
 
 def _is_torch_distributed() -> bool:

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -56,6 +56,9 @@ from ._utils import (
 
 logger = logging.getLogger(__name__)
 
+# Distinct from None so config dedup can tell "never logged" from "logged None".
+_MISSING = object()
+
 _original_wandb_init = None
 _original_wandb_log = None
 _original_wandb_finish = None
@@ -95,6 +98,10 @@ class WandbRunWrapper:
         # Keys we've already warned about being unforwardable to Pluto, so a
         # value logged every step warns once rather than spamming the logs.
         self._unforwardable_warned: set = set()
+        # Last config values we synced to Pluto, keyed by log key. Lets us skip
+        # redundant update_config() calls when a str/bool/config value is logged
+        # unchanged every step (a common pattern: phase/status/checkpoint paths).
+        self._last_logged_config: Dict[str, Any] = {}
 
         if self._pluto_run:
             atexit.register(self._atexit_cleanup_pluto)
@@ -174,9 +181,13 @@ class WandbRunWrapper:
           summary/overview placement and stay queryable via
           get_run().config.
         - anything else with no metric/media mapping -> preserved as
-          config if JSON-serializable, otherwise dropped and reported to
-          Sentry telemetry once per key (a maintainer-coverage signal, not
-          a user-facing warning). See _handle_unforwardable.
+          config if it survives update_config's normalization (incl.
+          OmegaConf), otherwise dropped and reported to Sentry telemetry
+          once per key (a maintainer-coverage signal, not a user-facing
+          warning). See _handle_unforwardable.
+
+        str/bool/config values are deduped against the last synced value, so
+        logging an unchanged value every step doesn't spam update_config.
         """
         # Determine the step to use for Pluto.
         # When step is explicit, use it. Otherwise:
@@ -217,13 +228,17 @@ class WandbRunWrapper:
                     if isinstance(value, bool):
                         # bool is a subclass of int, but Pluto drops bool
                         # metrics — surface it as config so it isn't lost.
-                        pluto_config[key] = value
+                        # Skip if unchanged since last log (avoid redundant
+                        # config writes when logged every step).
+                        if self._last_logged_config.get(key, _MISSING) != value:
+                            pluto_config[key] = value
                     elif isinstance(value, (int, float)):
                         pluto_data[key] = value
                     elif (num := _as_scalar_number(value)) is not None:
                         pluto_data[key] = num
                     elif isinstance(value, str):
-                        pluto_config[key] = value
+                        if self._last_logged_config.get(key, _MISSING) != value:
+                            pluto_config[key] = value
                     elif isinstance(value, (list, tuple)):
                         # List of wandb media — convert each element.
                         converted_items = []
@@ -247,22 +262,32 @@ class WandbRunWrapper:
                             # so the value is never silently dropped.
                             self._handle_unforwardable(key, value, pluto_config)
 
+                # Metrics and config are sent in independent try blocks: a
+                # failure logging metrics must NOT skip the config update (or
+                # vice versa) — str/bool from the same wandb.log() call live in
+                # config and would otherwise be silently lost.
                 if pluto_data:
-                    log_kwargs = {}
-                    if actual_step is not None:
-                        log_kwargs['step'] = actual_step
-                    self._pluto_run.log(pluto_data, **log_kwargs)
+                    try:
+                        log_kwargs = {}
+                        if actual_step is not None:
+                            log_kwargs['step'] = actual_step
+                        self._pluto_run.log(pluto_data, **log_kwargs)
+                    except Exception as e:
+                        logger.debug(
+                            f'pluto.compat.wandb: Failed to log metrics to Pluto: {e}'
+                        )
 
                 if pluto_config:
                     try:
                         self._pluto_run.update_config(pluto_config)
+                        # Only remember as synced once the update succeeds.
+                        self._last_logged_config.update(pluto_config)
                     except Exception as e:
                         logger.debug(
-                            f'pluto.compat.wandb: Failed to sync string/bool '
-                            f'values to Pluto config: {e}'
+                            f'pluto.compat.wandb: Failed to sync config to Pluto: {e}'
                         )
             except Exception as e:
-                logger.debug(f'pluto.compat.wandb: Failed to log metrics to Pluto: {e}')
+                logger.debug(f'pluto.compat.wandb: Failed to prepare Pluto data: {e}')
 
         return result
 
@@ -276,9 +301,11 @@ class WandbRunWrapper:
         silently — which is what made missing data so hard to diagnose —
         we:
 
-        1. Preserve the value as config if it's JSON-serializable (mirrors
-           how wandb keeps loose values in the run summary). This covers
-           nested dicts/lists of primitives, None, etc.
+        1. Preserve the value as config if it survives update_config's own
+           normalization (mirrors how wandb keeps loose values in the run
+           summary). This covers nested dicts/lists of primitives, None, and
+           OmegaConf DictConfig/ListConfig nodes (which to_native_config
+           deep-converts). Skipped if unchanged since the last log.
         2. Otherwise drop the Pluto copy (it still reached W&B) and report
            it as a maintainer-coverage signal via Sentry telemetry — once
            per key. This is a gap in OUR type handling, not a user error,
@@ -287,8 +314,10 @@ class WandbRunWrapper:
            we can fix. The local log stays at debug for self-host
            debugging.
         """
-        if _is_json_serializable(value):
-            pluto_config[key] = value
+        storable, native = _config_storable_value(value)
+        if storable:
+            if self._last_logged_config.get(key, _MISSING) != native:
+                pluto_config[key] = native
             return
         if key in self._unforwardable_warned:
             return
@@ -625,19 +654,28 @@ def _as_scalar_number(value):
     return result
 
 
-def _is_json_serializable(value) -> bool:
-    """True if value can be stored as Pluto config (round-trips through JSON).
+def _config_storable_value(value):
+    """Return ``(storable, native)`` for the config fallback.
 
-    Used as the last-resort fallback for values with no metric/media
-    mapping: serializable ones (str, bool, None, nested dicts/lists of
-    primitives) are preserved as config; everything else is warned about
-    and dropped. Mirrors the serialization Pluto config itself performs.
+    Mirrors what ``update_config`` actually does — normalize via
+    ``to_native_config`` (which deep-converts OmegaConf ``DictConfig`` /
+    ``ListConfig`` to native containers), then check JSON-serializability.
+    Keeping the gate in lockstep with ``update_config`` means a logged
+    ``DictConfig`` is correctly stored as config, even though plain
+    ``json.dumps`` would reject it. Tensors / ndarrays / custom objects still
+    fail (``to_native_config`` leaves them as-is) and fall through to the
+    Sentry path.
+
+    Returns ``(True, native_value)`` when storable, else ``(False, None)``.
     """
     try:
-        json.dumps(value)
-        return True
-    except (TypeError, ValueError):
-        return False
+        from pluto.util import to_native_config
+
+        native = to_native_config(value)
+        json.dumps(native)
+        return True, native
+    except Exception:
+        return False, None
 
 
 def _is_torch_distributed() -> bool:

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -41,6 +41,7 @@ Hard Requirements:
 """
 
 import atexit
+import json
 import logging
 import os
 import threading
@@ -91,6 +92,9 @@ class WandbRunWrapper:
         self._fallback_step = 0  # Used when wandb is disabled (_step won't increment)
         self._closed = False
         self._close_lock = threading.Lock()
+        # Keys we've already warned about being unforwardable to Pluto, so a
+        # value logged every step warns once rather than spamming the logs.
+        self._unforwardable_warned: set = set()
 
         if self._pluto_run:
             atexit.register(self._atexit_cleanup_pluto)
@@ -169,6 +173,10 @@ class WandbRunWrapper:
           string/bool time-series metric, so these mirror wandb's
           summary/overview placement and stay queryable via
           get_run().config.
+        - anything else with no metric/media mapping -> preserved as
+          config if JSON-serializable, otherwise dropped with a ONE-TIME
+          warning per key (see _handle_unforwardable). Nothing is dropped
+          silently.
         """
         # Determine the step to use for Pluto.
         # When step is explicit, use it. Otherwise:
@@ -225,11 +233,19 @@ class WandbRunWrapper:
                                 converted_items.append(c)
                         if converted_items:
                             pluto_data[key] = converted_items
+                        else:
+                            # Not a media list (e.g. list of primitives) —
+                            # preserve as config if possible, else warn.
+                            self._handle_unforwardable(key, value, pluto_config)
                     else:
                         # Try to convert wandb data types to pluto equivalents
                         converted = _convert_wandb_to_pluto(key, value, self._pluto)
                         if converted is not None:
                             pluto_data[key] = converted
+                        else:
+                            # No metric/media mapping — last-resort handling
+                            # so the value is never silently dropped.
+                            self._handle_unforwardable(key, value, pluto_config)
 
                 if pluto_data:
                     log_kwargs = {}
@@ -249,6 +265,36 @@ class WandbRunWrapper:
                 logger.debug(f'pluto.compat.wandb: Failed to log metrics to Pluto: {e}')
 
         return result
+
+    def _handle_unforwardable(self, key, value, pluto_config: Dict[str, Any]) -> None:
+        """Last-resort handling for a value with no metric/media mapping.
+
+        Pluto only stores numbers (metrics), media/structured data, and
+        config — so values outside those (dicts, None, raw/multi-element
+        tensors, numpy arrays, unconvertible wandb media like Html/Object3D,
+        custom objects) have nowhere to go. Rather than dropping them
+        silently — which is what made missing data so hard to diagnose —
+        we:
+
+        1. Preserve the value as config if it's JSON-serializable (mirrors
+           how wandb keeps loose values in the run summary). This covers
+           nested dicts/lists of primitives, None, etc.
+        2. Otherwise warn ONCE per key (WARNING, not debug) naming the key
+           and type, so the drop is visible. The value still reached W&B;
+           only the Pluto copy is dropped.
+        """
+        if _is_json_serializable(value):
+            pluto_config[key] = value
+            return
+        if key not in self._unforwardable_warned:
+            self._unforwardable_warned.add(key)
+            logger.warning(
+                'pluto.compat.wandb: not forwarding %r to Pluto — value of '
+                'type %s has no metric/media/config mapping (it was still '
+                'logged to W&B). This warning is shown once per key.',
+                key,
+                type(value).__name__,
+            )
 
     def finish(self, exit_code=None, quiet=None):
         """Finish both wandb and Pluto runs."""
@@ -558,6 +604,21 @@ def _as_scalar_number(value):
     if isinstance(result, bool) or not isinstance(result, (int, float)):
         return None
     return result
+
+
+def _is_json_serializable(value) -> bool:
+    """True if value can be stored as Pluto config (round-trips through JSON).
+
+    Used as the last-resort fallback for values with no metric/media
+    mapping: serializable ones (str, bool, None, nested dicts/lists of
+    primitives) are preserved as config; everything else is warned about
+    and dropped. Mirrors the serialization Pluto config itself performs.
+    """
+    try:
+        json.dumps(value)
+        return True
+    except (TypeError, ValueError):
+        return False
 
 
 def _is_torch_distributed() -> bool:

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -158,7 +158,17 @@ class WandbRunWrapper:
             logger.debug(f'pluto.compat.wandb: Pluto finish timed out after {timeout}s')
 
     def log(self, data: Dict[str, Any], step=None, commit=None, **kwargs):
-        """Log metrics to both wandb and Pluto."""
+        """Log metrics to both wandb and Pluto.
+
+        Value routing for the Pluto side:
+        - int/float, torch & numpy scalars -> Pluto metrics (time-series)
+        - wandb media (Image/Video/Audio/Histogram/Table), and lists
+          thereof -> converted Pluto media
+        - str and bool -> Pluto config (latest-wins). Pluto has no
+          string/bool time-series metric, so these mirror wandb's
+          summary/overview placement and stay queryable via
+          get_run().config.
+        """
         # Determine the step to use for Pluto.
         # When step is explicit, use it. Otherwise:
         # - Normal mode: read wandb's _step before log() increments it
@@ -186,11 +196,25 @@ class WandbRunWrapper:
                 # Pluto.log() natively supports lists, so we just need
                 # to convert each element and pass the list through.
                 pluto_data: Dict[str, Any] = {}
+                # String values have no time-series metric equivalent in
+                # Pluto (op._process_log_item_sync only keeps int/float/
+                # tensor/File/Data). wandb puts loose strings in the run
+                # summary/overview; the closest Pluto analogue is config,
+                # which is latest-wins and queryable via get_run().config.
+                # This is what lets e.g. a resume skill read back the most
+                # recent checkpoint/r2_path for a run.
+                pluto_config: Dict[str, Any] = {}
                 for key, value in data.items():
-                    if isinstance(value, (int, float)):
+                    if isinstance(value, bool):
+                        # bool is a subclass of int, but Pluto drops bool
+                        # metrics — surface it as config so it isn't lost.
+                        pluto_config[key] = value
+                    elif isinstance(value, (int, float)):
                         pluto_data[key] = value
-                    elif _is_torch_tensor_scalar(value):
+                    elif _is_torch_tensor_scalar(value) or _is_numpy_scalar(value):
                         pluto_data[key] = value.item()
+                    elif isinstance(value, str):
+                        pluto_config[key] = value
                     elif isinstance(value, (list, tuple)):
                         # List of wandb media — convert each element.
                         converted_items = []
@@ -211,6 +235,15 @@ class WandbRunWrapper:
                     if actual_step is not None:
                         log_kwargs['step'] = actual_step
                     self._pluto_run.log(pluto_data, **log_kwargs)
+
+                if pluto_config:
+                    try:
+                        self._pluto_run.update_config(pluto_config)
+                    except Exception as e:
+                        logger.debug(
+                            f'pluto.compat.wandb: Failed to sync string/bool '
+                            f'values to Pluto config: {e}'
+                        )
             except Exception as e:
                 logger.debug(f'pluto.compat.wandb: Failed to log metrics to Pluto: {e}')
 
@@ -504,6 +537,22 @@ def _is_torch_tensor_scalar(value):
         import torch
 
         return isinstance(value, torch.Tensor) and value.dim() == 0
+    except ImportError:
+        return False
+
+
+def _is_numpy_scalar(value):
+    """Check if value is a numpy scalar number (e.g. np.int64, np.float32).
+
+    numpy scalars are NOT instances of Python int/float, so frameworks that
+    log ``np.int64(step)`` / ``np.float32(loss)`` would otherwise be dropped
+    by the numeric filter below — even though Pluto's own log() accepts
+    anything with .item(). Booleans are excluded (Pluto drops bool metrics).
+    """
+    try:
+        import numpy as np
+
+        return isinstance(value, np.generic) and not isinstance(value, np.bool_)
     except ImportError:
         return False
 

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -174,9 +174,9 @@ class WandbRunWrapper:
           summary/overview placement and stay queryable via
           get_run().config.
         - anything else with no metric/media mapping -> preserved as
-          config if JSON-serializable, otherwise dropped with a ONE-TIME
-          warning per key (see _handle_unforwardable). Nothing is dropped
-          silently.
+          config if JSON-serializable, otherwise dropped and reported to
+          Sentry telemetry once per key (a maintainer-coverage signal, not
+          a user-facing warning). See _handle_unforwardable.
         """
         # Determine the step to use for Pluto.
         # When step is explicit, use it. Otherwise:
@@ -279,22 +279,41 @@ class WandbRunWrapper:
         1. Preserve the value as config if it's JSON-serializable (mirrors
            how wandb keeps loose values in the run summary). This covers
            nested dicts/lists of primitives, None, etc.
-        2. Otherwise warn ONCE per key (WARNING, not debug) naming the key
-           and type, so the drop is visible. The value still reached W&B;
-           only the Pluto copy is dropped.
+        2. Otherwise drop the Pluto copy (it still reached W&B) and report
+           it as a maintainer-coverage signal via Sentry telemetry — once
+           per key. This is a gap in OUR type handling, not a user error,
+           so we deliberately do NOT emit a user-facing warning: people
+           migrating away from wandb shouldn't be nagged about types only
+           we can fix. The local log stays at debug for self-host
+           debugging.
         """
         if _is_json_serializable(value):
             pluto_config[key] = value
             return
-        if key not in self._unforwardable_warned:
-            self._unforwardable_warned.add(key)
-            logger.warning(
-                'pluto.compat.wandb: not forwarding %r to Pluto — value of '
-                'type %s has no metric/media/config mapping (it was still '
-                'logged to W&B). This warning is shown once per key.',
-                key,
-                type(value).__name__,
+        if key in self._unforwardable_warned:
+            return
+        self._unforwardable_warned.add(key)
+        type_name = type(value).__name__
+        # Quiet locally (debug only) — not a user-actionable problem.
+        logger.debug(
+            'pluto.compat.wandb: not forwarding %r to Pluto — type %s has no '
+            'metric/media/config mapping (still logged to W&B).',
+            key,
+            type_name,
+        )
+        # Alert us (the maintainers) so we can add coverage for the type.
+        # Message is keyed on the type (not the run-specific key) so Sentry
+        # groups all occurrences of the same unhandled type together.
+        try:
+            from pluto import sentry
+
+            sentry.capture_message(
+                f'wandb compat: unforwardable Pluto log value of type '
+                f'{type_name!r} (no metric/media/config mapping)',
+                level='warning',
             )
+        except Exception:
+            pass
 
     def finish(self, exit_code=None, quiet=None):
         """Finish both wandb and Pluto runs."""

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -236,3 +236,71 @@ def test_omegaconf_config_flows_through_shim_and_serializes(clean_env, monkeypat
     payload = make_compat_start_v1(native, Settings(), info=None)
     inner = json.loads(json.loads(payload.decode())['config'])
     assert inner['model']['full_name'] == 'resnet-v2'  # interpolation resolved
+
+
+# ---------------------------------------------------------------------------
+# WandbRunWrapper.log value routing
+#
+# The shim pre-filters each logged value before forwarding to Pluto. These
+# tests pin the routing that backs the /resume-crashed-run use case: string
+# paths (e.g. checkpoint/r2_path) must reach Pluto as config (latest-wins,
+# queryable via get_run().config), and numpy scalars must not be silently
+# dropped the way plain str/np values were before.
+# ---------------------------------------------------------------------------
+
+
+def _make_wrapper():
+    """Build a WandbRunWrapper with mock wandb/pluto runs (no atexit)."""
+    wandb_run = MagicMock()
+    wandb_run._step = 7
+    pluto_run = MagicMock()
+    pluto_module = MagicMock()
+    # Avoid registering a real atexit handler during the test.
+    with mock.patch.object(wandb_compat.atexit, 'register'):
+        wrapper = wandb_compat.WandbRunWrapper(
+            wandb_run, pluto_run, pluto_module, wandb_disabled=False
+        )
+    return wrapper, pluto_run
+
+
+def test_log_routes_strings_to_config_not_metrics():
+    """checkpoint/r2_path (a str) must land in Pluto config, not log()."""
+    wrapper, pluto_run = _make_wrapper()
+
+    wrapper.log(
+        {
+            'checkpoint/step': 100,
+            'checkpoint/r2_path': 's3://bucket/run/ckpt-100.pt',
+            'checkpoint/local_path': '/nfs/run/ckpt-100.pt',
+        }
+    )
+
+    # Strings forwarded to config (latest-wins, readable via get_run().config).
+    assert pluto_run.update_config.call_count == 1
+    cfg = pluto_run.update_config.call_args.args[0]
+    assert cfg['checkpoint/r2_path'] == 's3://bucket/run/ckpt-100.pt'
+    assert cfg['checkpoint/local_path'] == '/nfs/run/ckpt-100.pt'
+
+    # Numeric value still goes to metrics; strings must NOT be in log().
+    logged = pluto_run.log.call_args.args[0]
+    assert logged == {'checkpoint/step': 100}
+    assert 'checkpoint/r2_path' not in logged
+
+
+def test_log_forwards_numpy_scalars_as_metrics():
+    """np.int64/np.float32 must reach Pluto metrics, not be dropped."""
+    np = pytest.importorskip('numpy')
+    wrapper, pluto_run = _make_wrapper()
+
+    wrapper.log(
+        {
+            'checkpoint/step': np.int64(100),
+            'loss': np.float32(0.5),
+        }
+    )
+
+    logged = pluto_run.log.call_args.args[0]
+    assert logged['checkpoint/step'] == 100
+    assert isinstance(logged['checkpoint/step'], int)  # .item() -> python int
+    assert abs(logged['loss'] - 0.5) < 1e-6
+    assert isinstance(logged['loss'], float)

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -397,6 +397,23 @@ def test_log_skips_redundant_config_updates():
     assert pluto_run.update_config.call_args.args[0] == {'phase': 'val'}
 
 
+def test_scalar_bool_tensor_routes_to_config_not_dropped():
+    """A scalar whose .item() is a bool goes to config like a plain bool."""
+    wrapper, pluto_run = _make_wrapper()
+
+    class _BoolScalar:  # mimics torch.tensor(True) / np.bool_
+        def item(self):
+            return True
+
+    with mock.patch('pluto.sentry.capture_message') as cap:
+        wrapper.log({'flag': _BoolScalar()})
+
+    cfg = pluto_run.update_config.call_args.args[0]
+    assert cfg == {'flag': True}
+    assert not cap.called  # not treated as unforwardable
+    assert not pluto_run.log.called  # bool is not a metric
+
+
 def test_omegaconf_value_falls_back_to_config_not_dropped():
     """A logged OmegaConf node is storable as config (not Sentry-dropped)."""
     OmegaConf = pytest.importorskip('omegaconf').OmegaConf

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -342,8 +342,8 @@ def test_log_does_not_treat_failing_item_as_scalar():
     assert not pluto_run.update_config.called
 
 
-def test_unforwardable_value_warns_once_not_silent(caplog):
-    """A value with no Pluto mapping must warn (once per key), never silently drop."""
+def test_unforwardable_value_alerts_sentry_once_not_user():
+    """An unmappable value alerts Sentry (maintainers) once — not the user."""
     wrapper, pluto_run = _make_wrapper()
 
     class _Opaque:
@@ -352,15 +352,15 @@ def test_unforwardable_value_warns_once_not_silent(caplog):
         def item(self):
             raise ValueError('not a scalar')
 
-    with caplog.at_level('WARNING', logger='pluto.compat.wandb'):
+    with mock.patch('pluto.sentry.capture_message') as cap:
         wrapper.log({'mystery': _Opaque()})
-        wrapper.log({'mystery': _Opaque()})  # second time: must NOT warn again
+        wrapper.log({'mystery': _Opaque()})  # second time: no duplicate alert
 
-    warnings = [r for r in caplog.records if 'mystery' in r.getMessage()]
-    assert len(warnings) == 1, 'should warn exactly once per key'
-    assert 'mystery' in warnings[0].getMessage()
-    assert '_Opaque' in warnings[0].getMessage()  # names the offending type
-    # Nothing forwarded — but it was loud about it.
+    # Exactly one maintainer-facing Sentry alert, grouped by type name.
+    assert cap.call_count == 1
+    assert '_Opaque' in cap.call_args.args[0]
+    assert cap.call_args.kwargs.get('level') == 'warning'
+    # Nothing forwarded to the user's run, and no user-facing exception.
     assert not pluto_run.log.called
     assert not pluto_run.update_config.called
 

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -340,3 +340,38 @@ def test_log_does_not_treat_failing_item_as_scalar():
 
     assert not pluto_run.log.called
     assert not pluto_run.update_config.called
+
+
+def test_unforwardable_value_warns_once_not_silent(caplog):
+    """A value with no Pluto mapping must warn (once per key), never silently drop."""
+    wrapper, pluto_run = _make_wrapper()
+
+    class _Opaque:
+        """Not numeric, not media, not JSON-serializable."""
+
+        def item(self):
+            raise ValueError('not a scalar')
+
+    with caplog.at_level('WARNING', logger='pluto.compat.wandb'):
+        wrapper.log({'mystery': _Opaque()})
+        wrapper.log({'mystery': _Opaque()})  # second time: must NOT warn again
+
+    warnings = [r for r in caplog.records if 'mystery' in r.getMessage()]
+    assert len(warnings) == 1, 'should warn exactly once per key'
+    assert 'mystery' in warnings[0].getMessage()
+    assert '_Opaque' in warnings[0].getMessage()  # names the offending type
+    # Nothing forwarded — but it was loud about it.
+    assert not pluto_run.log.called
+    assert not pluto_run.update_config.called
+
+
+def test_json_serializable_unmapped_value_falls_back_to_config():
+    """A dict/None with no metric mapping is preserved as config, not dropped."""
+    wrapper, pluto_run = _make_wrapper()
+
+    wrapper.log({'meta/info': {'kind': 'resume', 'attempt': 3}, 'note': None})
+
+    cfg = pluto_run.update_config.call_args.args[0]
+    assert cfg['meta/info'] == {'kind': 'resume', 'attempt': 3}
+    assert cfg['note'] is None
+    assert not pluto_run.log.called  # no numeric metrics in this call

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -304,3 +304,39 @@ def test_log_forwards_numpy_scalars_as_metrics():
     assert isinstance(logged['checkpoint/step'], int)  # .item() -> python int
     assert abs(logged['loss'] - 0.5) < 1e-6
     assert isinstance(logged['loss'], float)
+
+
+def test_log_forwards_any_item_scalar_like_pluto_core():
+    """Any scalar exposing .item() is forwarded, matching Pluto's own log().
+
+    Guards against the shim being stricter than op._process_log_item_sync:
+    e.g. an ``epoch`` that arrives as a 0-d-tensor-like wrapper rather than a
+    plain int must still reach Pluto instead of being silently dropped.
+    """
+    wrapper, pluto_run = _make_wrapper()
+
+    class _ScalarLike:
+        def __init__(self, v):
+            self._v = v
+
+        def item(self):
+            return self._v
+
+    wrapper.log({'checkpoint/epoch': _ScalarLike(12)})
+
+    logged = pluto_run.log.call_args.args[0]
+    assert logged == {'checkpoint/epoch': 12}
+
+
+def test_log_does_not_treat_failing_item_as_scalar():
+    """A non-scalar whose .item() raises must not crash or produce a metric."""
+    wrapper, pluto_run = _make_wrapper()
+
+    class _MultiElement:
+        def item(self):
+            raise ValueError('can only convert an array of size 1')
+
+    wrapper.log({'weird': _MultiElement()})
+
+    assert not pluto_run.log.called
+    assert not pluto_run.update_config.called

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -375,3 +375,39 @@ def test_json_serializable_unmapped_value_falls_back_to_config():
     assert cfg['meta/info'] == {'kind': 'resume', 'attempt': 3}
     assert cfg['note'] is None
     assert not pluto_run.log.called  # no numeric metrics in this call
+
+
+def test_log_skips_redundant_config_updates():
+    """An unchanged str/bool config value must not re-trigger update_config."""
+    wrapper, pluto_run = _make_wrapper()
+
+    # First log: config is synced.
+    wrapper.log({'phase': 'train', 'loss': 0.5})
+    assert pluto_run.update_config.call_count == 1
+    assert pluto_run.update_config.call_args.args[0] == {'phase': 'train'}
+
+    # Same config value again: update_config must NOT be called.
+    pluto_run.update_config.reset_mock()
+    wrapper.log({'phase': 'train', 'loss': 0.4})
+    assert pluto_run.update_config.call_count == 0
+
+    # Changed config value: update_config is called again, with only the change.
+    wrapper.log({'phase': 'val', 'loss': 0.3})
+    assert pluto_run.update_config.call_count == 1
+    assert pluto_run.update_config.call_args.args[0] == {'phase': 'val'}
+
+
+def test_omegaconf_value_falls_back_to_config_not_dropped():
+    """A logged OmegaConf node is storable as config (not Sentry-dropped)."""
+    OmegaConf = pytest.importorskip('omegaconf').OmegaConf
+    wrapper, pluto_run = _make_wrapper()
+
+    cfg_node = OmegaConf.create({'lr': 0.01, 'sched': {'name': 'cosine'}})
+
+    with mock.patch('pluto.sentry.capture_message') as cap:
+        wrapper.log({'hparams': cfg_node})
+
+    # Stored as config, deep-converted to native containers; not dropped.
+    cfg = pluto_run.update_config.call_args.args[0]
+    assert cfg['hparams'] == {'lr': 0.01, 'sched': {'name': 'cosine'}}
+    assert not cap.called  # OmegaConf is storable -> no maintainer alert


### PR DESCRIPTION
## Description

This PR improves how the wandb compatibility shim forwards logged values to Pluto by implementing proper value routing and handling for unmapped types.

### Key Changes

1. **Value Routing for Pluto**:
   - **Numeric metrics**: int/float and any scalar exposing `.item()` (numpy/torch/etc.) → Pluto metrics (time-series)
   - **Strings and bools**: → Pluto config (latest-wins, queryable via `get_run().config`). This enables the /resume-crashed-run use case where checkpoint paths and other string metadata need to be readable from Pluto
   - **wandb media and lists**: → converted Pluto media
   - **JSON-serializable values** (dicts, None, nested structures): → Pluto config as fallback
   - **Unmapped types**: Reported to Sentry telemetry once per key (maintainer-coverage signal, not user-facing)

2. **Improved Scalar Detection**:
   - Replaced `_is_torch_tensor_scalar()` with `_as_scalar_number()` that mirrors Pluto core's own `op._process_log_item_sync`
   - Now accepts any scalar exposing a callable `.item()` method (numpy scalars, 0-d arrays, custom tensor-like objects)
   - Properly excludes bool and str from scalar handling

3. **Unforwardable Value Handling**:
   - Added `_handle_unforwardable()` method to gracefully handle values with no metric/media/config mapping
   - Attempts JSON serialization as last resort (preserves dicts, None, nested primitives)
   - Reports non-serializable types to Sentry once per key for maintainer awareness
   - No user-facing warnings (not a user-actionable problem)

4. **Config Synchronization**:
   - Added `pluto_config` dict to collect string/bool/JSON-serializable values
   - Calls `pluto_run.update_config()` after logging metrics
   - Includes error handling for config sync failures

### Testing

Added comprehensive test coverage in `test_wandb_compat.py`:
- `test_log_routes_strings_to_config_not_metrics`: Verifies strings land in config, not metrics
- `test_log_forwards_numpy_scalars_as_metrics`: Ensures numpy scalars reach Pluto
- `test_log_forwards_any_item_scalar_like_pluto_core`: Guards against being stricter than Pluto core
- `test_log_does_not_treat_failing_item_as_scalar`: Handles non-scalars with `.item()` gracefully
- `test_unforwardable_value_alerts_sentry_once_not_user`: Verifies Sentry alerting and deduplication
- `test_json_serializable_unmapped_value_falls_back_to_config`: Confirms dict/None fallback to config

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] New unit tests for value routing and type handling

https://claude.ai/code/session_01JzBDybRDXt1TLnsQAxhKqz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dual-logging behavior for all wandb.log calls (config sync and type routing) but failures are isolated from wandb and wrapped in try/except; mis-routing could affect resume/metadata reads from Pluto.
> 
> **Overview**
> **Expands wandb→Pluto forwarding in `WandbRunWrapper.log`** so mixed `wandb.log()` payloads are split correctly instead of dropping non-numeric types.
> 
> **Strings and bools** now go to **`update_config`** (latest-wins, deduped via `_last_logged_config` / `_MISSING`) so keys like checkpoint paths stay readable from Pluto config (e.g. resume flows). **Scalars** use **`_as_scalar_number`** (any `.item()` scalar, not just torch) for metrics. **Unmapped values** try **`_config_storable_value`** (`to_native_config` + JSON check, including OmegaConf); otherwise a **once-per-key Sentry** maintainer signal with debug-only local logs. **Metrics and config** are flushed in **separate try blocks** so one failure does not skip the other.
> 
> **Tests** in `test_wandb_compat.py` cover routing, numpy/scalar-like values, config dedup, OmegaConf, and Sentry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b338a3487ffbb5e6e687c8cbda52fa2899f399d4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->