### PR TITLE
feat: send media captions to the server (Image/Audio/Video caption=)

### DIFF
--- a/pluto/api.py
+++ b/pluto/api.py
@@ -170,6 +170,9 @@ def make_compat_file_v1(file, timestamp, step):
                 'logName': k,
                 'step': step,
             }
+            caption = getattr(f, '_caption', None)
+            if caption is not None:
+                i['caption'] = caption
             batch.append(i)
     return json.dumps({'files': batch}).encode()
 

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -701,6 +701,17 @@ def _is_torch_distributed() -> bool:
         return False
 
 
+def _wandb_caption(value):
+    """Extract a user-provided caption from a wandb media object.
+
+    wandb.Image/Audio/Video store the ``caption=`` kwarg on ``_caption``.
+    Returns a non-empty string or None (ignores wandb's list-of-captions
+    grouping form, which has no single-file equivalent here).
+    """
+    cap = getattr(value, '_caption', None)
+    return cap if isinstance(cap, str) and cap else None
+
+
 def _convert_wandb_to_pluto(key, value, pluto_module):
     """
     Convert wandb data types to Pluto equivalents.
@@ -720,15 +731,16 @@ def _convert_wandb_to_pluto(key, value, pluto_module):
             # which does NOT match subclasses, so we can't pass the PIL
             # object directly. Instead, use the file path — wandb.Image
             # always writes to _path on construction.
+            caption = _wandb_caption(value)
             if getattr(value, '_path', None):
-                return pluto_module.Image(value._path)
+                return pluto_module.Image(value._path, caption=caption)
             # Fallback: convert PIL to numpy (which pluto.Image handles)
             pil_img = getattr(value, 'image', None) or getattr(value, '_image', None)
             if pil_img is not None:
                 try:
                     import numpy as np
 
-                    return pluto_module.Image(np.asarray(pil_img))
+                    return pluto_module.Image(np.asarray(pil_img), caption=caption)
                 except Exception:
                     return None
             return None
@@ -748,14 +760,14 @@ def _convert_wandb_to_pluto(key, value, pluto_module):
             # wandb.Audio always writes to _path on construction
             # (whether from numpy, file path, or bytes).
             if getattr(value, '_path', None):
-                return pluto_module.Audio(value._path)
+                return pluto_module.Audio(value._path, caption=_wandb_caption(value))
             return None
 
         if type_name == 'Video':
             # wandb.Video always writes to _path on construction (after
             # encoding). This can take a few seconds for numpy input.
             if getattr(value, '_path', None):
-                return pluto_module.Video(value._path)
+                return pluto_module.Video(value._path, caption=_wandb_caption(value))
             return None
 
         if type_name == 'Table':

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -161,7 +161,8 @@ class WandbRunWrapper:
         """Log metrics to both wandb and Pluto.
 
         Value routing for the Pluto side:
-        - int/float, torch & numpy scalars -> Pluto metrics (time-series)
+        - int/float and any scalar exposing .item() (numpy/torch/etc.)
+          -> Pluto metrics (time-series), matching Pluto core's own log()
         - wandb media (Image/Video/Audio/Histogram/Table), and lists
           thereof -> converted Pluto media
         - str and bool -> Pluto config (latest-wins). Pluto has no
@@ -211,8 +212,8 @@ class WandbRunWrapper:
                         pluto_config[key] = value
                     elif isinstance(value, (int, float)):
                         pluto_data[key] = value
-                    elif _is_torch_tensor_scalar(value) or _is_numpy_scalar(value):
-                        pluto_data[key] = value.item()
+                    elif (num := _as_scalar_number(value)) is not None:
+                        pluto_data[key] = num
                     elif isinstance(value, str):
                         pluto_config[key] = value
                     elif isinstance(value, (list, tuple)):
@@ -531,30 +532,32 @@ def _resolve_wandb_to_pluto_run(wandb_run_id, project):
     return None
 
 
-def _is_torch_tensor_scalar(value):
-    """Check if value is a scalar torch tensor."""
-    try:
-        import torch
+def _as_scalar_number(value):
+    """Return value as a python int/float if it's a scalar number, else None.
 
-        return isinstance(value, torch.Tensor) and value.dim() == 0
-    except ImportError:
-        return False
+    Mirrors Pluto's own log() (op._process_log_item_sync), which forwards
+    anything exposing a callable ``.item()``. The shim previously only
+    accepted plain int/float and torch scalar tensors, so a value logged as
+    a numpy scalar (``np.int64``), a 0-d numpy array, or a non-torch 0-d
+    tensor was dropped here even though Pluto core would have kept it — e.g.
+    an ``epoch`` that is ``np.int64`` rather than a plain ``int``.
 
-
-def _is_numpy_scalar(value):
-    """Check if value is a numpy scalar number (e.g. np.int64, np.float32).
-
-    numpy scalars are NOT instances of Python int/float, so frameworks that
-    log ``np.int64(step)`` / ``np.float32(loss)`` would otherwise be dropped
-    by the numeric filter below — even though Pluto's own log() accepts
-    anything with .item(). Booleans are excluded (Pluto drops bool metrics).
+    bool and str are excluded (Pluto drops bool metrics; str routes to
+    config). ``.item()`` on a multi-element array/tensor raises — we treat
+    that as "not a scalar" and return None, same as Pluto would fail it.
     """
+    if isinstance(value, (bool, str)):
+        return None
+    item = getattr(value, 'item', None)
+    if not callable(item):
+        return None
     try:
-        import numpy as np
-
-        return isinstance(value, np.generic) and not isinstance(value, np.bool_)
-    except ImportError:
-        return False
+        result = item()
+    except Exception:
+        return None
+    if isinstance(result, bool) or not isinstance(result, (int, float)):
+        return None
+    return result
 
 
 def _is_torch_distributed() -> bool:

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -56,6 +56,9 @@ from ._utils import (
 
 logger = logging.getLogger(__name__)
 
+# Distinct from None so config dedup can tell "never logged" from "logged None".
+_MISSING = object()
+
 _original_wandb_init = None
 _original_wandb_log = None
 _original_wandb_finish = None
@@ -95,6 +98,10 @@ class WandbRunWrapper:
         # Keys we've already warned about being unforwardable to Pluto, so a
         # value logged every step warns once rather than spamming the logs.
         self._unforwardable_warned: set = set()
+        # Last config values we synced to Pluto, keyed by log key. Lets us skip
+        # redundant update_config() calls when a str/bool/config value is logged
+        # unchanged every step (a common pattern: phase/status/checkpoint paths).
+        self._last_logged_config: Dict[str, Any] = {}
 
         if self._pluto_run:
             atexit.register(self._atexit_cleanup_pluto)
@@ -174,9 +181,13 @@ class WandbRunWrapper:
           summary/overview placement and stay queryable via
           get_run().config.
         - anything else with no metric/media mapping -> preserved as
-          config if JSON-serializable, otherwise dropped and reported to
-          Sentry telemetry once per key (a maintainer-coverage signal, not
-          a user-facing warning). See _handle_unforwardable.
+          config if it survives update_config's normalization (incl.
+          OmegaConf), otherwise dropped and reported to Sentry telemetry
+          once per key (a maintainer-coverage signal, not a user-facing
+          warning). See _handle_unforwardable.
+
+        str/bool/config values are deduped against the last synced value, so
+        logging an unchanged value every step doesn't spam update_config.
         """
         # Determine the step to use for Pluto.
         # When step is explicit, use it. Otherwise:
