### PR TITLE
Point server submodule at Trainy-ai/pluto-server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "server"]
 	path = server
-	url = https://github.com/mlop-ai/server.git
+	url = https://github.com/Trainy-ai/pluto-server.git


### PR DESCRIPTION
## Summary

The `server` git submodule in `.gitmodules` still referenced the old `mlop-ai/server` repo. This updates the URL to the renamed `Trainy-ai/pluto-server` repository.

- `url = https://github.com/mlop-ai/server.git` → `url = https://github.com/Trainy-ai/pluto-server.git`

The pinned commit (`02788a9`) is unchanged. The submodule is not initialized in this working tree, so `.gitmodules` is the only place the URL is recorded; `git submodule sync` is a no-op here.

https://claude.ai/code/session_01MvaLJcUGtwNWJRtkpxJqTb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvaLJcUGtwNWJRtkpxJqTb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata URL change with no application or runtime code impact; clone/sync behavior follows the new remote name.
> 
> **Overview**
> Updates the **`server` git submodule** URL in `.gitmodules` from `https://github.com/mlop-ai/server.git` to **`https://github.com/Trainy-ai/pluto-server.git`**, matching the repository rename. The submodule path (`server`) and pinned commit are unchanged; this only affects where `git submodule update` clones from.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d369b1b011fc0132c7b34e07149f4018d1202eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->