### PR TITLE
Bump version to 0.0.26

### DIFF
--- a/docs-api/meta.json
+++ b/docs-api/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "package": "pluto",
-  "package_version": "0.0.25",
+  "package_version": "0.0.26",
   "public_api": [
     "Artifact",
     "Audio",

--- a/pluto/__init__.py
+++ b/pluto/__init__.py
@@ -41,7 +41,7 @@ __all__ = (
     'generate_run_id',
 )
 
-__version__ = '0.0.25'
+__version__ = '0.0.26'
 
 
 # Replaced with the current commit when building the wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pluto-ml"
-version = "0.0.25"
+version = "0.0.26"
 description = "Pluto ML - Machine Learning Operations Framework"
 packages = [
     {include = "pluto"},


### PR DESCRIPTION
Bumps the release version from `0.0.25` to `0.0.26`, updating both the canonical version sources:

- `pyproject.toml` (`[tool.poetry] version`)
- `pluto/__init__.py` (`__version__`)

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)

Version-only change — no code/behavior modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrMqBR8JRypSgXn3EYydpF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-string-only change with no logic or dependency updates.
> 
> **Overview**
> Bumps the **pluto-ml** release from `0.0.25` to **`0.0.26`** in the two version sources: Poetry `[tool.poetry] version` in `pyproject.toml` and runtime `__version__` in `pluto/__init__.py`.
> 
> No libraries, APIs, or runtime behavior are modified—only packaging and the string exposed as the package version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dc374ce634d25fe6c9bdab329e54a68b5287206. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->