@@ -217,13 +228,17 @@ class WandbRunWrapper:
                     if isinstance(value, bool):
                         # bool is a subclass of int, but Pluto drops bool
                         # metrics — surface it as config so it isn't lost.
-                        pluto_config[key] = value
+                        # Skip if unchanged since last log (avoid redundant
+                        # config writes when logged every step).
+                        if self._last_logged_config.get(key, _MISSING) != value:
+                            pluto_config[key] = value
                     elif isinstance(value, (int, float)):
                         pluto_data[key] = value
                     elif (num := _as_scalar_number(value)) is not None:
                         pluto_data[key] = num
                     elif isinstance(value, str):
-                        pluto_config[key] = value
+                        if self._last_logged_config.get(key, _MISSING) != value:
+                            pluto_config[key] = value
                     elif isinstance(value, (list, tuple)):
                         # List of wandb media — convert each element.
                         converted_items = []
@@ -247,22 +262,32 @@ class WandbRunWrapper:
                             # so the value is never silently dropped.
                             self._handle_unforwardable(key, value, pluto_config)
 
+                # Metrics and config are sent in independent try blocks: a
+                # failure logging metrics must NOT skip the config update (or
+                # vice versa) — str/bool from the same wandb.log() call live in
+                # config and would otherwise be silently lost.
                 if pluto_data:
-                    log_kwargs = {}
-                    if actual_step is not None:
-                        log_kwargs['step'] = actual_step
-                    self._pluto_run.log(pluto_data, **log_kwargs)
+                    try:
+                        log_kwargs = {}
+                        if actual_step is not None:
+                            log_kwargs['step'] = actual_step
+                        self._pluto_run.log(pluto_data, **log_kwargs)
+                    except Exception as e:
+                        logger.debug(
+                            f'pluto.compat.wandb: Failed to log metrics to Pluto: {e}'
+                        )
 
                 if pluto_config:
                     try:
                         self._pluto_run.update_config(pluto_config)
+                        # Only remember as synced once the update succeeds.
+                        self._last_logged_config.update(pluto_config)
                     except Exception as e:
                         logger.debug(
-                            f'pluto.compat.wandb: Failed to sync string/bool '
-                            f'values to Pluto config: {e}'
+                            f'pluto.compat.wandb: Failed to sync config to Pluto: {e}'
                         )
             except Exception as e:
-                logger.debug(f'pluto.compat.wandb: Failed to log metrics to Pluto: {e}')
+                logger.debug(f'pluto.compat.wandb: Failed to prepare Pluto data: {e}')
 
         return result
 
@@ -276,9 +301,11 @@ class WandbRunWrapper:
         silently — which is what made missing data so hard to diagnose —
         we:
 
-        1. Preserve the value as config if it's JSON-serializable (mirrors
-           how wandb keeps loose values in the run summary). This covers
-           nested dicts/lists of primitives, None, etc.
+        1. Preserve the value as config if it survives update_config's own
+           normalization (mirrors how wandb keeps loose values in the run
+           summary). This covers nested dicts/lists of primitives, None, and
+           OmegaConf DictConfig/ListConfig nodes (which to_native_config
+           deep-converts). Skipped if unchanged since the last log.
         2. Otherwise drop the Pluto copy (it still reached W&B) and report
            it as a maintainer-coverage signal via Sentry telemetry — once
            per key. This is a gap in OUR type handling, not a user error,
@@ -287,8 +314,10 @@ class WandbRunWrapper:
            we can fix. The local log stays at debug for self-host
            debugging.
         """
-        if _is_json_serializable(value):
-            pluto_config[key] = value
+        storable, native = _config_storable_value(value)
+        if storable:
+            if self._last_logged_config.get(key, _MISSING) != native:
+                pluto_config[key] = native
             return
         if key in self._unforwardable_warned:
             return
@@ -625,19 +654,28 @@ def _as_scalar_number(value):
     return result
 
 
-def _is_json_serializable(value) -> bool:
-    """True if value can be stored as Pluto config (round-trips through JSON).
+def _config_storable_value(value):
+    """Return ``(storable, native)`` for the config fallback.
 
-    Used as the last-resort fallback for values with no metric/media
-    mapping: serializable ones (str, bool, None, nested dicts/lists of
-    primitives) are preserved as config; everything else is warned about
-    and dropped. Mirrors the serialization Pluto config itself performs.
+    Mirrors what ``update_config`` actually does — normalize via
+    ``to_native_config`` (which deep-converts OmegaConf ``DictConfig`` /
+    ``ListConfig`` to native containers), then check JSON-serializability.
+    Keeping the gate in lockstep with ``update_config`` means a logged
+    ``DictConfig`` is correctly stored as config, even though plain
+    ``json.dumps`` would reject it. Tensors / ndarrays / custom objects still
+    fail (``to_native_config`` leaves them as-is) and fall through to the
+    Sentry path.
+
+    Returns ``(True, native_value)`` when storable, else ``(False, None)``.
     """
     try:
-        json.dumps(value)
-        return True
-    except (TypeError, ValueError):
-        return False
+        from pluto.util import to_native_config
+
+        native = to_native_config(value)
+        json.dumps(native)
+        return True, native
+    except Exception:
+        return False, None
 
 
 def _is_torch_distributed() -> bool:

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -41,6 +41,7 @@ Hard Requirements:
 """
 
 import atexit
+import json
 import logging
 import os
 import threading
@@ -91,6 +92,9 @@ class WandbRunWrapper:
         self._fallback_step = 0  # Used when wandb is disabled (_step won't increment)
         self._closed = False
         self._close_lock = threading.Lock()
+        # Keys we've already warned about being unforwardable to Pluto, so a
+        # value logged every step warns once rather than spamming the logs.
+        self._unforwardable_warned: set = set()
 
         if self._pluto_run:
             atexit.register(self._atexit_cleanup_pluto)
@@ -169,6 +173,10 @@ class WandbRunWrapper:
           string/bool time-series metric, so these mirror wandb's
           summary/overview placement and stay queryable via
           get_run().config.
+        - anything else with no metric/media mapping -> preserved as
+          config if JSON-serializable, otherwise dropped with a ONE-TIME
+          warning per key (see _handle_unforwardable). Nothing is dropped
+          silently.
         """
         # Determine the step to use for Pluto.
         # When step is explicit, use it. Otherwise:
@@ -225,11 +233,19 @@ class WandbRunWrapper:
                                 converted_items.append(c)
                         if converted_items:
                             pluto_data[key] = converted_items
+                        else:
+                            # Not a media list (e.g. list of primitives) —
+                            # preserve as config if possible, else warn.
+                            self._handle_unforwardable(key, value, pluto_config)
                     else:
                         # Try to convert wandb data types to pluto equivalents
                         converted = _convert_wandb_to_pluto(key, value, self._pluto)
                         if converted is not None:
                             pluto_data[key] = converted
+                        else:
+                            # No metric/media mapping — last-resort handling
+                            # so the value is never silently dropped.
+                            self._handle_unforwardable(key, value, pluto_config)
 
                 if pluto_data:
                     log_kwargs = {}
@@ -249,6 +265,36 @@ class WandbRunWrapper:
                 logger.debug(f'pluto.compat.wandb: Failed to log metrics to Pluto: {e}')
 
         return result
