### PR TITLE
fix(log): fd-level console capture so pre-init logging handlers are uploaded

### DIFF
--- a/pluto/_fd_capture.py
+++ b/pluto/_fd_capture.py
@@ -1,0 +1,261 @@
+"""
+File-descriptor-level console capture (the wandb console="redirect" approach).
+
+pluto.log.ConsoleHandler captures console output by swapping the
+``sys.stdout``/``sys.stderr`` *variables* — which misses every writer that
+bound the original stream object before ``pluto.init()`` ran. The dominant
+real-world case is ``logging.StreamHandler``: CPython stores
+``self.stream = sys.stderr`` at handler construction, so frameworks that
+configure logging at process start (torchtitan, most torch trainers) write
+straight to the raw fd and the run's console section stays empty.
+
+``FdCapture`` intercepts at the OS level instead: it ``dup2``s a pipe over
+fd 1/2, and a daemon reader thread tees every byte back to the saved real
+fd (so the terminal stays live) while line-buffering the captured copy into
+``SyncProcessManager.enqueue_console_batch`` — same tuple contract, rank
+prefixing, and sanitization as ``ConsoleHandler``. This catches logging
+handlers, C extensions, and child processes that inherit the fd.
+
+Shutdown notes (``stop()``):
+- A sentinel byte-sequence is written into the pipe before the real fd is
+  restored. When the reader sees it, everything written before ``stop()``
+  has been enqueued — ``stop()`` waits on that (bounded), giving a
+  deterministic flush without racing the reader.
+- The reader thread is NOT joined/killed. Child processes forked while
+  capture was active (e.g. DataLoader workers) inherit the pipe write end;
+  if nobody drained it, their writes would block once the pipe buffer
+  fills. The daemon reader stays behind in tee-only mode, forwarding any
+  such stragglers to the real fd until EOF or interpreter exit.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, List, Optional, Tuple
+
+logger = logging.getLogger(f'{__name__.split(".")[0]}')
+
+# Written into the pipe by stop() to mark "everything before this is
+# pre-stop output". Control bytes make a collision with real output
+# effectively impossible; writes <= PIPE_BUF are atomic so it can't
+# interleave with a concurrent writer's bytes.
+_STOP_SENTINEL = b'\x00\x1dpluto:fdcap:flush\x1d\x00'
+
+
+class FdCapture:
+    # Mirrors pluto.log.ConsoleHandler's batching to keep SQLite write
+    # pressure low while still delivering logs promptly.
+    _FLUSH_SIZE = 50
+    _FLUSH_INTERVAL = 0.2  # seconds
+    _READ_CHUNK = 8192
+
+    def __init__(
+        self,
+        fd: int,
+        level: int,
+        sync_manager: Any,
+        sanitizer: Optional[Any] = None,
+    ):
+        self.fd = fd
+        self.level = level
+        self.sync_manager = sync_manager
+        self.sanitizer = sanitizer
+        self.count = 0
+
+        self._orig_fd: Optional[int] = None
+        self._read_fd: Optional[int] = None
+        self._thread: Optional[threading.Thread] = None
+        self._started = False
+        self._stopped = False
+
+        # Guards line/batch state shared between the reader thread and a
+        # stop() caller doing a last-resort flush.
+        self._state_lock = threading.Lock()
+        self._enqueue_enabled = True
+        self._partial_line = ''
+        self._log_buffer: List[Tuple[str, str, int, int]] = []
+        self._last_flush = 0.0
+        # Set once the reader has flushed everything written before stop().
+        self._flushed = threading.Event()
+
+        # Same rank tagging as ConsoleHandler: only the captured copy is
+        # prefixed, never the tee (torchrun prefixes the terminal itself).
+        rank = os.environ.get('RANK')
+        self._rank_prefix = f'[rank{rank}] ' if rank is not None else ''
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> None:
+        """Redirect self.fd into a pipe drained by a daemon reader thread."""
+        if self._started or self._stopped:
+            return
+        self._orig_fd = os.dup(self.fd)
+        read_fd, write_fd = os.pipe()
+        os.dup2(write_fd, self.fd)
+        os.close(write_fd)
+        self._read_fd = read_fd
+        self._started = True
+        self._thread = threading.Thread(
+            target=self._reader_loop,
+            name=f'pluto-fdcap-{self.fd}',
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 2.0) -> None:
+        """Restore the real fd and flush everything captured so far.
+
+        Idempotent. Never raises. The reader thread is left running in
+        tee-only drain mode (see module docstring).
+        """
+        if not self._started or self._stopped:
+            return
+        self._stopped = True
+
+        # 1. Sentinel into the pipe while self.fd still points at it — it
+        #    lands after all pre-stop output. Written from a helper thread:
+        #    if the pipe buffer is full (reader wedged on a blocked tee), a
+        #    direct write would hang stop() — and stop() runs in finish()
+        #    paths that must never block (DDP).
+        def _write_sentinel() -> None:
+            try:
+                os.write(self.fd, _STOP_SENTINEL)
+            except OSError:
+                pass
+
+        writer = threading.Thread(target=_write_sentinel, daemon=True)
+        writer.start()
+        writer.join(timeout=min(0.5, timeout))
+
+        # 2. Point the fd back at the real destination — new writes bypass
+        #    the pipe from here on.
+        try:
+            if self._orig_fd is not None:
+                os.dup2(self._orig_fd, self.fd)
+        except OSError as e:
+            logger.debug('fdcap: failed to restore fd %d: %s', self.fd, e)
+
+        # 3. Wait for the reader to reach the sentinel and flush. On
+        #    timeout, flush whatever state we can see ourselves.
+        if not self._flushed.wait(timeout):
+            with self._state_lock:
+                self._flush_locked(drain_partial=True)
+                self._enqueue_enabled = False
+        # _orig_fd stays open: the drain-mode reader tees stragglers to it.
+
+    # -- reader thread -----------------------------------------------------
+
+    def _reader_loop(self) -> None:
+        assert self._read_fd is not None
+        held = b''  # possible partial sentinel at a chunk boundary
+        while True:
+            try:
+                chunk = os.read(self._read_fd, self._READ_CHUNK)
+            except OSError:
+                break
+            if not chunk:  # EOF: every write end (incl. children's) closed
+                break
+            data = held + chunk
+            held = b''
+
+            idx = data.find(_STOP_SENTINEL)
+            if idx != -1:
+                before = data[:idx]
+                after = data[idx + len(_STOP_SENTINEL) :]
+                self._tee(before)
+                self._ingest(before)
+                with self._state_lock:
+                    self._flush_locked(drain_partial=True)
+                    self._enqueue_enabled = False
+                self._flushed.set()
+                self._tee(after)
+                continue  # drain mode: _ingest below is a no-op now
+
+            # A sentinel prefix at the very end of the chunk may be the
+            # sentinel split across reads — hold those bytes back until the
+            # next read resolves it. Real output essentially never starts
+            # with \x00, so this doesn't delay the tee in practice.
+            cut = self._partial_sentinel_suffix(data)
+            if cut:
+                held = data[-cut:]
+                data = data[:-cut]
+            self._tee(data)
+            self._ingest(data)
+        if held:
+            self._tee(held)
+            self._ingest(held)
+        with self._state_lock:
+            self._flush_locked(drain_partial=True)
+        self._flushed.set()
+        try:
+            os.close(self._read_fd)
+        except OSError:
+            pass
+
+    @staticmethod
+    def _partial_sentinel_suffix(data: bytes) -> int:
+        """Length of the longest proper sentinel prefix that ends ``data``."""
+        max_k = min(len(_STOP_SENTINEL) - 1, len(data))
+        for k in range(max_k, 0, -1):
+            if data.endswith(_STOP_SENTINEL[:k]):
+                return k
+        return 0
+
+    def _tee(self, data: bytes) -> None:
+        """Forward captured bytes to the real destination, completely."""
+        if not data or self._orig_fd is None:
+            return
+        view = memoryview(data)
+        try:
+            while view:
+                written = os.write(self._orig_fd, view)
+                view = view[written:]
+        except OSError:
+            pass  # real terminal gone (e.g. closed pty) — keep capturing
+
+    # -- line buffering (mirrors pluto.log.ConsoleHandler) ------------------
+
+    def _ingest(self, data: bytes) -> None:
+        if not data:
+            return
+        text = data.decode('utf-8', errors='replace')
+        with self._state_lock:
+            if not self._enqueue_enabled:
+                return
+            self._partial_line += text
+            if '\n' in self._partial_line:
+                *complete, self._partial_line = self._partial_line.split('\n')
+                for line in complete:
+                    self._emit_line_locked(line)
+            if self._log_buffer and (
+                len(self._log_buffer) >= self._FLUSH_SIZE
+                or time.time() - self._last_flush >= self._FLUSH_INTERVAL
+            ):
+                self._flush_locked()
+
+    def _emit_line_locked(self, line: str) -> None:
+        if not line:  # do not log empty lines (matches ConsoleHandler)
+            return
+        self.count += 1
+        if self._rank_prefix:
+            line = self._rank_prefix + line
+        if self.sanitizer:
+            line = self.sanitizer.sanitize(line)
+        log_type = logging._levelToName.get(self.level, 'INFO')
+        self._log_buffer.append((line, log_type, int(time.time() * 1000), self.count))
+
+    def _flush_locked(self, drain_partial: bool = False) -> None:
+        if drain_partial and self._partial_line:
+            self._emit_line_locked(self._partial_line)
+            self._partial_line = ''
+        if not self._log_buffer:
+            return
+        try:
+            self.sync_manager.enqueue_console_batch(self._log_buffer)
+        except Exception as e:
+            logger.debug('fdcap: failed to flush console batch: %s', e)
+        self._log_buffer = []
+        self._last_flush = time.time()

--- a/pluto/log.py
+++ b/pluto/log.py
@@ -12,6 +12,10 @@ _input = builtins.input
 _stdout = sys.stdout
 _stderr = sys.stderr
 
+# Active fd-level captures (see pluto._fd_capture). Populated by
+# setup_logger_file, stopped in teardown_logger.
+_fd_captures: list = []
+
 colors = {
     'DEBUG': ANSI.green,
     'INFO': ANSI.cyan,
@@ -192,14 +196,31 @@ def teardown_logger(logger, console=None):
     for h in logger.handlers[:]:
         logger.removeHandler(h)
     if console:
+        _stop_fd_captures()
         builtins.input = _input
         sys.stdout = _stdout  # global _stdout
         sys.stderr = _stderr
         teardown_logger(logger=console)
 
 
+def _stop_fd_captures() -> None:
+    """Stop and forget all active fd-level captures. Never raises."""
+    while _fd_captures:
+        capture = _fd_captures.pop()
+        try:
+            capture.stop()
+        except Exception as e:
+            logger.debug('Failed to stop fd capture: %s', e)
+
+
 def setup_logger_file(settings, logger, console, sync_manager=None):
     console.setLevel(logging.DEBUG)
+    # The console logger is internal capture plumbing. If it propagated,
+    # every captured line would re-emit through the user's root handlers —
+    # duplicating terminal output, and under fd capture feeding the line
+    # straight back into the capture pipe (root handler → pre-init stderr
+    # object → fd 2).
+    console.propagate = False
 
     file_handler = logging.FileHandler(f'{settings.get_dir()}/{settings.tag}.log')
     file_formatter = logging.Formatter(
@@ -223,13 +244,87 @@ def setup_logger_file(settings, logger, console, sync_manager=None):
 
         sanitizer = SecretSanitizer()
 
+    # fd-level capture (dup2 tee over fds 1/2) catches writers that bound
+    # the original stream objects before init — logging.StreamHandlers set
+    # up by frameworks like torchtitan, C extensions, forked children. The
+    # sys.stdout/sys.stderr swap below can't see any of those (a handler
+    # holds the old object), which left the console section empty for any
+    # job that configures logging before pluto.init().
+    fd_capture_active = _start_fd_captures(settings, sync_manager, sanitizer)
+
     if settings.mode == 'debug':
         builtins.input = lambda prompt='': input_hook(prompt, logger=console)
+    # The ConsoleHandler wrappers stay even with fd capture active: they
+    # flush Python-level writes through to the fd promptly (the original
+    # sys.stdout is block-buffered when not a tty) and feed the local
+    # sys.log file. Exactly ONE layer may enqueue a given stream to the
+    # sync manager, or every Python-level line would be uploaded twice.
+    # The fd layer owns a stream only when that stream actually writes to
+    # the captured fd; when it doesn't (Jupyter's ZMQ OutStream, pytest's
+    # capture objects), its writes never reach the pipe, so the wrapper
+    # must keep enqueueing them.
+    stdout_owned_by_fd = fd_capture_active and _stream_writes_to_fd(sys.stdout, 1)
+    stderr_owned_by_fd = fd_capture_active and _stream_writes_to_fd(sys.stderr, 2)
     sys.stdout = ConsoleHandler(
-        console, sync_manager, logging.INFO, sys.stdout, 'stdout', sanitizer
+        console,
+        None if stdout_owned_by_fd else sync_manager,
+        logging.INFO,
+        sys.stdout,
+        'stdout',
+        sanitizer,
     )
     sys.stderr = ConsoleHandler(
-        console, sync_manager, logging.ERROR, sys.stderr, 'stderr', sanitizer
+        console,
+        None if stderr_owned_by_fd else sync_manager,
+        logging.ERROR,
+        sys.stderr,
+        'stderr',
+        sanitizer,
     )
 
     return logger, console
+
+
+def _stream_writes_to_fd(stream, fd: int) -> bool:
+    """True if writes to `stream` land on OS file descriptor `fd`."""
+    try:
+        return stream.fileno() == fd
+    except Exception:  # no fileno / io.UnsupportedOperation / detached
+        return False
+
+
+def _start_fd_captures(settings, sync_manager, sanitizer) -> bool:
+    """Start fd-level console capture on fds 1/2. Returns True if active.
+
+    Fails soft: any OS-level problem (exotic platform, fds not real) falls
+    back to the legacy wrapper-based capture so logging never breaks a run.
+    """
+    if sync_manager is None or not getattr(settings, 'x_console_fd_capture', True):
+        return False
+    from ._fd_capture import FdCapture
+
+    started = []
+    try:
+        # Flush Python-level buffers so pre-init output goes to the real
+        # terminal instead of being captured into this run's console.
+        for stream in (sys.stdout, sys.stderr):
+            try:
+                stream.flush()
+            except Exception:
+                pass
+        for fd, level in ((1, logging.INFO), (2, logging.ERROR)):
+            capture = FdCapture(
+                fd=fd, level=level, sync_manager=sync_manager, sanitizer=sanitizer
+            )
+            capture.start()
+            started.append(capture)
+    except Exception as e:
+        logger.debug('fd-level console capture unavailable, using fallback: %s', e)
+        for capture in started:
+            try:
+                capture.stop()
+            except Exception:
+                pass
+        return False
+    _fd_captures.extend(started)
+    return True

--- a/pluto/log.py
+++ b/pluto/log.py
@@ -213,6 +213,31 @@ def _stop_fd_captures() -> None:
             logger.debug('Failed to stop fd capture: %s', e)
 
 
+def flush_console_buffers() -> None:
+    """Flush every console-capture layer into the sync store. Never raises.
+
+    Op._teardown() calls this BEFORE draining/stopping the sync manager:
+    lines still sitting in the fd reader's batch buffer (up to 0.2s of
+    output) or a ConsoleHandler's buffer are otherwise enqueued at
+    teardown_logger time — after the uploader is gone — and sit in SQLite
+    unuploaded. Observed on CI as a line logged immediately before
+    finish() never reaching the server.
+
+    Stopping the fd captures here (rather than just flushing) is
+    deliberate: output written after the sync drain below can't be
+    uploaded in this run anyway, and stop() is the only deterministic
+    flush point the reader thread offers. teardown_logger's later
+    _stop_fd_captures() is then a no-op.
+    """
+    _stop_fd_captures()
+    for stream in (sys.stdout, sys.stderr):
+        if isinstance(stream, ConsoleHandler):
+            try:
+                stream.flush()
+            except Exception as e:
+                logger.debug('Failed to flush console stream: %s', e)
+
+
 def setup_logger_file(settings, logger, console, sync_manager=None):
     console.setLevel(logging.DEBUG)
     # The console logger is internal capture plumbing. If it propagated,

--- a/pluto/op.py
+++ b/pluto/op.py
@@ -28,7 +28,7 @@ from .auth import login
 from .data import Data
 from .file import Artifact, Audio, File, Image, Text, Video
 from .iface import ServerInterface
-from .log import setup_logger, teardown_logger
+from .log import flush_console_buffers, setup_logger, teardown_logger
 from .store import DataStore
 from .sync import SyncProcessManager
 from .sync.store import HEALTH_METRIC_KEYS
@@ -815,6 +815,13 @@ class Op:
         try:
             # Stop the monitor (system metrics and heartbeats)
             self._monitor.stop(code)
+
+            # Push pending console-capture lines into the sync store while
+            # the sync process can still upload them — anything enqueued
+            # after the drain below stays in SQLite unuploaded (the capture
+            # layers batch up to 0.2s of output).
+            if self._sync_manager is not None:
+                flush_console_buffers()
 
             # Handle sync process shutdown
             if self._sync_manager is not None:

--- a/pluto/sets.py
+++ b/pluto/sets.py
@@ -42,6 +42,10 @@ class Settings:
     disable_progress: bool = True
     disable_console: bool = False  # disable file-based logging
     sanitize_logs: bool = True  # redact secrets before uploading console logs
+    # Capture console at the file-descriptor level (dup2 tee, like wandb's
+    # console="redirect") so logging handlers configured before init() are
+    # still captured. False falls back to the sys.stdout/sys.stderr swap.
+    x_console_fd_capture: bool = True
 
     _op_name: Optional[str] = None
     _op_id: Optional[int] = None

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -12,6 +12,7 @@ Requires:
 
 import importlib.util
 import io
+import logging
 import time
 import uuid
 from typing import Callable, List, TypeVar
@@ -396,22 +397,68 @@ def test_e2e_image_download(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def _poll_console_messages(run_id: int, sentinel: str) -> List[str]:
+    """Poll /api/runs/logs until a line containing *sentinel* appears."""
+
+    def _messages() -> List[str]:
+        logs = pq.get_logs(TESTING_PROJECT_NAME, run_id, limit=500)
+        return [entry.get('message', '') for entry in logs]
+
+    return _poll(fn=_messages, check=lambda ms: any(sentinel in m for m in ms))
+
+
 def test_e2e_console_logs():
     """Verify print() output is captured and queryable."""
+    sentinel = f'e2e-print-{uuid.uuid4().hex[:12]}'
     run = pluto.init(project=TESTING_PROJECT_NAME, name=get_task_name(), config={})
     run_id = run.settings._op_id
 
-    print('e2e-log-sentinel-12345')
+    print(sentinel)
     run.finish()
 
-    logs = pq.get_logs(TESTING_PROJECT_NAME, run_id, limit=100)
-    messages = [entry.get('message', '') for entry in logs]
-    found = any('e2e-log-sentinel-12345' in msg for msg in messages)
-    # Console capture may be disabled or delayed; don't hard-fail
-    if not found:
-        pytest.skip(
-            'Console log not found on server (capture may be disabled or delayed)'
-        )
+    messages = _poll_console_messages(run_id, sentinel)
+    assert any(sentinel in msg for msg in messages), (
+        f'printed line ({sentinel}) never reached the server; '
+        f'got {len(messages)} console lines'
+    )
+
+
+def test_e2e_pre_init_logging_handler_console_logs():
+    """torchtitan scenario: a logging.StreamHandler bound to fd 2 BEFORE
+    pluto.init() must still have its output reach the server.
+
+    Frameworks like torchtitan call init_logger() at process start;
+    CPython's StreamHandler binds the stream object at construction, so the
+    old sys-swap console capture never saw those writes and the run's
+    console section stayed empty. fd-level capture (pluto/_fd_capture.py)
+    fixes this; this test pins the full path: pre-bound handler → fd pipe →
+    sync store → upload → /api/runs/logs.
+
+    The handler is bound to an explicitly fd-2-backed stream because under
+    pytest sys.stderr is a capture object that does not write to fd 2 —
+    outside pytest this is exactly `logging.StreamHandler()`.
+    """
+    sentinel = f'titan-e2e-{uuid.uuid4().hex[:12]}'
+    pre_bound = io.TextIOWrapper(io.FileIO(2, 'w', closefd=False), write_through=True)
+    handler = logging.StreamHandler(pre_bound)
+    handler.setFormatter(logging.Formatter('[titan] %(message)s'))
+    titan_logger = logging.getLogger('e2e_titan_repro')
+    titan_logger.propagate = False
+    titan_logger.setLevel(logging.INFO)
+    titan_logger.addHandler(handler)
+    try:
+        run = pluto.init(project=TESTING_PROJECT_NAME, name=get_task_name(), config={})
+        run_id = run.settings._op_id
+        titan_logger.info(f'step: 10  loss: 2.31  {sentinel}')
+        run.finish()
+    finally:
+        titan_logger.removeHandler(handler)
+
+    messages = _poll_console_messages(run_id, sentinel)
+    assert any(sentinel in msg for msg in messages), (
+        f'pre-init logging handler line ({sentinel}) never reached the '
+        f'server; got {len(messages)} console lines'
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -12,7 +12,9 @@ Requires:
 
 import importlib.util
 import io
-import logging
+import os
+import subprocess
+import sys
 import time
 import uuid
 from typing import Callable, List, TypeVar
@@ -423,36 +425,66 @@ def test_e2e_console_logs():
     )
 
 
-def test_e2e_pre_init_logging_handler_console_logs():
-    """torchtitan scenario: a logging.StreamHandler bound to fd 2 BEFORE
-    pluto.init() must still have its output reach the server.
+# Faithful torchtitan repro, run as a real subprocess: the logging handler
+# binds sys.stderr at process start (init_logger), pluto.init() comes later
+# (inside WandBLogger in the real job), and training output goes through
+# logging — never bare print(). Run in a fresh interpreter so real fds are
+# in play (under pytest, sys.stderr is a capture object detached from fd 2)
+# and no state leaks between xdist worker tests.
+_TITAN_SCRIPT = """
+import logging, os, sys
 
-    Frameworks like torchtitan call init_logger() at process start;
-    CPython's StreamHandler binds the stream object at construction, so the
-    old sys-swap console capture never saw those writes and the run's
-    console section stayed empty. fd-level capture (pluto/_fd_capture.py)
-    fixes this; this test pins the full path: pre-bound handler → fd pipe →
-    sync store → upload → /api/runs/logs.
+# 1. torchtitan tools/logging.py init_logger(): runs before anything else
+#    and binds the current sys.stderr object into the handler.
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter('[titan] %(message)s'))
+logger.addHandler(handler)
 
-    The handler is bound to an explicitly fd-2-backed stream because under
-    pytest sys.stderr is a capture object that does not write to fd 2 —
-    outside pytest this is exactly `logging.StreamHandler()`.
+# 2. pluto.init() happens later (via the wandb compat inside WandBLogger).
+import pluto
+run = pluto.init(project=os.environ['E2E_PROJECT'], name=os.environ['E2E_NAME'])
+with open(os.environ['E2E_RUN_ID_FILE'], 'w') as f:
+    f.write(str(run.settings._op_id))
+
+# 3. All training output goes through logging -> the pre-bound handler.
+logger.info('step: 10  loss: 2.31  ' + os.environ['E2E_SENTINEL'])
+run.finish()
+"""
+
+
+def test_e2e_pre_init_logging_handler_console_logs(tmp_path):
+    """torchtitan scenario: logging configured BEFORE pluto.init() must
+    still have its output reach the server.
+
+    CPython's StreamHandler stores the sys.stderr object at construction,
+    so the old sys-swap console capture never saw these writes and the
+    run's console section stayed empty. fd-level capture
+    (pluto/_fd_capture.py) fixes this; this test pins the full path:
+    pre-bound handler → fd pipe → sync store → upload → /api/runs/logs.
     """
     sentinel = f'titan-e2e-{uuid.uuid4().hex[:12]}'
