### PR TITLE
fix(file): bound staging filename so long captions don't silently drop media (videos)

### DIFF
--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -202,6 +202,14 @@ class WandbRunWrapper:
             f'pluto.compat.wandb: {detail} '
             '(Pluto copy dropped; wandb unaffected; further occurrences at debug)'
         )
+        # Telemetry: report the failure once per (context, type) so we see these
+        # in the wild. Self-gates on PLUTO_DISABLE_TELEMETRY / CI; never raises.
+        try:
+            from pluto import sentry
+
+            sentry.capture_exception(exc)
+        except Exception:
+            pass
 
     def log(self, data: Dict[str, Any], step=None, commit=None, **kwargs):
         """Log metrics to both wandb and Pluto.

--- a/pluto/compat/wandb.py
+++ b/pluto/compat/wandb.py
@@ -103,6 +103,10 @@ class WandbRunWrapper:
         # redundant update_config() calls when a str/bool/config value is logged
         # unchanged every step (a common pattern: phase/status/checkpoint paths).
         self._last_logged_config: Dict[str, Any] = {}
+        # (context, exc-type) pairs already surfaced at error, so a failure that
+        # recurs every step is shouted once then drops to debug (see
+        # _log_pluto_failure).
+        self._pluto_failure_warned: set = set()
 
         if self._pluto_run:
             atexit.register(self._atexit_cleanup_pluto)
@@ -168,6 +172,36 @@ class WandbRunWrapper:
             thread.join(timeout=1.0)
         else:
             logger.debug(f'pluto.compat.wandb: Pluto finish timed out after {timeout}s')
+
+    def _log_pluto_failure(self, context: str, exc: Exception) -> None:
+        """Report a swallowed Pluto-side failure at a severity matching its kind.
+
+        The shim must never let a Pluto problem break wandb logging, so callers
+        catch broadly. But severity should depend on the cause:
+
+        - Transient/expected network errors (httpx) are noisy and already
+          retried by the sync layer -> keep them at debug.
+        - Anything else (e.g. an OSError from an oversized staging filename, or
+          a bug) means the user's data was silently dropped and they'd otherwise
+          be left guessing -> surface it at error, once per (context, type) so a
+          per-step failure is shouted once then drops to debug.
+        """
+        import httpx
+
+        if isinstance(exc, httpx.HTTPError):
+            logger.debug(f'pluto.compat.wandb: {context}: {exc}')
+            return
+
+        detail = f'{context}: {type(exc).__name__}: {exc}'
+        key = (context, type(exc).__name__)
+        if key in self._pluto_failure_warned:
+            logger.debug(f'pluto.compat.wandb: {detail}')
+            return
+        self._pluto_failure_warned.add(key)
+        logger.error(
+            f'pluto.compat.wandb: {detail} '
+            '(Pluto copy dropped; wandb unaffected; further occurrences at debug)'
+        )
 
     def log(self, data: Dict[str, Any], step=None, commit=None, **kwargs):
         """Log metrics to both wandb and Pluto.
@@ -274,9 +308,7 @@ class WandbRunWrapper:
                             log_kwargs['step'] = actual_step
                         self._pluto_run.log(pluto_data, **log_kwargs)
                     except Exception as e:
-                        logger.debug(
-                            f'pluto.compat.wandb: Failed to log metrics to Pluto: {e}'
-                        )
+                        self._log_pluto_failure('Failed to log media/metrics', e)
 
                 if pluto_config:
                     try:
@@ -289,11 +321,9 @@ class WandbRunWrapper:
                         # even if a future branch stores a user object directly.
                         self._last_logged_config.update(copy.deepcopy(pluto_config))
                     except Exception as e:
-                        logger.debug(
-                            f'pluto.compat.wandb: Failed to sync config to Pluto: {e}'
-                        )
+                        self._log_pluto_failure('Failed to sync config', e)
             except Exception as e:
-                logger.debug(f'pluto.compat.wandb: Failed to prepare Pluto data: {e}')
+                self._log_pluto_failure('Failed to prepare Pluto data', e)
 
         return result
 

--- a/pluto/file.py
+++ b/pluto/file.py
@@ -20,6 +20,27 @@ tag = 'File'
 VALID_CHAR = re.compile(r'^[a-zA-Z0-9_\-.]+$')
 INVALID_CHAR = re.compile(r'[^a-zA-Z0-9_\-.]')
 
