### PR TITLE
chore: bump version to 0.0.27

### DIFF
--- a/pluto/__init__.py
+++ b/pluto/__init__.py
@@ -41,7 +41,7 @@ __all__ = (
     'generate_run_id',
 )
 
-__version__ = '0.0.26'
+__version__ = '0.0.27'
 
 
 # Replaced with the current commit when building the wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pluto-ml"
-version = "0.0.26"
+version = "0.0.27"
 description = "Pluto ML - Machine Learning Operations Framework"
 packages = [
     {include = "pluto"},


### PR DESCRIPTION
## Summary
- Bump version from 0.0.26 to 0.0.27 in `pyproject.toml` and `pluto/__init__.py`

## Test plan
- N/A (version bump only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ef98oSYknpnJAerGEFad4M)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no logic, API, or dependency changes.
> 
> **Overview**
> Bumps the **pluto-ml** release from `0.0.26` to **0.0.27** in `pyproject.toml` (Poetry package version) and `pluto/__init__.py` (`__version__`), keeping runtime and packaging version strings aligned for the next publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d79009c1492ca7bbf25c2d848725b90efb0496fb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->