+
+    def _handle_unforwardable(self, key, value, pluto_config: Dict[str, Any]) -> None:
+        """Last-resort handling for a value with no metric/media mapping.
+
+        Pluto only stores numbers (metrics), media/structured data, and
+        config — so values outside those (dicts, None, raw/multi-element
+        tensors, numpy arrays, unconvertible wandb media like Html/Object3D,
+        custom objects) have nowhere to go. Rather than dropping them
+        silently — which is what made missing data so hard to diagnose —
+        we:
+
+        1. Preserve the value as config if it's JSON-serializable (mirrors
+           how wandb keeps loose values in the run summary). This covers
+           nested dicts/lists of primitives, None, etc.
+        2. Otherwise warn ONCE per key (WARNING, not debug) naming the key
+           and type, so the drop is visible. The value still reached W&B;
+           only the Pluto copy is dropped.
+        """
+        if _is_json_serializable(value):
+            pluto_config[key] = value
+            return
+        if key not in self._unforwardable_warned:
+            self._unforwardable_warned.add(key)
+            logger.warning(
+                'pluto.compat.wandb: not forwarding %r to Pluto — value of '
+                'type %s has no metric/media/config mapping (it was still '
+                'logged to W&B). This warning is shown once per key.',
+                key,
+                type(value).__name__,
+            )
 
     def finish(self, exit_code=None, quiet=None):
         """Finish both wandb and Pluto runs."""
@@ -558,6 +604,21 @@ def _as_scalar_number(value):
     if isinstance(result, bool) or not isinstance(result, (int, float)):
         return None
     return result
+
+
+def _is_json_serializable(value) -> bool:
+    """True if value can be stored as Pluto config (round-trips through JSON).
+
+    Used as the last-resort fallback for values with no metric/media
+    mapping: serializable ones (str, bool, None, nested dicts/lists of
+    primitives) are preserved as config; everything else is warned about
+    and dropped. Mirrors the serialization Pluto config itself performs.
+    """
+    try:
+        json.dumps(value)
+        return True
+    except (TypeError, ValueError):
+        return False
 
 
 def _is_torch_distributed() -> bool:

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -158,7 +158,17 @@ class WandbRunWrapper:
             logger.debug(f'pluto.compat.wandb: Pluto finish timed out after {timeout}s')
 
     def log(self, data: Dict[str, Any], step=None, commit=None, **kwargs):
-        """Log metrics to both wandb and Pluto."""
+        """Log metrics to both wandb and Pluto.
+
+        Value routing for the Pluto side:
+        - int/float, torch & numpy scalars -> Pluto metrics (time-series)
+        - wandb media (Image/Video/Audio/Histogram/Table), and lists
+          thereof -> converted Pluto media
+        - str and bool -> Pluto config (latest-wins). Pluto has no
+          string/bool time-series metric, so these mirror wandb's
+          summary/overview placement and stay queryable via
+          get_run().config.
+        """
         # Determine the step to use for Pluto.
         # When step is explicit, use it. Otherwise:
         # - Normal mode: read wandb's _step before log() increments it
@@ -186,11 +196,25 @@ class WandbRunWrapper:
                 # Pluto.log() natively supports lists, so we just need
                 # to convert each element and pass the list through.
                 pluto_data: Dict[str, Any] = {}
+                # String values have no time-series metric equivalent in
+                # Pluto (op._process_log_item_sync only keeps int/float/
+                # tensor/File/Data). wandb puts loose strings in the run
+                # summary/overview; the closest Pluto analogue is config,
+                # which is latest-wins and queryable via get_run().config.
+                # This is what lets e.g. a resume skill read back the most
+                # recent checkpoint/r2_path for a run.
+                pluto_config: Dict[str, Any] = {}
                 for key, value in data.items():
-                    if isinstance(value, (int, float)):
+                    if isinstance(value, bool):
+                        # bool is a subclass of int, but Pluto drops bool
+                        # metrics — surface it as config so it isn't lost.
+                        pluto_config[key] = value
+                    elif isinstance(value, (int, float)):
                         pluto_data[key] = value
-                    elif _is_torch_tensor_scalar(value):
+                    elif _is_torch_tensor_scalar(value) or _is_numpy_scalar(value):
                         pluto_data[key] = value.item()
+                    elif isinstance(value, str):
+                        pluto_config[key] = value
                     elif isinstance(value, (list, tuple)):
                         # List of wandb media — convert each element.
                         converted_items = []
@@ -211,6 +235,15 @@ class WandbRunWrapper:
                     if actual_step is not None:
                         log_kwargs['step'] = actual_step
                     self._pluto_run.log(pluto_data, **log_kwargs)
+
+                if pluto_config:
+                    try:
+                        self._pluto_run.update_config(pluto_config)
+                    except Exception as e:
+                        logger.debug(
+                            f'pluto.compat.wandb: Failed to sync string/bool '
+                            f'values to Pluto config: {e}'
+                        )
             except Exception as e:
                 logger.debug(f'pluto.compat.wandb: Failed to log metrics to Pluto: {e}')
 
@@ -504,6 +537,22 @@ def _is_torch_tensor_scalar(value):
         import torch
 
         return isinstance(value, torch.Tensor) and value.dim() == 0
+    except ImportError:
+        return False
+
+
+def _is_numpy_scalar(value):
+    """Check if value is a numpy scalar number (e.g. np.int64, np.float32).
+
+    numpy scalars are NOT instances of Python int/float, so frameworks that
+    log ``np.int64(step)`` / ``np.float32(loss)`` would otherwise be dropped
+    by the numeric filter below — even though Pluto's own log() accepts
+    anything with .item(). Booleans are excluded (Pluto drops bool metrics).
+    """
+    try:
+        import numpy as np
+
+        return isinstance(value, np.generic) and not isinstance(value, np.bool_)
     except ImportError:
         return False
 

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -174,9 +174,9 @@ class WandbRunWrapper:
           summary/overview placement and stay queryable via
           get_run().config.
         - anything else with no metric/media mapping -> preserved as
-          config if JSON-serializable, otherwise dropped with a ONE-TIME
-          warning per key (see _handle_unforwardable). Nothing is dropped
-          silently.
+          config if JSON-serializable, otherwise dropped and reported to
+          Sentry telemetry once per key (a maintainer-coverage signal, not
+          a user-facing warning). See _handle_unforwardable.
         """
         # Determine the step to use for Pluto.
         # When step is explicit, use it. Otherwise:
@@ -279,22 +279,41 @@ class WandbRunWrapper:
         1. Preserve the value as config if it's JSON-serializable (mirrors
            how wandb keeps loose values in the run summary). This covers
            nested dicts/lists of primitives, None, etc.
-        2. Otherwise warn ONCE per key (WARNING, not debug) naming the key
-           and type, so the drop is visible. The value still reached W&B;
-           only the Pluto copy is dropped.
+        2. Otherwise drop the Pluto copy (it still reached W&B) and report
+           it as a maintainer-coverage signal via Sentry telemetry — once
+           per key. This is a gap in OUR type handling, not a user error,
+           so we deliberately do NOT emit a user-facing warning: people
+           migrating away from wandb shouldn't be nagged about types only
+           we can fix. The local log stays at debug for self-host
+           debugging.
         """
         if _is_json_serializable(value):
             pluto_config[key] = value
             return
