### PR TITLE
Bump release version to 0.0.24

### DIFF
--- a/docs-api/meta.json
+++ b/docs-api/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "package": "pluto",
-  "package_version": "0.0.23",
+  "package_version": "0.0.24",
   "public_api": [
     "Artifact",
     "Audio",

--- a/pluto/__init__.py
+++ b/pluto/__init__.py
@@ -41,7 +41,7 @@ __all__ = (
     'generate_run_id',
 )
 
-__version__ = '0.0.23'
+__version__ = '0.0.24'
 
 
 # Replaced with the current commit when building the wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pluto-ml"
-version = "0.0.23"
+version = "0.0.24"
 description = "Pluto ML - Machine Learning Operations Framework"
 packages = [
     {include = "pluto"},


### PR DESCRIPTION
Bumps the release version from `0.0.23` to `0.0.24`.

## Changes
- `pyproject.toml`: `version = "0.0.24"`
- `pluto/__init__.py`: `__version__ = '0.0.24'`

The `mlop` compat package re-exports `__version__` from `pluto`, so no separate change is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCbZXYqUQtsqTCjb8YDZuT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no functional code impact.
> 
> **Overview**
> Bumps the **pluto-ml** package release from `0.0.23` to **`0.0.24`** in `pyproject.toml` and `pluto/__init__.py` (`__version__`). No runtime or API changes—only version metadata for the next publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2099dc830b0b8b011f5de71ee89c2202a310492. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->