+# Most filesystems cap a single path component at 255 bytes (NAME_MAX). The
+# staging filename embeds the caption-derived ``_name`` — which, via the wandb
+# compat shim, can be a long generation-parameter tuple — so it can overflow
+# that limit and make open()/shutil.copyfile raise ENAMETOOLONG, silently
+# dropping the file. Bound the *on-disk* name only; ``self._name`` (and thus the
+# server-side fileName/display) is left intact.
+NAME_MAX = 255
+
+
+def _bounded_basename(name: str, uid: str, ext: str) -> str:
+    """Build ``{name}-{uid}{ext}``, truncating ``name`` to fit NAME_MAX bytes.
+
+    Only the caption-derived ``name`` is shortened; ``uid`` (uniqueness) and
+    ``ext`` are always preserved, so truncation can't cause collisions or break
+    the extension. Truncation is byte-aware to avoid splitting a multibyte char.
+    """
+    suffix = f'-{uid}{ext}'
+    budget = max(NAME_MAX - len(suffix.encode('utf-8')), 0)
+    safe = name.encode('utf-8')[:budget].decode('utf-8', 'ignore')
+    return f'{safe}{suffix}'
+
 
 class File:
     tag = tag
@@ -65,9 +86,13 @@ class File:
         with open(self._path, 'rb') as f:
             return hashlib.sha256(f.read()).hexdigest()
 
+    def _staging_path(self, dir: str) -> str:
+        """Absolute on-disk path for the staged copy, bounded to NAME_MAX."""
+        return f'{dir}/files/{_bounded_basename(self._name, self._id, self._ext)}'
+
     def _mkcopy(self, dir: str) -> None:
         if self._tmp is None:
-            self._tmp = f'{dir}/files/{self._name}-{self._id}{self._ext}'
+            self._tmp = self._staging_path(dir)
             if self._path is None:
                 raise ValueError('File path is not set')
             shutil.copyfile(self._path, self._tmp)
@@ -138,7 +163,7 @@ class Artifact(File):
 
     def load(self, dir: Optional[str] = None) -> None:
         if not self._path and self._bytes is not None and dir:
-            self._tmp = f'{dir}/files/{self._name}-{self._id}{self._ext}'
+            self._tmp = self._staging_path(dir)
             with open(self._tmp, 'wb') as f:
                 f.write(self._bytes)
             self._path = os.path.abspath(self._tmp)
@@ -175,7 +200,7 @@ class Text(File):
     def load(self, dir: Optional[str] = None) -> None:
         if not self._path:
             if dir:
-                self._tmp = f'{dir}/files/{self._name}-{self._id}{self._ext}'
+                self._tmp = self._staging_path(dir)
                 with open(self._tmp, 'w') as f:
                     f.write(self._text)
                 self._path = os.path.abspath(self._tmp)
@@ -234,7 +259,7 @@ class Image(File):
     def load(self, dir: Optional[str] = None) -> None:
         if not self._path:
             if dir:
-                self._tmp = f'{dir}/files/{self._name}-{self._id}{self._ext}'
+                self._tmp = self._staging_path(dir)
                 if getattr(self, '_matplotlib', False):
                     make_compat_image_matplotlib(self._tmp, self._image)
                 elif self._image == 'bytes' and self._bytes is not None:
@@ -297,7 +322,7 @@ class Audio(File):
     def load(self, dir: Optional[str] = None) -> None:
         if not self._path:
             if dir:
-                self._tmp = f'{dir}/files/{self._name}-{self._id}{self._ext}'
+                self._tmp = self._staging_path(dir)
                 if isinstance(self._audio, str) and self._audio == 'bytes':
                     if self._bytes is not None:
                         with open(self._tmp, 'wb') as f:
@@ -361,7 +386,7 @@ class Video(File):
     def load(self, dir: Optional[str] = None) -> None:
         if not self._path:
             if dir:
-                self._tmp = f'{dir}/files/{self._name}-{self._id}{self._ext}'
+                self._tmp = self._staging_path(dir)
                 if self._video == 'bytes' and self._bytes is not None:
                     with open(self._tmp, 'wb') as f:
                         f.write(self._bytes)

--- a/pluto/file.py
+++ b/pluto/file.py
@@ -30,15 +30,23 @@ NAME_MAX = 255
 
 
 def _bounded_basename(name: str, uid: str, ext: str) -> str:
-    """Build ``{name}-{uid}{ext}``, truncating ``name`` to fit NAME_MAX bytes.
+    """Build ``{name}-{uid}{ext}``, sanitized and truncated to fit NAME_MAX bytes.
 