-        if key not in self._unforwardable_warned:
-            self._unforwardable_warned.add(key)
-            logger.warning(
-                'pluto.compat.wandb: not forwarding %r to Pluto — value of '
-                'type %s has no metric/media/config mapping (it was still '
-                'logged to W&B). This warning is shown once per key.',
-                key,
-                type(value).__name__,
+        if key in self._unforwardable_warned:
+            return
+        self._unforwardable_warned.add(key)
+        type_name = type(value).__name__
+        # Quiet locally (debug only) — not a user-actionable problem.
+        logger.debug(
+            'pluto.compat.wandb: not forwarding %r to Pluto — type %s has no '
+            'metric/media/config mapping (still logged to W&B).',
+            key,
+            type_name,
+        )
+        # Alert us (the maintainers) so we can add coverage for the type.
+        # Message is keyed on the type (not the run-specific key) so Sentry
+        # groups all occurrences of the same unhandled type together.
+        try:
+            from pluto import sentry
+
+            sentry.capture_message(
+                f'wandb compat: unforwardable Pluto log value of type '
+                f'{type_name!r} (no metric/media/config mapping)',
+                level='warning',
             )
+        except Exception:
+            pass
 
     def finish(self, exit_code=None, quiet=None):
         """Finish both wandb and Pluto runs."""

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -41,6 +41,7 @@ Hard Requirements:
 """
 
 import atexit
+import copy
 import json
 import logging
 import os
@@ -281,7 +282,12 @@ class WandbRunWrapper:
                     try:
                         self._pluto_run.update_config(pluto_config)
                         # Only remember as synced once the update succeeds.
-                        self._last_logged_config.update(pluto_config)
+                        # deepcopy so the dedup snapshot can't share a reference
+                        # with a caller-owned mutable: today pluto_config holds
+                        # only immutable str/bool or a fresh to_native_config
+                        # rebuild, but copying keeps the != comparison correct
+                        # even if a future branch stores a user object directly.
+                        self._last_logged_config.update(copy.deepcopy(pluto_config))
                     except Exception as e:
                         logger.debug(
                             f'pluto.compat.wandb: Failed to sync config to Pluto: {e}'

--- a/pluto/file.py
+++ b/pluto/file.py
@@ -23,6 +23,10 @@ INVALID_CHAR = re.compile(r'[^a-zA-Z0-9_\-.]')
 
 class File:
     tag = tag
+    # Optional user-provided caption (e.g. Image(caption=...)). Media subclasses
+    # override this instance attribute in their __init__; the class-level default
+    # ensures it always exists (e.g. on a directly-constructed File).
+    _caption: Optional[str] = None
 
     def __init__(
         self,
@@ -112,6 +116,10 @@ class Artifact(File):
         self._tmp: Optional[str] = None
         self._ext: str = ''
         self._name = caption + f'.{uuid.uuid4()}' if caption else f'{uuid.uuid4()}'
+        # Preserve the raw caption separately so it can be sent to the server
+        # as a dedicated field (mlop_files.caption); _name keeps the legacy
+        # caption-as-filename behavior for back-compat with older servers.
+        self._caption = caption
         self._id = f'{uuid.uuid4()}{uuid.uuid4()}'.replace('-', '')
 
         self._metadata: Dict[str, Any] = metadata or {}
@@ -148,6 +156,10 @@ class Text(File):
 
     def __init__(self, data: Union[str, Any], caption: Optional[str] = None) -> None:
         self._name = caption + f'.{uuid.uuid4()}' if caption else f'{uuid.uuid4()}'
+        # Preserve the raw caption separately so it can be sent to the server
+        # as a dedicated field (mlop_files.caption); _name keeps the legacy
+        # caption-as-filename behavior for back-compat with older servers.
+        self._caption = caption
         self._id = f'{uuid.uuid4()}{uuid.uuid4()}'.replace('-', '')
         self._ext = '.txt'
         self._path: Optional[str] = None
@@ -182,6 +194,10 @@ class Image(File):
         caption: Optional[str] = None,
     ) -> None:
         self._name = caption + f'.{uuid.uuid4()}' if caption else f'{uuid.uuid4()}'
+        # Preserve the raw caption separately so it can be sent to the server
+        # as a dedicated field (mlop_files.caption); _name keeps the legacy
+        # caption-as-filename behavior for back-compat with older servers.
+        self._caption = caption
         self._id = f'{uuid.uuid4()}{uuid.uuid4()}'.replace('-', '')
         self._ext = '.png'
         self._image: Any = None
@@ -252,6 +268,10 @@ class Audio(File):
         rate = kwargs.get('sample_rate', rate)
 
         self._name = caption + f'.{uuid.uuid4()}' if caption else f'{uuid.uuid4()}'
+        # Preserve the raw caption separately so it can be sent to the server
+        # as a dedicated field (mlop_files.caption); _name keeps the legacy
+        # caption-as-filename behavior for back-compat with older servers.
+        self._caption = caption
         self._id = f'{uuid.uuid4()}{uuid.uuid4()}'.replace('-', '')
         self._ext = '.wav'
         self._audio: Any
@@ -305,6 +325,10 @@ class Video(File):
         rate = kwargs.get('fps', rate)
 
         self._name = caption + f'.{uuid.uuid4()}' if caption else f'{uuid.uuid4()}'
+        # Preserve the raw caption separately so it can be sent to the server
+        # as a dedicated field (mlop_files.caption); _name keeps the legacy
+        # caption-as-filename behavior for back-compat with older servers.
+        self._caption = caption
         self._id = f'{uuid.uuid4()}{uuid.uuid4()}'.replace('-', '')
         self._ext = f'.{format}' if format in ['mp4', 'webm', 'ogg', 'gif'] else '.mp4'
         self._path: Optional[str] = None

--- a/pluto/op.py
+++ b/pluto/op.py
@@ -638,6 +638,7 @@ class Op:
                 log_name=log_name,
                 timestamp_ms=timestamp_ms,
                 step=self._step,
+                caption=file_obj._caption,
             )
             logger.debug(
                 f'{tag}: enqueued file {file_obj._name}{file_obj._ext} for sync'

--- a/pluto/sync/process.py
+++ b/pluto/sync/process.py
@@ -346,6 +346,7 @@ class SyncProcessManager:
         log_name: str,
         timestamp_ms: int,
         step: Optional[int] = None,
+        caption: Optional[str] = None,
     ) -> None:
         """
         Enqueue a file for upload.
@@ -363,6 +364,7 @@ class SyncProcessManager:
             log_name=log_name,
             timestamp_ms=timestamp_ms,
             step=step,
+            caption=caption,
         )
         # Update heartbeat to show we're alive
         self.store.heartbeat(self.run_id)
@@ -1287,16 +1289,20 @@ class _SyncUploader:
         for f in file_records:
             file_ext = f.file_ext
             file_type = file_ext[1:] if file_ext.startswith('.') else file_ext
-            batch.append(
-                {
-                    'fileName': f'{f.file_name}{f.file_ext}',
-                    'fileSize': f.file_size,
-                    'fileType': file_type,
-                    'time': f.timestamp_ms,
-                    'logName': f.log_name,
-                    'step': f.step,
-                }
-            )
+            entry: Dict[str, Any] = {
+                'fileName': f'{f.file_name}{f.file_ext}',
+                'fileSize': f.file_size,
+                'fileType': file_type,
+                'time': f.timestamp_ms,
+                'logName': f.log_name,
+                'step': f.step,
+            }
+            # Only include caption when set — keeps the payload identical to
+            # before for un-captioned files and older servers (which ignore
+            # unknown fields anyway).
+            if f.caption is not None:
+                entry['caption'] = f.caption
+            batch.append(entry)
 
         body = json.dumps({'files': batch})
         headers = self._get_headers()

--- a/pluto/sync/store.py
+++ b/pluto/sync/store.py
@@ -162,6 +162,7 @@ class FileRecord:
     last_attempt_at: Optional[float]
     error_message: Optional[str]
     presigned_url: Optional[str]
+    caption: Optional[str] = None
 
 
 @dataclass
