### PR TITLE
Suppress httpx INFO logs in metadata update requests

### DIFF
--- a/pluto/iface.py
+++ b/pluto/iface.py
@@ -187,12 +187,16 @@ class ServerInterface:
             num: List of numeric metric names
             df: Dict mapping file type names to lists of log names
         """
+        # Suppress the per-request httpx INFO line ("HTTP Request: POST
+        # .../api/runs/logName/add ..."). One POST fires per new metric/file
+        # name, so this is noisy; the heartbeat/status path suppresses it too.
         if num:
             self._post_v1(
                 self.settings.url_meta,
                 self.headers,
                 make_compat_meta_v1(num, 'num', self.settings),
                 client=self.client_api,
+                suppress_httpx_logs=True,
             )
         if df:
             for type_name, names in df.items():
@@ -201,6 +205,7 @@ class ServerInterface:
                     self.headers,
                     make_compat_meta_v1(names, type_name, self.settings),
                     client=self.client_api,
+                    suppress_httpx_logs=True,
                 )
 
     def _log_failed_request(


### PR DESCRIPTION
## Description

Suppress the per-request httpx INFO log messages when updating metric and file metadata. These requests fire once per new metric/file name, creating noisy logs. The heartbeat/status path already suppresses these logs, so this change brings metadata updates in line with that pattern.

Changes:
- Added `suppress_httpx_logs=True` parameter to `_post_v1()` calls in `_update_meta()` for both numeric metrics and file type metadata updates
- Added explanatory comment documenting why suppression is needed

## Tests

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (no new tests needed - existing logging behavior tests cover this)

https://claude.ai/code/session_01Ap1ZhqZNqTY2craxAKxofa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only behavior for internal HTTP calls; no API, auth, or data-path changes.
> 
> **Overview**
> **`_update_meta()`** now passes **`suppress_httpx_logs=True`** on every `logName/add` POST (numeric metrics and per file-type batches), matching the heartbeat/status path so httpx’s per-request INFO lines don’t flood logs when many new metric/file names are registered.
> 
> A short comment in **`iface.py`** documents why suppression is needed (one POST per new name).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a97be85c90ff71026e4cb5a0c3b3aed41e81e6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->