-    Only the caption-derived ``name`` is shortened; ``uid`` (uniqueness) and
-    ``ext`` are always preserved, so truncation can't cause collisions or break
-    the extension. Truncation is byte-aware to avoid splitting a multibyte char.
+    ``name`` is caption-derived and can reach here *before* File.__init__ has
+    sanitized ``self._name`` -- the media ``load()`` methods build the staging
+    path first -- so sanitize here too: map anything outside the allowed set to
+    ``-`` (mirroring File.__init__), which strips ``/`` and ``\\`` so the result
+    is always a single, path-traversal-safe component. A name that is empty or
+    only dots collapses to a placeholder. ``uid`` (uniqueness) and ``ext`` are
+    always preserved, so truncation can't cause collisions or drop the
+    extension; truncation is byte-aware to avoid splitting a multibyte char.
     """
+    safe_name = INVALID_CHAR.sub('-', name)
+    if not safe_name.strip('.'):  # '', '.', '..', ... -> never a dir reference
+        safe_name = 'file'
     suffix = f'-{uid}{ext}'
     budget = max(NAME_MAX - len(suffix.encode('utf-8')), 0)
-    safe = name.encode('utf-8')[:budget].decode('utf-8', 'ignore')
+    safe = safe_name.encode('utf-8')[:budget].decode('utf-8', 'ignore')
     return f'{safe}{suffix}'
 
 

--- a/pluto/op.py
+++ b/pluto/op.py
@@ -422,6 +422,9 @@ class Op:
         self._queue: queue.Queue[QueueItem] = queue.Queue()
         self._finished = False
         self._finish_lock = threading.Lock()
+        # (log-key, exc-type) pairs already surfaced at error from a dropped log
+        # item, so a per-step failure is shouted once then drops to debug.
+        self._dropped_item_warned: set = set()
         atexit.register(self.finish)
 
     def _init_sync_manager(self) -> None:
@@ -599,7 +602,15 @@ class Op:
                 self._register_meta_sync(k, items[0], new_metric_names, new_file_meta)
 
             for item in items:
-                self._process_log_item_sync(k, item, metrics, timestamp_ms)
+                try:
+                    self._process_log_item_sync(k, item, metrics, timestamp_ms)
+                except Exception as e:
+                    # One bad item (e.g. media that can't be encoded/staged)
+                    # must not abort the rest of the batch or crash the caller's
+                    # training loop -- logging is best-effort. Drop just this
+                    # item, loudly, and keep going so sibling metrics/files in
+                    # the same call still reach the server.
+                    self._warn_dropped_item(k, item, e)
 
         if metrics:
             self._sync_manager.enqueue_metrics(metrics, timestamp_ms, self._step)
@@ -607,6 +618,26 @@ class Op:
         # Register new metric/file names with server (required for dashboard display)
         if (new_metric_names or new_file_meta) and self._iface:
             self._iface._update_meta(num=new_metric_names, df=dict(new_file_meta))
+
+    def _warn_dropped_item(self, key: str, value: Any, exc: Exception) -> None:
+        """Report a log item dropped due to an unexpected error.
+
+        Surfaced at the native API so every entry point (direct log(), and the
+        wandb/neptune/lightning shims alike) gets the same visibility -- a shim
+        catching exceptions is then only defense-in-depth, not the sole signal.
+        Logged once per (key, exc-type) at error, then at debug, so a failure
+        that recurs every step is shouted once rather than flooding.
+        """
+        seen = (key, type(exc).__name__)
+        detail = (
+            f'{tag}: dropped {key!r} ({type(value).__name__}): '
+            f'{type(exc).__name__}: {exc}'
+        )
+        if seen in self._dropped_item_warned:
+            logger.debug(detail)
+            return
+        self._dropped_item_warned.add(seen)
+        logger.error(f'{detail} (further occurrences at debug)')
 
     def _is_numeric_value(self, value: Any) -> bool:
         """Check if value is a numeric type (int, float, or tensor)."""

--- a/pluto/op.py
+++ b/pluto/op.py
@@ -638,6 +638,15 @@ class Op:
             return
         self._dropped_item_warned.add(seen)
         logger.error(f'{detail} (further occurrences at debug)')
+        # Telemetry: report once per (key, exc-type) so we can spot and fix
+        # these in the wild (ships the exception + traceback). Self-gates on
+        # PLUTO_DISABLE_TELEMETRY / CI and never raises.
+        try:
+            from pluto import sentry
+
+            sentry.capture_exception(exc)
+        except Exception:
+            pass
 
     def _is_numeric_value(self, value: Any) -> bool:
         """Check if value is a numeric type (int, float, or tensor)."""

--- a/tests/test_sync_process.py
+++ b/tests/test_sync_process.py
@@ -1377,16 +1377,52 @@ class TestCaptionEndToEndClientPath:
             else:
                 assert payload[log_name]['caption'] == expected
 
-    def test_long_caption_does_not_drop_file(self, tmp_path):
-        """A long caption must not make _mkcopy raise ENAMETOOLONG.
+    # A synthetic structured caption (sanitized-form params), long enough to
+    # overflow NAME_MAX once combined with uuid + sha256 + ext.
+    _LONG_CAPTION = (
+        'group-a--key1-val1--key2-val2--key3-val3--key4-val4--key5-val5--key6'
+        '--group-b--key7-val7--key8-val8--key9-val9--key10-val10'
+        '--group-c--key11-val11--key12-val12'
+    )
 