@@ -193,7 +194,8 @@ class SyncStore:
     - Health diagnostics (queue depth, write latency, WAL size)
     """
 
-    SCHEMA_VERSION = 1
+    # v2: added file_uploads.caption (backfilled via _add_column_if_missing)
+    SCHEMA_VERSION = 2
 
     # SQLite's own busy handler wait. Kept deliberately short because we layer
     # application-level exponential backoff (see _retry_on_locked) on top: a
@@ -256,10 +258,12 @@ class SyncStore:
                     (self.SCHEMA_VERSION,),
                 )
             elif row['version'] != self.SCHEMA_VERSION:
-                # Handle migrations in future versions
-                logger.warning(
-                    f'{tag}: Schema version mismatch: {row["version"]} != '
-                    f'{self.SCHEMA_VERSION}'
+                logger.info(
+                    f'{tag}: migrating schema {row["version"]} -> {self.SCHEMA_VERSION}'
+                )
+                cursor.execute(
+                    'UPDATE schema_version SET version = ?',
+                    (self.SCHEMA_VERSION,),
                 )
 
             # Run metadata (which runs are active, their sync state)
@@ -318,6 +322,7 @@ class SyncStore:
                     file_name TEXT,
                     file_ext TEXT,
                     log_name TEXT,
+                    caption TEXT,
                     timestamp_ms INTEGER NOT NULL,
                     step INTEGER,
                     status INTEGER DEFAULT 0,
@@ -329,7 +334,23 @@ class SyncStore:
                 )
             """)
 
+            # Additive migrations for DBs created before a column existed.
+            # CREATE TABLE IF NOT EXISTS above is a no-op on an existing table,
+            # so backfill new columns here. Idempotent (skips if present).
+            self._add_column_if_missing(cursor, 'file_uploads', 'caption', 'TEXT')
+
             self.conn.commit()
+
+    def _add_column_if_missing(
+        self, cursor: Any, table: str, column: str, decl: str
+    ) -> None:
+        """Add a column to an existing table if it isn't already present.
+
+        SQLite's ALTER TABLE has no IF NOT EXISTS, so check PRAGMA first.
+        """
+        existing = {r['name'] for r in cursor.execute(f'PRAGMA table_info({table})')}
+        if column not in existing:
+            cursor.execute(f'ALTER TABLE {table} ADD COLUMN {column} {decl}')
 
     @_retry_on_locked
     def register_run(
@@ -672,6 +693,7 @@ class SyncStore:
         log_name: str,
         timestamp_ms: int,
         step: Optional[int] = None,
+        caption: Optional[str] = None,
     ) -> int:
         """Add a file to the upload queue. Returns file record ID."""
         now = time.time()
