### PR TITLE
feat(query): add step_min/step_max to get_metrics

### DIFF
--- a/docs-api/query.mdx
+++ b/docs-api/query.mdx
@@ -144,6 +144,10 @@ finer resolution within it.
 
 **Returns:** `Any` — `pandas.DataFrame` or `list[dict]`.
 
+**Raises:**
+
+- `ValueError` — If a step bound is negative, or `step_min` exceeds `step_max`.
+
 #### `Client.get_statistics`
 
 ```python

--- a/docs-api/query.mdx
+++ b/docs-api/query.mdx
@@ -113,6 +113,8 @@ get_metrics(
     run_id: Union[int, str],
     metric_names: Optional[List[str]] = None,
     limit: int = 10000,
+    step_min: Optional[int] = None,
+    step_max: Optional[int] = None,
 ) -> Any
 ```
 
@@ -125,12 +127,20 @@ When *pandas* is installed the return value is a
 `~pandas.DataFrame` with columns `metric`, `step`,
 `value`, `time`. Otherwise a list of dicts is returned.
 
+`step_min` / `step_max` scope the query to a step window instead
+of pulling the whole series — useful for zooming in around a spike or
+anomaly (e.g. `step_min=4000, step_max=4500`). Because the server
+samples down to `limit` points, narrowing the range also gives you
+finer resolution within it.
+
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `project` | `str` | Project name. |
 | `run_id` | `Union[int, str]` | Numeric server ID (`int`) or display ID string (e.g. `"MMP-1"`). |
 | `metric_names` | `Optional[List[str]]` | Metric names to fetch. `None` fetches all. |
 | `limit` | `int` | Max data points per metric (max 10 000). |
+| `step_min` | `Optional[int]` | Lowest step to return, **inclusive**. `None` for no lower bound. |
+| `step_max` | `Optional[int]` | Highest step to return, **inclusive**. `None` for no upper bound. |
 
 **Returns:** `Any` — `pandas.DataFrame` or `list[dict]`.
 