-        Regression for the wandb compat shim baking long generation-param
-        captions into the staging filename: ``{caption}.{uuid}-{sha256}{ext}``
-        could exceed the 255-byte NAME_MAX, so shutil.copyfile raised
-        OSError(ENAMETOOLONG). That error propagated out of _enqueue_file_sync
-        and was swallowed by the shim's try/except, silently dropping the file
-        (and never registering its log). The on-disk name must be bounded while
-        the full caption is preserved for the server-side fileName.
+    def _captioned_media(self, tmp_path, kind, caption):
+        """Build one media object of ``kind`` with ``caption``.
+
+        Covers both staging-path call sites: file-path inputs stage in
+        _mkcopy() (after File.__init__ sanitizes _name); the in-memory Text
+        input stages in load() (before sanitization).
+        """
+        if kind == 'image':
+            p = tmp_path / 'src.png'
+            p.write_bytes(bytes.fromhex('89504e470d0a1a0a') + b'\x00' * 64)
+            return pluto.Image(str(p), caption=caption)
+        if kind == 'audio':
+            p = tmp_path / 'src.wav'
+            p.write_bytes(b'RIFF\x00\x00\x00\x00WAVE' + b'\x00' * 64)
+            return pluto.Audio(str(p), caption=caption)
+        if kind == 'video':
+            p = tmp_path / 'src.mp4'
+            p.write_bytes(b'\x00\x00\x00\x18ftypmp42' + b'\x00' * 64)
+            return pluto.Video(str(p), caption=caption)
+        if kind == 'text':
+            return pluto.Text('log line', caption=caption)
+        if kind == 'artifact':
+            p = tmp_path / 'src.json'
+            p.write_text('{"k": 1}')
+            return pluto.Artifact(str(p), caption=caption)
+        raise ValueError(kind)
+
+    @pytest.mark.parametrize('kind', ['image', 'audio', 'video', 'text', 'artifact'])
+    def test_long_caption_does_not_drop_file(self, tmp_path, kind):
+        """A long caption must not make _mkcopy/load raise ENAMETOOLONG.
+
+        The staging copy is named ``{caption}.{uuid}-{sha256}{ext}`` for *every*
+        media type, so a long caption could exceed the 255-byte NAME_MAX and
+        make shutil.copyfile/open raise OSError(ENAMETOOLONG). That error
+        propagated out of _enqueue_file_sync and was swallowed by the shim's
+        try/except, silently dropping the file (and never registering its log).
+        The on-disk name must be bounded while the full caption is preserved for
+        the server-side fileName. Parametrized across all media types.
         """
         import types
 
@@ -1405,19 +1441,10 @@ class TestCaptionEndToEndClientPath:
             _step=1,
         )
 
-        mp4 = tmp_path / 'src.mp4'
-        mp4.write_bytes(b'\x00\x00\x00\x18ftypmp42' + b'\x00' * 64)
-        # A synthetic structured caption (sanitized-form params), long
-        # enough to overflow NAME_MAX once combined with uuid + sha256 + ext.
-        long_caption = (
-            'group-a--key1-val1--key2-val2--key3-val3--key4-val4--key5-val5--key6'
-            '--group-b--key7-val7--key8-val8--key9-val9--key10-val10'
-            '--group-c--key11-val11--key12-val12'
-        )
-        obj = pluto.Video(str(mp4), caption=long_caption)
+        obj = self._captioned_media(tmp_path, kind, self._LONG_CAPTION)
 
         # Must not raise (previously raised OSError: File name too long).
-        Op._enqueue_file_sync(fake_op, 'eval-videos/x', obj, 1705600000000)
+        Op._enqueue_file_sync(fake_op, f'eval/{kind}', obj, 1705600000000)
 
         records = store.get_pending_files(limit=10)
         assert len(records) == 1
@@ -1426,8 +1453,8 @@ class TestCaptionEndToEndClientPath:
         assert os.path.exists(rec.local_path)
         assert len(os.path.basename(rec.local_path).encode('utf-8')) <= NAME_MAX
         # Full caption is preserved for the server-side fileName/display.