@@ -681,9 +703,10 @@ class SyncStore:
                 """
                 INSERT INTO file_uploads (
                     run_id, local_path, file_type, file_size,
-                    timestamp_ms, step, created_at, file_name, file_ext, log_name
+                    timestamp_ms, step, created_at, file_name, file_ext,
+                    log_name, caption
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     run_id,
@@ -696,6 +719,7 @@ class SyncStore:
                     file_name,
                     file_ext,
                     log_name,
+                    caption,
                 ),
             )
             return cursor.lastrowid or 0
@@ -738,6 +762,7 @@ class SyncStore:
                         last_attempt_at=row['last_attempt_at'],
                         error_message=row['error_message'],
                         presigned_url=row['remote_url'],
+                        caption=(row['caption'] if 'caption' in row.keys() else None),
                     )
                 )
             return records

--- a/tests/test_sync_process.py
+++ b/tests/test_sync_process.py
@@ -1245,3 +1245,134 @@ class TestDistributedEnvironmentDetection:
                 del os.environ['SLURM_NTASKS']
             if original_world is not None:
                 os.environ['WORLD_SIZE'] = original_world
+
+
+class TestCaptionEndToEndClientPath:
+    """No-network coverage of the *whole* media-caption client path.
+
+    The other caption tests each cover a single link in isolation, with the
+    neighbouring links stubbed out:
+
+    - ``test_wandb_media_caption_forwarded`` mocks ``pluto`` and stops at the
+      wandb->pluto conversion boundary.
+    - ``test_enqueue_file_caption_roundtrip`` calls ``store.enqueue_file``
+      directly.
+    - ``test_file_payload_includes_caption`` hand-builds a ``FileRecord``.
+
+    None of them drive a *real* ``pluto.Image/Audio/Video/Text/Artifact(
+    caption=...)`` through ``Op._enqueue_file_sync`` -- which runs
+    ``load()``/``_mkcopy()`` and reads ``file_obj._caption`` -- and on into the
+    ``/files`` presign payload. That glue is exactly where a caption can be
+    silently dropped, and it's the path a logged caption actually travels to
+    the server. This test exercises the full chain for every media type
+    (including Video), so a regression in any single link fails here.
+    """
+
+    def _build_media(self, tmp_path):
+        """Real on-disk media so load()/_mkcopy() run for real.
+
+        Returns ``[(log_name, pluto_obj, expected_caption)]`` including one
+        deliberately un-captioned file (expected ``None``).
+        """
+        png = tmp_path / 'src.png'
+        png.write_bytes(bytes.fromhex('89504e470d0a1a0a') + b'\x00' * 64)
+        wav = tmp_path / 'src.wav'
+        wav.write_bytes(b'RIFF\x00\x00\x00\x00WAVE' + b'\x00' * 64)
+        mp4 = tmp_path / 'src.mp4'
+        mp4.write_bytes(b'\x00\x00\x00\x18ftypmp42' + b'\x00' * 64)
+        art = tmp_path / 'src.json'
+        art.write_text('{"k": 1}')
+
+        return [
+            (
+                'media/image',
+                pluto.Image(str(png), caption='a fluffy cat'),
+                'a fluffy cat',
+            ),
+            (
+                'media/audio',
+                pluto.Audio(str(wav), caption='one second of noise'),
+                'one second of noise',
+            ),
+            (
+                'media/video',
+                pluto.Video(str(mp4), caption='ten random frames'),
+                'ten random frames',
+            ),
+            ('media/text', pluto.Text('log line', caption='a caption'), 'a caption'),
+            (
+                'media/artifact',
+                pluto.Artifact(str(art), caption='an artifact'),
+                'an artifact',
+            ),
+            # No caption -> must propagate as None / be omitted from payload.
+            ('media/no_caption', pluto.Image(str(png)), None),
+        ]
+
+    def test_captions_reach_files_payload(self, tmp_path):
+        import types
+
+        from pluto.op import Op
+
+        # Real SQLite store; a fake sync manager forwards _enqueue_file_sync's
+        # call straight into it (the real SyncProcessManager would do the same,
+        # minus spawning a subprocess).
+        store = SyncStore(str(tmp_path / 'sync.db'))
+        os.makedirs(tmp_path / 'files', exist_ok=True)
+
+        def _enqueue_file(**kwargs):
+            store.enqueue_file(run_id='test-run', **kwargs)
+
+        fake_op = types.SimpleNamespace(
+            _sync_manager=types.SimpleNamespace(enqueue_file=_enqueue_file),
+            settings=types.SimpleNamespace(get_dir=lambda: str(tmp_path)),
+            _step=1,
+        )
+
+        media = self._build_media(tmp_path)
+        for log_name, obj, _ in media:
+            Op._enqueue_file_sync(fake_op, log_name, obj, 1705600000000)
+
+        # Glue link: caption survived load()/_mkcopy() into the stored record.
+        records = store.get_pending_files(limit=50)
+        by_log = {r.log_name: r for r in records}
+        assert set(by_log) == {m[0] for m in media}
+        for log_name, _, expected in media:
+            assert by_log[log_name].caption == expected, (
+                f'{log_name}: stored caption {by_log[log_name].caption!r} '
+                f'!= expected {expected!r}'
+            )
+
+        # Final link: the caption shows up in the /files presign payload that
+        # is actually POSTed to the server (and is omitted when unset).
+        settings = {
+            '_auth': 'test-token',
+            '_op_id': 12345,
+            '_op_name': 'test-run',
+            'project': 'test-project',
+            'url_file': 'https://test.example.com/files',
+        }
+        uploader = _SyncUploader(settings, logging.getLogger('test'))
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {}
+        with patch('httpx.Client') as MockClient:
+            mock_client = MagicMock()
+            mock_client.post.return_value = mock_response
+            MockClient.return_value = mock_client
+            uploader._client = None
+
+            uploader._get_presigned_urls(records)
+
+            call_args = mock_client.post.call_args
+            body = call_args.kwargs.get('content') or call_args[1].get('content')
+            if isinstance(body, bytes):
+                body = body.decode('utf-8')
+            payload = {f['logName']: f for f in json.loads(body)['files']}
+
+        for log_name, _, expected in media:
+            if expected is None:
+                assert 'caption' not in payload[log_name]
+            else:
+                assert payload[log_name]['caption'] == expected

--- a/tests/test_sync_process.py
+++ b/tests/test_sync_process.py
@@ -436,9 +436,9 @@ class TestSyncProcessShutdown:
         assert 'test_metric_gamma' in run.settings.meta
 
         # Verify _iface exists and would have been used for metadata
-        assert run._iface is not None, (
-            'ServerInterface must exist to register metric names with server'
-        )
+        assert (
+            run._iface is not None
+        ), 'ServerInterface must exist to register metric names with server'
 
         run.finish()
 

--- a/tests/test_sync_process.py
+++ b/tests/test_sync_process.py
@@ -90,6 +90,88 @@ class TestSyncStore:
         assert all(isinstance(f, FileRecord) for f in pending)
         assert all(f.status == SyncStatus.PENDING for f in pending)
 
+    def test_enqueue_file_caption_roundtrip(self, store):
+        """A caption set on enqueue survives the get_pending_files read-back,
+        and an un-captioned file reads back as None."""
+        store.register_run('test-run-1', 'test-project')
+
+        store.enqueue_file(
+            run_id='test-run-1',
+            local_path='/tmp/cat.png',
+            file_name='cat',
+            file_ext='.png',
+            file_type='image/png',
+            file_size=1024,
+            log_name='eval/images',
+            timestamp_ms=int(time.time() * 1000),
+            step=0,
+            caption='a fluffy orange cat',
+        )
+        store.enqueue_file(
+            run_id='test-run-1',
+            local_path='/tmp/dog.png',
+            file_name='dog',
+            file_ext='.png',
+            file_type='image/png',
+            file_size=1024,
+            log_name='eval/images',
+            timestamp_ms=int(time.time() * 1000),
+            step=1,
+        )
+
+        by_name = {f.file_name: f for f in store.get_pending_files(limit=10)}
+        assert by_name['cat'].caption == 'a fluffy orange cat'
+        assert by_name['dog'].caption is None
+
+    def test_caption_migration_on_legacy_db(self, tmp_path):
+        """A DB created without the caption column gets it added on open
+        (additive migration), so enqueue/select with caption works."""
+        import sqlite3
+
+        db_path = str(tmp_path / 'legacy.db')
+        # Simulate a pre-caption file_uploads table.
+        conn = sqlite3.connect(db_path)
+        conn.execute("""
+            CREATE TABLE file_uploads (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id TEXT NOT NULL,
+                local_path TEXT NOT NULL,
+                remote_url TEXT,
+                file_type TEXT NOT NULL,
+                file_size INTEGER,
+                file_name TEXT,
+                file_ext TEXT,
+                log_name TEXT,
+                timestamp_ms INTEGER NOT NULL,
+                step INTEGER,
+                status INTEGER DEFAULT 0,
+                retry_count INTEGER DEFAULT 0,
+                created_at REAL NOT NULL,
+                last_attempt_at REAL,
+                error_message TEXT
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        store = SyncStore(db_path)
+        store.register_run('r', 'p')
+        store.enqueue_file(
+            run_id='r',
+            local_path='/tmp/cat.png',
+            file_name='cat',
+            file_ext='.png',
+            file_type='image/png',
+            file_size=1,
+            log_name='eval/images',
+            timestamp_ms=int(time.time() * 1000),
+            step=0,
+            caption='migrated cat',
+        )
+        pending = store.get_pending_files(limit=10)
+        store.close()
+        assert pending[0].caption == 'migrated cat'
+
     def test_file_status_transitions(self, store):
         """Test file status transitions work correctly."""
         store.register_run('test-run-1', 'test-project')
@@ -354,9 +436,9 @@ class TestSyncProcessShutdown:
         assert 'test_metric_gamma' in run.settings.meta
 
         # Verify _iface exists and would have been used for metadata
-        assert (
-            run._iface is not None
-        ), 'ServerInterface must exist to register metric names with server'
+        assert run._iface is not None, (
+            'ServerInterface must exist to register metric names with server'
+        )
 
         run.finish()
 
@@ -537,6 +619,72 @@ class TestSyncUploaderPayloadFormat:
             assert 'v' not in payload, "Should not use 'v' field"
             assert 's' not in payload, "Should not use 's' field"
             assert 't' not in payload, "Should not use 't' field"
+
+    def test_file_payload_includes_caption(self, uploader):
+        """The /files presign payload carries `caption` when set, and omits
+        the key entirely when the file has no caption."""
+        records = [
+            FileRecord(
+                id=1,
+                run_id='test-run',
+                local_path='/tmp/cat.png',
+                file_name='cat',
+                file_ext='.png',
+                file_type='image/png',
+                file_size=10,
+                log_name='eval/images',
+                timestamp_ms=1705600000000,
+                step=0,
+                status=SyncStatus.PENDING,
+                retry_count=0,
+                created_at=time.time(),
+                last_attempt_at=None,
+                error_message=None,
+                presigned_url=None,
+                caption='a fluffy orange cat',
+            ),
+            FileRecord(
+                id=2,
+                run_id='test-run',
+                local_path='/tmp/dog.png',
+                file_name='dog',
+                file_ext='.png',
+                file_type='image/png',
+                file_size=10,
+                log_name='eval/images',
+                timestamp_ms=1705600000000,
+                step=1,
+                status=SyncStatus.PENDING,
+                retry_count=0,
+                created_at=time.time(),
+                last_attempt_at=None,
+                error_message=None,
+                presigned_url=None,
+                caption=None,
+            ),
+        ]
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {}
+
+        with patch('httpx.Client') as MockClient:
+            mock_client = MagicMock()
+            mock_client.post.return_value = mock_response
+            MockClient.return_value = mock_client
+            uploader._client = None
+
+            uploader._get_presigned_urls(records)
+
+            call_args = mock_client.post.call_args
+            body = call_args.kwargs.get('content') or call_args[1].get('content')
+            if isinstance(body, bytes):
+                body = body.decode('utf-8')
+            files = json.loads(body)['files']
+            by_name = {f['fileName']: f for f in files}
+
+            assert by_name['cat.png']['caption'] == 'a fluffy orange cat'
+            assert 'caption' not in by_name['dog.png']
 
     def test_metrics_payload_filters_non_numeric(self, uploader):
         """Test that non-numeric values are filtered from metrics."""

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -236,3 +236,71 @@ def test_omegaconf_config_flows_through_shim_and_serializes(clean_env, monkeypat
     payload = make_compat_start_v1(native, Settings(), info=None)
     inner = json.loads(json.loads(payload.decode())['config'])
     assert inner['model']['full_name'] == 'resnet-v2'  # interpolation resolved
+
+
+# ---------------------------------------------------------------------------
+# WandbRunWrapper.log value routing
+#
+# The shim pre-filters each logged value before forwarding to Pluto. These
+# tests pin the routing that backs the /resume-crashed-run use case: string
+# paths (e.g. checkpoint/r2_path) must reach Pluto as config (latest-wins,
+# queryable via get_run().config), and numpy scalars must not be silently
+# dropped the way plain str/np values were before.
+# ---------------------------------------------------------------------------
+
+
+def _make_wrapper():
+    """Build a WandbRunWrapper with mock wandb/pluto runs (no atexit)."""
+    wandb_run = MagicMock()
+    wandb_run._step = 7
+    pluto_run = MagicMock()
+    pluto_module = MagicMock()
+    # Avoid registering a real atexit handler during the test.
+    with mock.patch.object(wandb_compat.atexit, 'register'):
+        wrapper = wandb_compat.WandbRunWrapper(
+            wandb_run, pluto_run, pluto_module, wandb_disabled=False
+        )
+    return wrapper, pluto_run
+
+
+def test_log_routes_strings_to_config_not_metrics():
+    """checkpoint/r2_path (a str) must land in Pluto config, not log()."""
+    wrapper, pluto_run = _make_wrapper()
+
+    wrapper.log(
+        {
+            'checkpoint/step': 100,
+            'checkpoint/r2_path': 's3://bucket/run/ckpt-100.pt',
+            'checkpoint/local_path': '/nfs/run/ckpt-100.pt',
+        }
+    )
+
+    # Strings forwarded to config (latest-wins, readable via get_run().config).
+    assert pluto_run.update_config.call_count == 1
+    cfg = pluto_run.update_config.call_args.args[0]
+    assert cfg['checkpoint/r2_path'] == 's3://bucket/run/ckpt-100.pt'
+    assert cfg['checkpoint/local_path'] == '/nfs/run/ckpt-100.pt'
+
+    # Numeric value still goes to metrics; strings must NOT be in log().
+    logged = pluto_run.log.call_args.args[0]
+    assert logged == {'checkpoint/step': 100}
+    assert 'checkpoint/r2_path' not in logged
+
+
+def test_log_forwards_numpy_scalars_as_metrics():
+    """np.int64/np.float32 must reach Pluto metrics, not be dropped."""
+    np = pytest.importorskip('numpy')
+    wrapper, pluto_run = _make_wrapper()
+
+    wrapper.log(
+        {
+            'checkpoint/step': np.int64(100),
+            'loss': np.float32(0.5),
+        }
+    )
+
+    logged = pluto_run.log.call_args.args[0]
+    assert logged['checkpoint/step'] == 100
+    assert isinstance(logged['checkpoint/step'], int)  # .item() -> python int
+    assert abs(logged['loss'] - 0.5) < 1e-6
+    assert isinstance(logged['loss'], float)

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -88,9 +88,9 @@ def test_init_failure_logs_traceback(clean_env, monkeypatch, caplog):
     assert result is wandb_run
     records = [r for r in caplog.records if 'DUAL-LOGGING DISABLED' in r.getMessage()]
     assert records, 'expected a DUAL-LOGGING DISABLED error log'
-    assert (
-        records[0].exc_info is not None
-    ), 'error must be logged with exc_info so the traceback is surfaced'
+    assert records[0].exc_info is not None, (
+        'error must be logged with exc_info so the traceback is surfaced'
+    )
 
 
 def test_project_kwarg_is_used_when_no_env_vars_set(clean_env):
@@ -411,3 +411,42 @@ def test_omegaconf_value_falls_back_to_config_not_dropped():
     cfg = pluto_run.update_config.call_args.args[0]
     assert cfg['hparams'] == {'lr': 0.01, 'sched': {'name': 'cosine'}}
     assert not cap.called  # OmegaConf is storable -> no maintainer alert
+
+
+# ---------------------------------------------------------------------------
+# Media caption forwarding: wandb.Image/Audio/Video(caption=...) must reach
+# pluto.Image/Audio/Video(caption=...). Regression for the shim dropping it.
+# ---------------------------------------------------------------------------
+def _fake_wandb_media(type_name, path, caption=None):
+    """An object whose type().__name__ matches what the shim dispatches on."""
+    cls = type(type_name, (), {})
+    obj = cls()
+    obj._path = path
+    obj._caption = caption
+    return obj
+
+
+@pytest.mark.parametrize('type_name', ['Image', 'Audio', 'Video'])
+def test_wandb_media_caption_forwarded(type_name):
+    """caption= on a wandb media object is forwarded to the pluto equivalent."""
+    pluto_module = MagicMock()
+    media = _fake_wandb_media(type_name, '/tmp/x.png', caption='a fluffy cat')
+
+    wandb_compat._convert_wandb_to_pluto('eval/images', media, pluto_module)
+
+    factory = getattr(pluto_module, type_name)
+    factory.assert_called_once()
+    assert factory.call_args.kwargs.get('caption') == 'a fluffy cat'
+
+
+@pytest.mark.parametrize('type_name', ['Image', 'Audio', 'Video'])
+def test_wandb_media_without_caption(type_name):
+    """No caption on the wandb object forwards caption=None (not a crash)."""
+    pluto_module = MagicMock()
+    media = _fake_wandb_media(type_name, '/tmp/x.png', caption=None)
+
+    wandb_compat._convert_wandb_to_pluto('eval/images', media, pluto_module)
+
+    factory = getattr(pluto_module, type_name)
+    factory.assert_called_once()
+    assert factory.call_args.kwargs.get('caption') is None

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -342,8 +342,8 @@ def test_log_does_not_treat_failing_item_as_scalar():
     assert not pluto_run.update_config.called
 
 
-def test_unforwardable_value_warns_once_not_silent(caplog):
-    """A value with no Pluto mapping must warn (once per key), never silently drop."""
+def test_unforwardable_value_alerts_sentry_once_not_user():
+    """An unmappable value alerts Sentry (maintainers) once — not the user."""
     wrapper, pluto_run = _make_wrapper()
 
     class _Opaque:
@@ -352,15 +352,15 @@ def test_unforwardable_value_warns_once_not_silent(caplog):
         def item(self):
             raise ValueError('not a scalar')
 
-    with caplog.at_level('WARNING', logger='pluto.compat.wandb'):
+    with mock.patch('pluto.sentry.capture_message') as cap:
         wrapper.log({'mystery': _Opaque()})
-        wrapper.log({'mystery': _Opaque()})  # second time: must NOT warn again
+        wrapper.log({'mystery': _Opaque()})  # second time: no duplicate alert
 
-    warnings = [r for r in caplog.records if 'mystery' in r.getMessage()]
-    assert len(warnings) == 1, 'should warn exactly once per key'
-    assert 'mystery' in warnings[0].getMessage()
-    assert '_Opaque' in warnings[0].getMessage()  # names the offending type
-    # Nothing forwarded — but it was loud about it.
+    # Exactly one maintainer-facing Sentry alert, grouped by type name.
+    assert cap.call_count == 1
+    assert '_Opaque' in cap.call_args.args[0]
+    assert cap.call_args.kwargs.get('level') == 'warning'
+    # Nothing forwarded to the user's run, and no user-facing exception.
     assert not pluto_run.log.called
     assert not pluto_run.update_config.called
 

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -340,3 +340,38 @@ def test_log_does_not_treat_failing_item_as_scalar():
 
     assert not pluto_run.log.called
     assert not pluto_run.update_config.called
+
+
+def test_unforwardable_value_warns_once_not_silent(caplog):
+    """A value with no Pluto mapping must warn (once per key), never silently drop."""
+    wrapper, pluto_run = _make_wrapper()
+
+    class _Opaque:
+        """Not numeric, not media, not JSON-serializable."""
+
+        def item(self):
+            raise ValueError('not a scalar')
+
+    with caplog.at_level('WARNING', logger='pluto.compat.wandb'):
+        wrapper.log({'mystery': _Opaque()})
+        wrapper.log({'mystery': _Opaque()})  # second time: must NOT warn again
+
+    warnings = [r for r in caplog.records if 'mystery' in r.getMessage()]
+    assert len(warnings) == 1, 'should warn exactly once per key'
+    assert 'mystery' in warnings[0].getMessage()
+    assert '_Opaque' in warnings[0].getMessage()  # names the offending type
+    # Nothing forwarded — but it was loud about it.
+    assert not pluto_run.log.called
+    assert not pluto_run.update_config.called
+
+
+def test_json_serializable_unmapped_value_falls_back_to_config():
+    """A dict/None with no metric mapping is preserved as config, not dropped."""
+    wrapper, pluto_run = _make_wrapper()
+
+    wrapper.log({'meta/info': {'kind': 'resume', 'attempt': 3}, 'note': None})
+
+    cfg = pluto_run.update_config.call_args.args[0]
+    assert cfg['meta/info'] == {'kind': 'resume', 'attempt': 3}
+    assert cfg['note'] is None
+    assert not pluto_run.log.called  # no numeric metrics in this call

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -88,9 +88,9 @@ def test_init_failure_logs_traceback(clean_env, monkeypatch, caplog):
     assert result is wandb_run
     records = [r for r in caplog.records if 'DUAL-LOGGING DISABLED' in r.getMessage()]
     assert records, 'expected a DUAL-LOGGING DISABLED error log'
-    assert records[0].exc_info is not None, (
-        'error must be logged with exc_info so the traceback is surfaced'
-    )
+    assert (
+        records[0].exc_info is not None
+    ), 'error must be logged with exc_info so the traceback is surfaced'
 
 
 def test_project_kwarg_is_used_when_no_env_vars_set(clean_env):

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -304,3 +304,39 @@ def test_log_forwards_numpy_scalars_as_metrics():
     assert isinstance(logged['checkpoint/step'], int)  # .item() -> python int
     assert abs(logged['loss'] - 0.5) < 1e-6
     assert isinstance(logged['loss'], float)
+
+
+def test_log_forwards_any_item_scalar_like_pluto_core():
+    """Any scalar exposing .item() is forwarded, matching Pluto's own log().
+
+    Guards against the shim being stricter than op._process_log_item_sync:
+    e.g. an ``epoch`` that arrives as a 0-d-tensor-like wrapper rather than a
+    plain int must still reach Pluto instead of being silently dropped.
+    """
+    wrapper, pluto_run = _make_wrapper()
+
+    class _ScalarLike:
+        def __init__(self, v):
+            self._v = v
+
+        def item(self):
+            return self._v
+
+    wrapper.log({'checkpoint/epoch': _ScalarLike(12)})
+
+    logged = pluto_run.log.call_args.args[0]
+    assert logged == {'checkpoint/epoch': 12}
+
+
+def test_log_does_not_treat_failing_item_as_scalar():
+    """A non-scalar whose .item() raises must not crash or produce a metric."""
+    wrapper, pluto_run = _make_wrapper()
+
+    class _MultiElement:
+        def item(self):
+            raise ValueError('can only convert an array of size 1')
+
+    wrapper.log({'weird': _MultiElement()})
+
+    assert not pluto_run.log.called
+    assert not pluto_run.update_config.called

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -375,3 +375,39 @@ def test_json_serializable_unmapped_value_falls_back_to_config():
     assert cfg['meta/info'] == {'kind': 'resume', 'attempt': 3}
     assert cfg['note'] is None
     assert not pluto_run.log.called  # no numeric metrics in this call
+
+
+def test_log_skips_redundant_config_updates():
+    """An unchanged str/bool config value must not re-trigger update_config."""
+    wrapper, pluto_run = _make_wrapper()
+
+    # First log: config is synced.
+    wrapper.log({'phase': 'train', 'loss': 0.5})
+    assert pluto_run.update_config.call_count == 1
+    assert pluto_run.update_config.call_args.args[0] == {'phase': 'train'}
+
+    # Same config value again: update_config must NOT be called.
+    pluto_run.update_config.reset_mock()
+    wrapper.log({'phase': 'train', 'loss': 0.4})
+    assert pluto_run.update_config.call_count == 0
+
+    # Changed config value: update_config is called again, with only the change.
+    wrapper.log({'phase': 'val', 'loss': 0.3})
+    assert pluto_run.update_config.call_count == 1
+    assert pluto_run.update_config.call_args.args[0] == {'phase': 'val'}
+
+
+def test_omegaconf_value_falls_back_to_config_not_dropped():
+    """A logged OmegaConf node is storable as config (not Sentry-dropped)."""
+    OmegaConf = pytest.importorskip('omegaconf').OmegaConf
+    wrapper, pluto_run = _make_wrapper()
+
+    cfg_node = OmegaConf.create({'lr': 0.01, 'sched': {'name': 'cosine'}})
+
+    with mock.patch('pluto.sentry.capture_message') as cap:
+        wrapper.log({'hparams': cfg_node})
+
+    # Stored as config, deep-converted to native containers; not dropped.
+    cfg = pluto_run.update_config.call_args.args[0]
+    assert cfg['hparams'] == {'lr': 0.01, 'sched': {'name': 'cosine'}}
+    assert not cap.called  # OmegaConf is storable -> no maintainer alert

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"


### PR DESCRIPTION
Threads pluto.Image/Audio/Video(caption=) end-to-end so mlop_files.caption is populated on the live path; the W&B shim now forwards captions too. Server side (mlop_files.caption + /files accepting optional caption) already shipped in #493. Verified e2e against a local server build: pluto.Image(caption=...) populates mlop_files.caption, un-captioned stays NULL. Tests: store round-trip, legacy-DB migration, /files payload include/omit, wandb shim forwarding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds SQLite schema migration and changes wandb→Pluto log routing (config vs metrics), which affects how resume/checkpoint metadata is stored but is guarded with dedup and separate error handling.
> 
> **Overview**
> **Media captions** now flow from `pluto.Image` / `Audio` / `Video` / `Text` / `Artifact` through sync and `/files` presign payloads into optional `caption` on file metadata (`mlop_files.caption`), while keeping the old “caption embedded in filename” behavior for older servers. The wandb shim forwards `wandb.Image`/`Audio`/`Video` `caption=` the same way.
> 
> **Wandb dual-logging** gains smarter value routing: strings and bools (e.g. checkpoint paths) go to Pluto **config** with deduped `update_config`; scalars with `.item()` (numpy/torch) go to metrics like core Pluto; JSON/OmegaConf-friendly values can fall back to config; unmappable types alert Sentry once per key without user warnings. Metrics and config uploads are isolated so one failure does not drop the other.
> 
> Sync SQLite schema bumps to **v2** with an additive `file_uploads.caption` migration; tests cover store round-trip, legacy DB migration, presign JSON, and shim routing/captions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff1b6312eca7c95ce032057360381632c6536754. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->