@@ -328,10 +338,16 @@ get_metrics(
     run_id: Union[int, str],
     metric_names: Optional[List[str]] = None,
     limit: int = 10000,
+    step_min: Optional[int] = None,
+    step_max: Optional[int] = None,
 ) -> Any
 ```
 
 Fetch metric data. See `Client.get_metrics`.
+
+`step_min` / `step_max` are **inclusive** bounds that scope the query
+to a step window (e.g. `step_min=4000, step_max=4500`) instead of
+pulling the full series.
 
 ---
 

--- a/pluto/query.py
+++ b/pluto/query.py
@@ -381,7 +381,30 @@ class Client:
 
         Returns:
             ``pandas.DataFrame`` or ``list[dict]``.
+
+        Raises:
+            ValueError: If a step bound is negative, or ``step_min`` exceeds
+                ``step_max``.
         """
+        # Validate before touching the network — _resolve_run_id() below can
+        # itself issue a request for a display-ID, so checking here means an
+        # obviously-bad range costs zero round-trips.
+        #
+        # The reversed-range check is the important one: the server validates
+        # each bound independently (int >= 0) but does NOT check that min <= max,
+        # so `step_min=100, step_max=50` is accepted, matches no rows, and comes
+        # back as an empty result with no error — a silently wrong answer. Fail
+        # loudly instead. (Negative bounds the server would reject with a 400;
+        # catching them here just makes the message immediate and clearer.)
+        if step_min is not None and step_min < 0:
+            raise ValueError(f'step_min must be non-negative, got {step_min}')
+        if step_max is not None and step_max < 0:
+            raise ValueError(f'step_max must be non-negative, got {step_max}')
+        if step_min is not None and step_max is not None and step_min > step_max:
+            raise ValueError(
+                f'step_min ({step_min}) cannot be greater than step_max ({step_max})'
+            )
+
         params: Dict[str, Any] = {
             'runId': self._resolve_run_id(project, run_id),
             'projectName': project,

--- a/pluto/query.py
+++ b/pluto/query.py
@@ -350,6 +350,8 @@ class Client:
         run_id: Union[int, str],
         metric_names: Optional[List[str]] = None,
         limit: int = 10000,
+        step_min: Optional[int] = None,
+        step_max: Optional[int] = None,
     ) -> Any:
         """Fetch time-series metric data for a run.
 
@@ -360,12 +362,22 @@ class Client:
         :class:`~pandas.DataFrame` with columns ``metric``, ``step``,
         ``value``, ``time``. Otherwise a list of dicts is returned.
 
+        ``step_min`` / ``step_max`` scope the query to a step window instead
+        of pulling the whole series — useful for zooming in around a spike or
+        anomaly (e.g. ``step_min=4000, step_max=4500``). Because the server
+        samples down to ``limit`` points, narrowing the range also gives you
+        finer resolution within it.
+
         Args:
             project: Project name.
             run_id: Numeric server ID (``int``) or display ID string
                 (e.g. ``"MMP-1"``).
             metric_names: Metric names to fetch. ``None`` fetches all.
             limit: Max data points per metric (max 10 000).
+            step_min: Lowest step to return, **inclusive**. ``None`` for no
+                lower bound.
+            step_max: Highest step to return, **inclusive**. ``None`` for no
+                upper bound.
 
         Returns:
             ``pandas.DataFrame`` or ``list[dict]``.
@@ -375,6 +387,13 @@ class Client:
             'projectName': project,
             'limit': min(limit, 10000),
         }
+        # Set on the base params (not per-branch) so the multi-metric path
+        # below — which copies these into one request per metric — carries the
+        # bounds too. Omit entirely when unset rather than sending empties.
+        if step_min is not None:
+            params['stepMin'] = step_min
+        if step_max is not None:
+            params['stepMax'] = step_max
 
         if metric_names is not None and len(metric_names) > 1:
             # Endpoint only supports a single logName filter, so fetch
@@ -739,13 +758,22 @@ def get_metrics(
     run_id: Union[int, str],
     metric_names: Optional[List[str]] = None,
     limit: int = 10000,
+    step_min: Optional[int] = None,
+    step_max: Optional[int] = None,
 ) -> Any:
-    """Fetch metric data. See :meth:`Client.get_metrics`."""
+    """Fetch metric data. See :meth:`Client.get_metrics`.
+
+    ``step_min`` / ``step_max`` are **inclusive** bounds that scope the query
+    to a step window (e.g. ``step_min=4000, step_max=4500``) instead of
+    pulling the full series.
+    """
     return _get_client().get_metrics(
         project,
         run_id,
         metric_names=metric_names,
         limit=limit,
+        step_min=step_min,
+        step_max=step_max,
     )
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -509,6 +509,63 @@ class TestGetMetrics:
         params = client._client.get.call_args[1]['params']
         assert 'logName' not in params
 
+    def test_step_range_sent_as_camel_case_params(self, client, mock_response):
+        """step_min/step_max serialize to the endpoint's stepMin/stepMax."""
+        client._client.get.return_value = mock_response(200, {'metrics': []})
+        client.get_metrics(
+            'proj', 42, metric_names=['loss'], step_min=4000, step_max=4500
+        )
+        params = client._client.get.call_args[1]['params']
+        assert params['stepMin'] == 4000
+        assert params['stepMax'] == 4500
+
+    def test_step_range_omitted_when_unset(self, client, mock_response):
+        """Neither bound is sent when not supplied — no empty params."""
+        client._client.get.return_value = mock_response(200, {'metrics': []})
+        client.get_metrics('proj', 42, metric_names=['loss'])
+        params = client._client.get.call_args[1]['params']
+        assert 'stepMin' not in params
+        assert 'stepMax' not in params
+
+    def test_step_range_bounds_are_independent(self, client, mock_response):
+        """Either bound can be given on its own."""
+        client._client.get.return_value = mock_response(200, {'metrics': []})
+        client.get_metrics('proj', 42, step_min=100)
+        params = client._client.get.call_args[1]['params']
+        assert params['stepMin'] == 100
+        assert 'stepMax' not in params
+
+        client._client.get.reset_mock()
+        client._client.get.return_value = mock_response(200, {'metrics': []})
+        client.get_metrics('proj', 42, step_max=900)
+        params = client._client.get.call_args[1]['params']
+        assert params['stepMax'] == 900
+        assert 'stepMin' not in params
+
+    def test_step_range_applied_to_every_multi_metric_request(
+        self, client, mock_response
+    ):
+        """The multi-metric path fans out to one request per metric; each one
+        must still carry the bounds (regression guard: setting them only on the
+        single-metric branch would silently drop them here and quietly return
+        the full series)."""
+        client._client.get.side_effect = [
+            mock_response(200, {'metrics': [{'logName': 'loss', 'step': 4000}]}),
+            mock_response(200, {'metrics': [{'logName': 'acc', 'step': 4000}]}),
+        ]
+        client.get_metrics(
+            'proj', 42, metric_names=['loss', 'acc'], step_min=4000, step_max=4500
+        )
+
+        assert client._client.get.call_count == 2
+        for call in client._client.get.call_args_list:
+            params = call[1]['params']
+            assert params['stepMin'] == 4000
+            assert params['stepMax'] == 4500
+        # ...and each request still targets its own metric.
+        sent = [c[1]['params']['logName'] for c in client._client.get.call_args_list]
+        assert sent == ['loss', 'acc']
+
     def test_empty_returns_empty_dataframe(self, client, mock_response):
         client._client.get.return_value = mock_response(200, {'metrics': []})
         result = client.get_metrics('proj', 42)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -566,6 +566,33 @@ class TestGetMetrics:
         sent = [c[1]['params']['logName'] for c in client._client.get.call_args_list]
         assert sent == ['loss', 'acc']
 
+    def test_negative_step_bounds_rejected(self, client):
+        """Negative bounds fail fast client-side (the server would 400)."""
+        with pytest.raises(ValueError, match='step_min must be non-negative'):
+            client.get_metrics('proj', 42, step_min=-1)
+        with pytest.raises(ValueError, match='step_max must be non-negative'):
+            client.get_metrics('proj', 42, step_max=-1)
+        client._client.get.assert_not_called()
+
+    def test_reversed_step_range_rejected(self, client):
+        """step_min > step_max raises instead of silently returning nothing.
+
+        The server validates each bound independently but not their ordering,
+        so a reversed range would match no rows and come back as an empty
+        result with no error — a silently wrong answer.
+        """
+        with pytest.raises(ValueError, match='cannot be greater than'):
+            client.get_metrics('proj', 42, step_min=100, step_max=50)
+        client._client.get.assert_not_called()
+
+    def test_equal_step_bounds_allowed(self, client, mock_response):
+        """step_min == step_max is a valid single-step window."""
+        client._client.get.return_value = mock_response(200, {'metrics': []})
+        client.get_metrics('proj', 42, step_min=42, step_max=42)
+        params = client._client.get.call_args[1]['params']
+        assert params['stepMin'] == 42
+        assert params['stepMax'] == 42
+
     def test_empty_returns_empty_dataframe(self, client, mock_response):
         client._client.get.return_value = mock_response(200, {'metrics': []})
         result = client.get_metrics('proj', 42)


### PR DESCRIPTION
## Why

`GET /api/runs/metrics` already accepts inclusive step-range bounds, and the **MCP server** already exposes them (`step_min`/`step_max` on its `query_metrics` / `visualize_metrics` tools, added in server-private#381). **The Python SDK is the only client that never got them.**

So an AI assistant over MCP can ask for *"train/loss between steps 4000–4500"*, but a user's analysis script or notebook can't — even though the endpoint supports it. This is a **parity gap, not a new feature**.

> **Naming trap that caused this to be missed:** server-private#381 says it updated "the Python client" — that's the MCP server's internal `PlutoClient` (`mcp/src/pluto_mcp_server/api_client.py`), *not* this SDK. Two different Python things with confusingly similar names.

**Verified against the server** (`runs-openapi.ts`, the `/metrics` route):
```ts
stepMin: z.coerce.number().int().min(0).optional()  // "Minimum step number (inclusive)"
stepMax: z.coerce.number().int().min(0).optional()  // "Maximum step number (inclusive)"
```
…so camelCase, integers ≥ 0, **inclusive** — a real, supported contract, not a silent no-op.

## What changed

`pluto/query.py` — two places:
- **`Client.get_metrics`** — new optional `step_min` / `step_max` (inclusive `int`s), serialized as the endpoint's **`stepMin`** / **`stepMax`**, and **only sent when set** (no empty params).
- **the module-level `get_metrics` wrapper** — same params, delegated through.

Docstrings updated on both (inclusive bounds; useful for scoping to a window around a spike/anomaly instead of pulling the whole series — and since the server samples down to `limit` points, narrowing the range also gives finer resolution within it). `docs-api/query.mdx` regenerated (it's generated from the docstrings and CI verifies it's in sync).

```python
pq.get_metrics("my-project", 42, metric_names=["train/loss"],
               step_min=4000, step_max=4500)