-        assert rec.caption == long_caption
-        assert long_caption in rec.file_name
+        assert rec.caption == self._LONG_CAPTION
+        assert self._LONG_CAPTION in rec.file_name
 
     def test_caption_with_separators_is_traversal_safe(self, tmp_path):
         """A caption with path separators / '..' must not escape the files dir.

--- a/tests/test_sync_process.py
+++ b/tests/test_sync_process.py
@@ -436,9 +436,9 @@ class TestSyncProcessShutdown:
         assert 'test_metric_gamma' in run.settings.meta
 
         # Verify _iface exists and would have been used for metadata
-        assert run._iface is not None, (
-            'ServerInterface must exist to register metric names with server'
-        )
+        assert (
+            run._iface is not None
+        ), 'ServerInterface must exist to register metric names with server'
 
         run.finish()
 
@@ -1428,3 +1428,40 @@ class TestCaptionEndToEndClientPath:
         # Full caption is preserved for the server-side fileName/display.
         assert rec.caption == long_caption
         assert long_caption in rec.file_name
+
+    def test_caption_with_separators_is_traversal_safe(self, tmp_path):
+        """A caption with path separators / '..' must not escape the files dir.
+
+        The staging path is built from the caption-derived name before
+        File.__init__ sanitizes it, so _bounded_basename must neutralize
+        separators itself. The staged file must land directly under <dir>/files.
+        """
+        import types
+
+        from pluto.op import Op
+
+        store = SyncStore(str(tmp_path / 'sync.db'))
+        files_dir = tmp_path / 'files'
+        os.makedirs(files_dir, exist_ok=True)
+
+        def _enqueue_file(**kwargs):
+            store.enqueue_file(run_id='test-run', **kwargs)
+
+        fake_op = types.SimpleNamespace(
+            _sync_manager=types.SimpleNamespace(enqueue_file=_enqueue_file),
+            settings=types.SimpleNamespace(get_dir=lambda: str(tmp_path)),
+            _step=1,
+        )
+
+        # In-memory image so load() builds the staging path from the raw caption.
+        arr = np.zeros((4, 4, 3), dtype=np.uint8)
+        obj = pluto.Image(arr, caption='../../etc/evil/payload')
+        Op._enqueue_file_sync(fake_op, 'eval-images/x', obj, 1705600000000)
+
+        rec = store.get_pending_files(limit=10)[0]
+        staged = os.path.realpath(rec.local_path)
+        # Staged directly in <dir>/files, not in a traversed-to directory, and
+        # the basename carries no surviving separators.
+        assert os.path.dirname(staged) == os.path.realpath(str(files_dir))
+        assert '/' not in rec.file_name and '\\' not in rec.file_name
+        assert os.path.exists(rec.local_path)

--- a/tests/test_sync_process.py
+++ b/tests/test_sync_process.py
@@ -436,9 +436,9 @@ class TestSyncProcessShutdown:
         assert 'test_metric_gamma' in run.settings.meta
 
         # Verify _iface exists and would have been used for metadata
-        assert (
-            run._iface is not None
-        ), 'ServerInterface must exist to register metric names with server'
+        assert run._iface is not None, (
+            'ServerInterface must exist to register metric names with server'
+        )
 
         run.finish()
 
@@ -1376,3 +1376,55 @@ class TestCaptionEndToEndClientPath:
                 assert 'caption' not in payload[log_name]
             else:
                 assert payload[log_name]['caption'] == expected
+
+    def test_long_caption_does_not_drop_file(self, tmp_path):
+        """A long caption must not make _mkcopy raise ENAMETOOLONG.
+
+        Regression for the wandb compat shim baking long generation-param
+        captions into the staging filename: ``{caption}.{uuid}-{sha256}{ext}``
+        could exceed the 255-byte NAME_MAX, so shutil.copyfile raised
+        OSError(ENAMETOOLONG). That error propagated out of _enqueue_file_sync
+        and was swallowed by the shim's try/except, silently dropping the file
+        (and never registering its log). The on-disk name must be bounded while
+        the full caption is preserved for the server-side fileName.
+        """
+        import types
+
+        from pluto.file import NAME_MAX
+        from pluto.op import Op
+
+        store = SyncStore(str(tmp_path / 'sync.db'))
+        os.makedirs(tmp_path / 'files', exist_ok=True)
+
+        def _enqueue_file(**kwargs):
+            store.enqueue_file(run_id='test-run', **kwargs)
+
+        fake_op = types.SimpleNamespace(
+            _sync_manager=types.SimpleNamespace(enqueue_file=_enqueue_file),
+            settings=types.SimpleNamespace(get_dir=lambda: str(tmp_path)),
+            _step=1,
+        )
+
+        mp4 = tmp_path / 'src.mp4'
+        mp4.write_bytes(b'\x00\x00\x00\x18ftypmp42' + b'\x00' * 64)
+        # A synthetic structured caption (sanitized-form params), long
+        # enough to overflow NAME_MAX once combined with uuid + sha256 + ext.
+        long_caption = (
+            'group-a--key1-val1--key2-val2--key3-val3--key4-val4--key5-val5--key6'
+            '--group-b--key7-val7--key8-val8--key9-val9--key10-val10'
+            '--group-c--key11-val11--key12-val12'
+        )
+        obj = pluto.Video(str(mp4), caption=long_caption)
+
+        # Must not raise (previously raised OSError: File name too long).
+        Op._enqueue_file_sync(fake_op, 'eval-videos/x', obj, 1705600000000)
+
+        records = store.get_pending_files(limit=10)
+        assert len(records) == 1
+        rec = records[0]
+        # File was actually staged on disk and the basename respects NAME_MAX.
+        assert os.path.exists(rec.local_path)
+        assert len(os.path.basename(rec.local_path).encode('utf-8')) <= NAME_MAX
+        # Full caption is preserved for the server-side fileName/display.
+        assert rec.caption == long_caption
+        assert long_caption in rec.file_name

--- a/tests/test_sync_process.py
+++ b/tests/test_sync_process.py
@@ -1505,20 +1505,25 @@ class TestLogItemResilience:
         png.write_bytes(bytes.fromhex('89504e470d0a1a0a') + b'\x00' * 64)
         bad = pluto.Image(str(png), caption='boom')
 
-        with caplog.at_level(logging.DEBUG, logger='pluto'):
-            # A good metric and a file whose enqueue fails, in the same call.
-            op._log_via_sync({'loss': 0.5, 'eval/img': bad}, step=1)
+        with patch('pluto.sentry.capture_exception') as cap:
+            with caplog.at_level(logging.DEBUG, logger='pluto'):
+                # A good metric and a file whose enqueue fails, in one call.
+                op._log_via_sync({'loss': 0.5, 'eval/img': bad}, step=1)
 
-        # Sibling metric still reached the sync manager (batch not aborted).
-        assert metrics_sink and 0.5 in metrics_sink[0].values()
-        # The drop was surfaced at error, not swallowed.
-        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
-        assert any('OSError' in r.message for r in errors)
+            # Sibling metric still reached the sync manager (batch not aborted).
+            assert metrics_sink and 0.5 in metrics_sink[0].values()
+            # The drop was surfaced at error, not swallowed.
+            errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+            assert any('OSError' in r.message for r in errors)
+            # ...and reported to Sentry telemetry (with the real exception).
+            assert cap.call_count == 1
+            assert isinstance(cap.call_args.args[0], OSError)
 
-        # Same (key, exc-type) again -> deduped to debug, no new error/warning.
-        caplog.clear()
-        with caplog.at_level(logging.DEBUG, logger='pluto'):
-            op._log_via_sync(
-                {'eval/img': pluto.Image(str(png), caption='boom2')}, step=2
-            )
-        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+            # Same (key, exc-type) again -> deduped: debug only, no new Sentry.
+            caplog.clear()
+            with caplog.at_level(logging.DEBUG, logger='pluto'):
+                op._log_via_sync(
+                    {'eval/img': pluto.Image(str(png), caption='boom2')}, step=2
+                )
+            assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+            assert cap.call_count == 1

--- a/tests/test_sync_process.py
+++ b/tests/test_sync_process.py
@@ -1465,3 +1465,60 @@ class TestCaptionEndToEndClientPath:
         assert os.path.dirname(staged) == os.path.realpath(str(files_dir))
         assert '/' not in rec.file_name and '\\' not in rec.file_name
         assert os.path.exists(rec.local_path)
+
+
+class TestLogItemResilience:
+    """Native-API resilience: a single bad log item must not abort the batch
+    or crash the caller, and must be surfaced loudly (not silently swallowed).
+    This is the property the wandb shim used to (silently) provide; owning it at
+    the native API means every entry point gets it.
+    """
+
+    def _make_op(self, tmp_path, enqueue_metrics_sink):
+        import types
+
+        from pluto.op import Op
+
+        os.makedirs(tmp_path / 'files', exist_ok=True)
+
+        def _enqueue_file(**kwargs):
+            raise OSError(36, 'File name too long')
+
+        op = Op.__new__(Op)
+        op._step = 0
+        op._iface = None
+        op._dropped_item_warned = set()
+        op.settings = types.SimpleNamespace(get_dir=lambda: str(tmp_path), meta=[])
+        op._sync_manager = types.SimpleNamespace(
+            enqueue_file=_enqueue_file,
+            enqueue_metrics=lambda m, ts, step: enqueue_metrics_sink.append(m),
+        )
+        return op
+
+    def test_bad_item_dropped_loudly_batch_survives(self, tmp_path, caplog):
+        import logging
+
+        metrics_sink = []
+        op = self._make_op(tmp_path, metrics_sink)
+
+        png = tmp_path / 'src.png'
+        png.write_bytes(bytes.fromhex('89504e470d0a1a0a') + b'\x00' * 64)
+        bad = pluto.Image(str(png), caption='boom')
+
+        with caplog.at_level(logging.DEBUG, logger='pluto'):
+            # A good metric and a file whose enqueue fails, in the same call.
+            op._log_via_sync({'loss': 0.5, 'eval/img': bad}, step=1)
+
+        # Sibling metric still reached the sync manager (batch not aborted).
+        assert metrics_sink and 0.5 in metrics_sink[0].values()
+        # The drop was surfaced at error, not swallowed.
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert any('OSError' in r.message for r in errors)
+
+        # Same (key, exc-type) again -> deduped to debug, no new error/warning.
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger='pluto'):
+            op._log_via_sync(
+                {'eval/img': pluto.Image(str(png), caption='boom2')}, step=2
+            )
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -287,6 +287,53 @@ def test_log_routes_strings_to_config_not_metrics():
     assert 'checkpoint/r2_path' not in logged
 
 
+def test_log_failure_unexpected_error_is_loud_then_deduped(caplog):
+    """A non-network failure (e.g. OSError) must surface at ERROR, not vanish
+    at debug -- that silent debug-swallow is what hid the long-filename bug.
+    A recurring identical failure is shouted once, then drops to debug."""
+    import logging
+
+    wrapper, pluto_run = _make_wrapper()
+    pluto_run.log.side_effect = OSError(36, 'File name too long')
+
+    with caplog.at_level(logging.DEBUG, logger='pluto.compat.wandb'):
+        wrapper.log({'loss': 0.1})  # first occurrence
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert 'OSError' in errors[0].message
+        # wandb itself is never impacted: the wrapped run.log was still called.
+        wrapper._wandb_run.log.assert_called()
+
+        caplog.clear()
+        wrapper.log({'loss': 0.2})  # same (context, type) -> deduped to debug
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any(
+            r.levelno == logging.DEBUG and 'OSError' in r.message
+            for r in caplog.records
+        )
+
+
+def test_log_failure_httpx_error_stays_at_debug(caplog):
+    """Transient network errors are noisy and already retried by the sync
+    layer, so they must stay at debug even on the first occurrence."""
+    import logging
+
+    import httpx
+
+    wrapper, pluto_run = _make_wrapper()
+    pluto_run.log.side_effect = httpx.ConnectError('connection refused')
+
+    with caplog.at_level(logging.DEBUG, logger='pluto.compat.wandb'):
+        wrapper.log({'loss': 0.1})
+
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(
+        'Failed to log media/metrics' in r.message
+        for r in caplog.records
+        if r.levelno == logging.DEBUG
+    )
+
+
 def test_log_forwards_numpy_scalars_as_metrics():
     """np.int64/np.float32 must reach Pluto metrics, not be dropped."""
     np = pytest.importorskip('numpy')

--- a/tests/test_wandb_compat.py
+++ b/tests/test_wandb_compat.py
@@ -296,21 +296,26 @@ def test_log_failure_unexpected_error_is_loud_then_deduped(caplog):
     wrapper, pluto_run = _make_wrapper()
     pluto_run.log.side_effect = OSError(36, 'File name too long')
 
-    with caplog.at_level(logging.DEBUG, logger='pluto.compat.wandb'):
-        wrapper.log({'loss': 0.1})  # first occurrence
-        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
-        assert len(errors) == 1
-        assert 'OSError' in errors[0].message
-        # wandb itself is never impacted: the wrapped run.log was still called.
-        wrapper._wandb_run.log.assert_called()
+    with mock.patch('pluto.sentry.capture_exception') as cap:
+        with caplog.at_level(logging.DEBUG, logger='pluto.compat.wandb'):
+            wrapper.log({'loss': 0.1})  # first occurrence
+            errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+            assert len(errors) == 1
+            assert 'OSError' in errors[0].message
+            # wandb itself is never impacted: the wrapped run.log still ran.
+            wrapper._wandb_run.log.assert_called()
+            # Reported to Sentry once, with the real exception.
+            assert cap.call_count == 1
+            assert isinstance(cap.call_args.args[0], OSError)
 
-        caplog.clear()
-        wrapper.log({'loss': 0.2})  # same (context, type) -> deduped to debug
-        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
-        assert any(
-            r.levelno == logging.DEBUG and 'OSError' in r.message
-            for r in caplog.records
-        )
+            caplog.clear()
+            wrapper.log({'loss': 0.2})  # same (context, type) -> deduped to debug
+            assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+            assert any(
+                r.levelno == logging.DEBUG and 'OSError' in r.message
+                for r in caplog.records
+            )
+            assert cap.call_count == 1  # no second telemetry event
 
 
 def test_log_failure_httpx_error_stays_at_debug(caplog):
@@ -323,15 +328,18 @@ def test_log_failure_httpx_error_stays_at_debug(caplog):
     wrapper, pluto_run = _make_wrapper()
     pluto_run.log.side_effect = httpx.ConnectError('connection refused')
 
-    with caplog.at_level(logging.DEBUG, logger='pluto.compat.wandb'):
-        wrapper.log({'loss': 0.1})
+    with mock.patch('pluto.sentry.capture_exception') as cap:
+        with caplog.at_level(logging.DEBUG, logger='pluto.compat.wandb'):
+            wrapper.log({'loss': 0.1})
 
-    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
-    assert any(
-        'Failed to log media/metrics' in r.message
-        for r in caplog.records
-        if r.levelno == logging.DEBUG
-    )
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any(
+            'Failed to log media/metrics' in r.message
+            for r in caplog.records
+            if r.levelno == logging.DEBUG
+        )
+        # Transient network errors are not telemetry-worthy.
+        cap.assert_not_called()
 
 
 def test_log_forwards_numpy_scalars_as_metrics():


### PR DESCRIPTION
## Summary

Fixes silent dropping of media (reported as "videos are not being sent to the server") for a user dual-logging through the wandb compat shim: images reached Pluto but videos did not.

**Root cause — a regression introduced in 0.0.24 (#125, media captions):**

- Before #125 the wandb compat shim created `pluto.Video(path)` with **no caption**, so the on-disk staging copy was named `<uuid>-<sha256>.mp4` (~105 chars).
- #125 made the shim forward the caption: `pluto.Video(path, caption=...)`. `_name` becomes `caption + uuid`, and `_mkcopy()`/`load()` name the staging copy `{caption}.{uuid}-{sha256}{ext}`.
- Users that log long generation-parameter captions (a structured `prompt / seed / resolution / steps / cfg / scheduler / …` tuple) push that basename past the **255-byte filesystem limit (`NAME_MAX`)**, so `shutil.copyfile`/`open` raise `OSError: [Errno 36] File name too long`.
- That error propagates out of `Op._enqueue_file_sync` → `_log_via_sync` **before `_update_meta` runs**, and the wandb shim's broad `try/except` swallowed it at `debug`. The file is silently dropped **and its log is never even registered**.
- **Images** survived only because their captions landed just under the limit (~236 bytes on disk); **videos** carry a few extra params (fps/frames/duration) and tipped over (~276 bytes) → "videos silently not sent, images fine".

### Evidence
- Confirmed against server-side data: runs on pluto **0.0.23** logged both images and videos; runs from the **0.0.24** rollout logged images but **zero videos**, and the log registry shows the video logs were never registered at all (a client-side drop, before upload). A minimal one-video repro with a short caption worked — matching the caption-length threshold.

## Fix (layered)

1. **Root cause — `pluto/file.py`**: route every staging-path construction through `File._staging_path()` → `_bounded_basename()`, which sanitizes (path-traversal-safe) and truncates **only** the caption-derived name to fit `NAME_MAX` (byte-aware), always preserving the `uuid`+`sha256` (uniqueness) and the extension. `self._name` is left intact, so the full caption still reaches the server as `fileName`/`caption` for display.
2. **Native-API resilience — `Op._log_via_sync`**: a single failing item no longer aborts the batch or crashes the caller; it's dropped, logged once per `(key, exc-type)` at `error`, and the rest of the batch (sibling metrics/files) still goes through.
3. **Shim severity — `compat/wandb.py`**: swallowed failures are logged by cause — httpx/network (transient, retried) → `debug`; everything else → `error` — so a real failure is never silent again.
4. **Telemetry**: dropped-item / unexpected failures are reported to the isolated Sentry client (deduped per `(key, type)`; network errors excluded; opt-out via `PLUTO_DISABLE_TELEMETRY`).

## Tests
- A long **synthetic** caption stages + enqueues without raising; on-disk basename ≤ `NAME_MAX`; full caption preserved.
- A caption with path separators stays inside the files dir (traversal-safe).
- One bad item doesn't sink the batch and is surfaced at `error` (native API + shim); httpx errors stay at `debug` and are not sent to Sentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)