### PR TITLE
Bump patch version to 0.0.25

### DIFF
--- a/docs-api/meta.json
+++ b/docs-api/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "package": "pluto",
-  "package_version": "0.0.24",
+  "package_version": "0.0.25",
   "public_api": [
     "Artifact",
     "Audio",

--- a/pluto/__init__.py
+++ b/pluto/__init__.py
@@ -41,7 +41,7 @@ __all__ = (
     'generate_run_id',
 )
 
-__version__ = '0.0.24'
+__version__ = '0.0.25'
 
 
 # Replaced with the current commit when building the wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pluto-ml"
-version = "0.0.24"
+version = "0.0.25"
 description = "Pluto ML - Machine Learning Operations Framework"
 packages = [
     {include = "pluto"},


### PR DESCRIPTION
Bumps the patch version from `0.0.24` to `0.0.25`.

Updated in all three locations that track the version:
- `pyproject.toml`
- `pluto/__init__.py` (`__version__`)
- `docs-api/meta.json` (`package_version`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJebum4R2TCJDbtmL6Yg54

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJebum4R2TCJDbtmL6Yg54)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no runtime or API behavior changes.
> 
> **Overview**
> **Release version bump** from `0.0.24` to `0.0.25` with no functional code changes.
> 
> The new version is set in **`pyproject.toml`** (Poetry package version), **`pluto/__init__.py`** (`__version__`), and **`docs-api/meta.json`** (`package_version`) so packaging, runtime reporting, and published API docs stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c9ee12ba000cf519abdddc49f22b18b20e37792. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->