```

## Validation (from PR review)

Two guards, run **before** `_resolve_run_id()` so a bad range costs **zero network round-trips**:

- **`step_min > step_max` → `ValueError`.** This is the important one. The server validates each bound *independently* (`int >= 0`) but has **no `.refine()` tying them together** — so a reversed range was **accepted**, matched no rows, and came back as an **empty result with no error**. A silently wrong answer. Now it fails loudly.
- **Negative bounds → `ValueError`.** The server would reject these with a 400 anyway; catching them locally just makes the failure immediate and the message clearer. This matches the existing house style stated in `query.py`: *"the client does a light structural check so obvious mistakes fail fast with a clear `ValueError` instead of an HTTP 400."*

`step_min == step_max` remains valid (a single-step window).

## One subtlety worth calling out

`get_metrics` **fans out to one HTTP request per metric** when `metric_names` has 2+ entries (the endpoint only supports a *single* `logName` filter, so the client loops and merges). The step bounds are therefore set on the **base `params` dict**, *not* inside one branch — if they were only added on the single-metric path, the multi-metric path would **silently drop them** and quietly return the **full series** with no error. There's an explicit regression test asserting every request in the fan-out carries the bounds.

## Tests (`tests/test_query.py::TestGetMetrics`) — 7 new

- `step_min=4000, step_max=4500` → `stepMin=4000` / `stepMax=4500` in the outgoing params
- omitted when unset → neither param is sent
- each bound works independently (only-min, only-max)
- **every** request in the multi-metric fan-out carries the bounds (and still targets its own metric)
- negative bounds rejected; reversed range rejected; **no HTTP request issued** in either rejection case
- equal bounds (`step_min == step_max`) allowed

Ruff + mypy clean.

## Scope

Just `get_metrics`. Deliberately **not** touching `get_statistics` / `compare_runs` — the MCP equivalents don't have step bounds either, so that stays as-is for now.

## Downstream

`docs/pluto/querying-runs.mdx` (Konduktor) documents `get_metrics(project, run_id, metric_names=None)` with no step args — deliberately, since they didn't exist. Once this merges, those docs can be updated to add them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