-    pre_bound = io.TextIOWrapper(io.FileIO(2, 'w', closefd=False), write_through=True)
-    handler = logging.StreamHandler(pre_bound)
-    handler.setFormatter(logging.Formatter('[titan] %(message)s'))
-    titan_logger = logging.getLogger('e2e_titan_repro')
-    titan_logger.propagate = False
-    titan_logger.setLevel(logging.INFO)
-    titan_logger.addHandler(handler)
-    try:
-        run = pluto.init(project=TESTING_PROJECT_NAME, name=get_task_name(), config={})
-        run_id = run.settings._op_id
-        titan_logger.info(f'step: 10  loss: 2.31  {sentinel}')
-        run.finish()
-    finally:
-        titan_logger.removeHandler(handler)
+    run_id_file = tmp_path / 'run_id'
+    env = {
+        **os.environ,
+        'E2E_PROJECT': TESTING_PROJECT_NAME,
+        'E2E_NAME': get_task_name(),
+        'E2E_SENTINEL': sentinel,
+        'E2E_RUN_ID_FILE': str(run_id_file),
+    }
+    proc = subprocess.run(
+        [sys.executable, '-c', _TITAN_SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert proc.returncode == 0, (
+        f'titan-style subprocess failed (rc={proc.returncode}):\n'
+        f'stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}'
+    )
+    run_id = int(run_id_file.read_text())
 
     messages = _poll_console_messages(run_id, sentinel)
     assert any(sentinel in msg for msg in messages), (

--- a/tests/test_fd_capture.py
+++ b/tests/test_fd_capture.py
@@ -1,0 +1,303 @@
+"""
+Unit tests for pluto._fd_capture.FdCapture — fd-level console capture.
+
+Why fd-level capture exists: frameworks like torchtitan configure a
+logging.StreamHandler at process start, BEFORE pluto.init() runs. CPython's
+StreamHandler binds the sys.stderr *object* at construction, so pluto's
+sys.stdout/sys.stderr swap (pluto.log.setup_logger_file) never sees those
+writes — they go straight to fd 2 and the run's console section on the
+server stays empty. Capturing at the file-descriptor level (dup2 tee, the
+same approach as wandb's console="redirect") catches output regardless of
+which Python object — or C extension — wrote it.
+
+These tests intentionally exercise the REAL fds 1/2. pytest's default
+capture is fd-level too and RE-dup2s the fds between the setup and call
+phases (that's how it attributes output per phase) — which silently unwires
+any FdCapture started inside a fixture. So captures here are always started
+and stopped inside the test body, via context-manager helpers.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import logging
+import os
+import sys
+import time
+from types import SimpleNamespace
+from unittest import mock
+
+from pluto._fd_capture import FdCapture
+
+
+class FakeSyncManager:
+    """Collects enqueue_console_batch calls like tests/test_log_console_handler.py."""
+
+    def __init__(self):
+        self.batches: list[list[tuple]] = []
+
+    def enqueue_console_batch(self, lines):
+        self.batches.append(list(lines))
+
+    @property
+    def lines(self) -> list[str]:
+        return [line for batch in self.batches for (line, *_rest) in batch]
+
+
+@contextlib.contextmanager
+def capture_fd(fd: int, level: int, sanitizer=None):
+    sm = FakeSyncManager()
+    cap = FdCapture(fd=fd, level=level, sync_manager=sm, sanitizer=sanitizer)
+    cap.start()
+    try:
+        yield cap, sm
+    finally:
+        cap.stop()  # idempotent — tests may have stopped already
+
+
+def _fd2_bound_text_stream() -> io.TextIOWrapper:
+    """A text stream permanently bound to fd 2 — what a logging.StreamHandler
+    holds after binding sys.stderr at import time."""
+    return io.TextIOWrapper(io.FileIO(2, 'w', closefd=False), write_through=True)
+
+
+class TestTheTorchtitanBug:
+    def test_logging_handler_bound_to_fd_before_capture_is_captured(self):
+        """THE bug: a StreamHandler created before capture starts must still
+        have its output reach the sync manager. This is torchtitan's
+        init_logger() → wandb.init() ordering."""
+        handler = logging.StreamHandler(_fd2_bound_text_stream())
+        log = logging.getLogger('test_fdcap_titan_repro')
+        log.propagate = False
+        log.setLevel(logging.INFO)
+        log.addHandler(handler)
+        try:
+            with capture_fd(2, logging.ERROR) as (cap, sm):
+                log.info('step: 10  loss: 2.31')
+                cap.stop()
+        finally:
+            log.removeHandler(handler)
+        assert any('step: 10  loss: 2.31' in line for line in sm.lines)
+
+    def test_raw_os_write_is_captured(self):
+        with capture_fd(2, logging.ERROR) as (cap, sm):
+            os.write(2, b'raw fd write\n')
+            cap.stop()
+        assert any('raw fd write' in line for line in sm.lines)
+
+
+class TestTeeToOriginalDestination:
+    def test_output_still_reaches_original_fd(self, capfd):
+        """Capture must tee, not swallow — the terminal (here: pytest's
+        capture file) keeps receiving everything."""
+        with capture_fd(1, logging.INFO) as (cap, sm):
+            os.write(1, b'tee me\n')
+            cap.stop()
+        assert 'tee me' in capfd.readouterr().out
+        assert any('tee me' in line for line in sm.lines)
+
+
+class TestStopSemantics:
+    def test_stop_restores_fd_and_stops_enqueueing(self):
+        with capture_fd(2, logging.ERROR) as (cap, sm):
+            os.write(2, b'during\n')
+            cap.stop()
+            os.write(2, b'after\n')
+            time.sleep(0.05)
+        assert any('during' in line for line in sm.lines)
+        assert not any('after' in line for line in sm.lines)
+
+    def test_stop_flushes_pending_partial_line(self):
+        with capture_fd(2, logging.ERROR) as (cap, sm):
+            os.write(2, b'no-trailing-newline')
+            cap.stop()
+        assert any('no-trailing-newline' in line for line in sm.lines)
+
+    def test_stop_is_idempotent(self):
+        with capture_fd(2, logging.ERROR) as (cap, sm):
+            os.write(2, b'once\n')
+            cap.stop()
+            cap.stop()
+        assert sum('once' in line for line in sm.lines) == 1
+
+    def test_start_after_stop_is_a_noop(self):
+        """One capture instance = one lifecycle; Op re-init builds new ones."""
+        with capture_fd(2, logging.ERROR) as (cap, sm):
+            cap.stop()
+            cap.start()
+            os.write(2, b'zombie\n')
+            cap.stop()
+        assert not any('zombie' in line for line in sm.lines)
+
+
+class TestLineHandling:
+    def test_partial_writes_coalesce_into_one_line(self):
+        with capture_fd(2, logging.ERROR) as (cap, sm):
+            os.write(2, b'abc')
+            os.write(2, b'def')
+            os.write(2, b'ghi\n')
+            cap.stop()
+        assert any(line.endswith('abcdefghi') for line in sm.lines)
+        assert not any(line.endswith('abc') for line in sm.lines)
+
+    def test_empty_lines_are_skipped(self):
+        with capture_fd(2, logging.ERROR) as (cap, sm):
+            os.write(2, b'one\n\ntwo\n')
+            cap.stop()
+        assert any('one' in line for line in sm.lines)
+        assert any('two' in line for line in sm.lines)
+        assert '' not in sm.lines
+
+    def test_non_utf8_bytes_do_not_crash(self):
+        with capture_fd(2, logging.ERROR) as (cap, sm):
+            os.write(2, b'bad \xff\xfe bytes\n')
+            cap.stop()
+        assert any('bad' in line and 'bytes' in line for line in sm.lines)
+
+    def test_tuple_shape_matches_console_handler_contract(self):
+        """(message, log_type, timestamp_ms, line_number) — same contract as
+        pluto.log.ConsoleHandler / SyncProcessManager.enqueue_console_batch."""
+        with capture_fd(2, logging.ERROR) as (cap, sm):
+            os.write(2, b'first\nsecond\n')
+            cap.stop()
+        rows = [
+            row
+            for batch in sm.batches
+            for row in batch
+            if row[0].endswith(('first', 'second'))
+        ]
+        assert len(rows) == 2
+        for message, log_type, timestamp_ms, line_number in rows:
+            assert log_type == 'ERROR'  # fd 2 capture logs at ERROR
+            assert isinstance(timestamp_ms, int) and timestamp_ms > 0
+            assert isinstance(line_number, int)
+        assert rows[1][3] == rows[0][3] + 1  # line numbers increase
+
+
+class TestRankPrefix:
+    def test_rank_env_var_prefixes_captured_lines(self, monkeypatch, capfd):
+        monkeypatch.setenv('RANK', '3')
+        with capture_fd(2, logging.ERROR) as (cap, sm):
+            os.write(2, b'starting fit\n')
+            cap.stop()
+        assert '[rank3] starting fit' in sm.lines
+        # tee stays unprefixed — torchrun adds its own [defaultN]: prefix
+        assert '[rank3]' not in capfd.readouterr().err
+
+    def test_no_rank_env_var_means_no_prefix(self, monkeypatch):
+        monkeypatch.delenv('RANK', raising=False)
+        with capture_fd(2, logging.ERROR) as (cap, sm):
+            os.write(2, b'hello\n')
+            cap.stop()
+        assert 'hello' in sm.lines
+
+
+class TestSanitizer:
+    def test_sanitizer_runs_on_captured_lines(self):
+        sanitizer = mock.MagicMock()
+        sanitizer.sanitize.side_effect = lambda s: s.replace('mlpi_secret', '***')
+        with capture_fd(2, logging.ERROR, sanitizer=sanitizer) as (cap, sm):
+            os.write(2, b'api_key=mlpi_secret here\n')
+            cap.stop()
+        assert any('api_key=*** here' in line for line in sm.lines)
+        assert not any('mlpi_secret' in line for line in sm.lines)
+
+
+def _fake_settings(tmp_path, fd_capture=True):
+    return SimpleNamespace(
+        tag='pluto-fdcap-test',
+        mode='perf',
+        sanitize_logs=False,
+        x_console_fd_capture=fd_capture,
+        get_dir=lambda: str(tmp_path),
+    )
+
+
+@contextlib.contextmanager
+def _logger_env(tmp_path, name, fd_capture=True):
+    """setup_logger_file + guaranteed teardown, all inside the call phase."""
+    from pluto.log import setup_logger_file, teardown_logger
+
+    sm = FakeSyncManager()
+    log = logging.getLogger(f'test_fdcap_{name}')
+    console = logging.getLogger(f'test_fdcap_{name}_console')
+    log.handlers.clear()
+    console.handlers.clear()
+    saved_stdout, saved_stderr = sys.stdout, sys.stderr
+    try:
+        setup_logger_file(
+            _fake_settings(tmp_path, fd_capture), log, console, sync_manager=sm
+        )
+        yield sm, log, console
+    finally:
+        teardown_logger(log, console=console)
+        # teardown_logger restores to import-time streams; put back what
+        # pytest had so later tests see the exact same objects.
+        sys.stdout, sys.stderr = saved_stdout, saved_stderr
+
+
+class TestSetupLoggerFileIntegration:
+    """setup_logger_file wires fd capture in and prevents double-enqueue."""
+
+    def test_pre_bound_handler_output_is_enqueued(self, tmp_path):
+        from pluto.log import _stop_fd_captures
+
+        handler = logging.StreamHandler(_fd2_bound_text_stream())
+        titan = logging.getLogger('test_fdcap_setup_titan')
+        titan.propagate = False
+        titan.setLevel(logging.INFO)
+        titan.addHandler(handler)
+        try:
+            with _logger_env(tmp_path, 'pre_bound') as (sm, _log, _console):
+                titan.info('loss: 1.23')
+                _stop_fd_captures()
+        finally:
+            titan.removeHandler(handler)
+        assert any('loss: 1.23' in line for line in sm.lines)
+
+    def test_print_is_enqueued_exactly_once(self, tmp_path):
+        """Exactly one layer owns each stream's enqueue duty. When sys.stdout
+        is fd-backed the fd layer owns it (wrapper enqueue disabled); when it
+        isn't — Jupyter's ZMQ stream, pytest's capture object (this test) —
+        the wrapper keeps enqueueing since the fd pipe never sees the write.
+        Either way a printed line must reach the sync manager exactly once."""
+        from pluto.log import _stop_fd_captures
+
+        with _logger_env(tmp_path, 'print_once') as (sm, _log, _console):
+            print('exactly-once-sentinel')
+            _stop_fd_captures()
+        assert sum('exactly-once-sentinel' in line for line in sm.lines) == 1
+
+    def test_console_logger_does_not_propagate(self, tmp_path):
+        """Captured lines re-emitted through root handlers would loop back
+        into the fd capture (root handler → old stderr → fd 2 → pipe)."""
+        with _logger_env(tmp_path, 'propagate') as (_sm, _log, console):
+            assert console.propagate is False
+
+    def test_teardown_stops_captures(self, tmp_path):
+        from pluto.log import _fd_captures
+
+        with _logger_env(tmp_path, 'teardown') as (sm, _log, _console):
+            assert len(_fd_captures) == 2
+        # _logger_env's finally ran teardown_logger
+        from pluto.log import _fd_captures as after
+
+        assert after == []
+        os.write(2, b'post-teardown\n')
+        time.sleep(0.05)
+        assert not any('post-teardown' in line for line in sm.lines)
+
+    def test_flag_off_falls_back_to_wrapper_enqueue(self, tmp_path):
+        """x_console_fd_capture=False keeps the legacy sys-swap capture."""
+        from pluto.log import _fd_captures
+
+        with _logger_env(tmp_path, 'flag_off', fd_capture=False) as (
+            sm,
+            _log,
+            _console,
+        ):
+            assert _fd_captures == []
+            print('legacy-path-sentinel')
+            sys.stdout.flush()
+        assert any('legacy-path-sentinel' in line for line in sm.lines)

--- a/tests/test_fd_capture.py
+++ b/tests/test_fd_capture.py
@@ -288,6 +288,37 @@ class TestSetupLoggerFileIntegration:
         time.sleep(0.05)
         assert not any('post-teardown' in line for line in sm.lines)
 
+    def test_flush_console_buffers_drains_capture_before_sync_stops(self, tmp_path):
+        """Op.finish() must be able to push pending console lines into the
+        sync store BEFORE the sync manager drains and stops. Lines that are
+        still sitting in the fd reader's batch buffer (up to 0.2s of output)
+        when finish() is called would otherwise be enqueued at
+        teardown_logger time — after the uploader is gone — and sit in
+        SQLite forever. Caught in CI: the torchtitan e2e sentinel logged
+        immediately before finish() never reached the server on 3.10/3.11.
+        """
+        from pluto.log import flush_console_buffers
+
+        with _logger_env(tmp_path, 'flush_before_stop') as (sm, _log, _console):
+            os.write(2, b'logged-right-before-finish\n')
+            flush_console_buffers()
+            assert any('logged-right-before-finish' in line for line in sm.lines)
+
+    def test_flush_console_buffers_drains_wrapper_path_too(self, tmp_path):
+        """Same guarantee for the legacy sys-swap path (fd capture off):
+        a ConsoleHandler batch buffered within its flush interval must reach
+        the sync store when flush_console_buffers() runs."""
+        from pluto.log import flush_console_buffers
+
+        with _logger_env(tmp_path, 'flush_wrapper', fd_capture=False) as (
+            sm,
+            _log,
+            _console,
+        ):
+            print('wrapper-line-before-finish')
+            flush_console_buffers()
+            assert any('wrapper-line-before-finish' in line for line in sm.lines)
+
     def test_flag_off_falls_back_to_wrapper_enqueue(self, tmp_path):
         """x_console_fd_capture=False keeps the legacy sys-swap capture."""
         from pluto.log import _fd_captures


### PR DESCRIPTION
## Problem

Console logs never reach the server for any job that configures Python `logging` before `pluto.init()` runs — which is every torchtitan run (and most torch trainers): metrics duplex fine, but the run's console section stays empty even though the same output shows up in wandb.

Root cause: console capture worked by swapping the `sys.stdout`/`sys.stderr` **variables** at init time. CPython's `logging.StreamHandler` stores `self.stream = sys.stderr` at handler construction, so a handler created before init keeps writing to the raw fd and completely bypasses the swap. wandb doesn't have this problem because its default console mode captures at the file-descriptor level.

Repro (torchtitan ordering):
1. `init_logger()` → `logging.StreamHandler()` binds the original stderr object
2. `wandb.init()` → pluto compat → `pluto.init()` swaps `sys.stdout`/`sys.stderr`
3. every `logger.info(...)` line goes to the old stream object → raw fd → never captured

## Fix

New `pluto/_fd_capture.py` — fd-level capture (the wandb `console="redirect"` approach): `dup2` a pipe over fds 1/2; a daemon reader thread tees every byte back to the real fd (terminal stays live) and line-buffers the captured copy into the sync process, with the same batch tuple contract, `[rankN]` prefixing, and secret sanitization as `ConsoleHandler`. Catches logging handlers, C extensions, and forked children that inherit the fd.

Wiring in `pluto/log.py`:
- `setup_logger_file` starts captures when a sync manager is present; any OS-level failure falls back to the legacy swap (`x_console_fd_capture=False` forces the fallback).
- The `ConsoleHandler` wrappers stay (prompt Python-level flushing + local `sys.log`), but exactly **one** layer enqueues per stream: the fd layer owns a stream only if that stream actually writes to the captured fd. Jupyter's ZMQ `OutStream` never touches fd 1, so there the wrapper keeps enqueueing — no notebook regression.
- `console` logger gets `propagate=False`: captured lines re-emitted through user root handlers would otherwise feed back into the capture pipe.

Shutdown is deadlock-safe for DDP: `stop()` writes a sentinel into the pipe for a deterministic flush (written from a helper thread so a wedged pipe can't hang `finish()`), restores the fd, and leaves the daemon reader in tee-only drain mode so DataLoader workers holding inherited pipe write ends never block on a full pipe.

## Testing

- 19 new tests in `tests/test_fd_capture.py` (TDD), including the exact torchtitan repro: a `StreamHandler` bound to fd 2 before capture starts is enqueued. Note: captures are started inside test bodies, not fixtures — pytest re-`dup2`s fds 1/2 between setup and call phases, which silently unwires fixture-started redirection.
- Verified nested inside real wandb 0.27.2's own redirect (offline mode): a pre-bound handler line and a plain `print` each reach Pluto exactly once, terminal output intact, and wandb's captured console is byte-identical to a control run without pluto.
- `ruff` + `mypy` clean; existing console-handler tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process-global fds 1/2 and threading at init/shutdown; mitigated by soft fallback, single-enqueue logic, and non-blocking stop semantics, but regressions could affect console upload or terminal output in notebooks, pytest, or multi-process training.
> 
> **Overview**
> Fixes empty run console sections when trainers configure `logging.StreamHandler` **before** `pluto.init()` (e.g. torchtitan): those handlers keep writing to the raw stderr fd and bypass the existing `sys.stdout`/`sys.stderr` swap.
> 
> Adds **`FdCapture`** (`pluto/_fd_capture.py`) — `dup2` tee on fds 1/2 with a daemon reader that forwards bytes to the real terminal and batches lines into `enqueue_console_batch` (same contract, rank prefix, sanitization as `ConsoleHandler`). Shutdown uses a pipe sentinel and bounded wait so `finish()`/DDP paths don’t hang; the reader stays in tee-only drain mode for forked workers.
> 
> **`setup_logger_file`** starts fd capture when a sync manager exists (opt out via **`x_console_fd_capture`** on `Settings`, default on), disables duplicate upload by giving only one layer enqueue duty per stream, sets **`console.propagate = False`** to avoid capture feedback loops, and **`teardown_logger`** stops captures. Legacy wrapper capture remains as fallback when fd capture fails or the flag is off.
> 
> **19 tests** in `tests/test_fd_capture.py` cover the torchtitan repro, tee, stop/flush, and integration wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95ee4445c0734ad33d4e9dabfc733c2bf22add00. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->