### PR TITLE
chore: regenerate API docs for 0.0.27

### DIFF
--- a/docs-api/meta.json
+++ b/docs-api/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "package": "pluto",
-  "package_version": "0.0.26",
+  "package_version": "0.0.27",
   "public_api": [
     "Artifact",
     "Audio",


### PR DESCRIPTION
## Summary
- Regenerate `docs-api/meta.json` (`package_version` 0.0.26 → 0.0.27) so it matches `pluto.__version__` after #137
- Fixes the `check` CI job on `main`, which was left red because #137 was merged without regenerating docs

## Test plan
- `python scripts/gen_api_docs.py --check` passes locally

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ef98oSYknpnJAerGEFad4M)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field in generated documentation; no runtime, auth, or API behavior changes.
> 
> **Overview**
> Updates **`docs-api/meta.json`** so **`package_version`** is **0.0.27**, matching **`pluto.__version__`** after the release bump in #137.
> 
> This is a generated-docs-only change (no API surface edits in this diff) and restores the **`python scripts/gen_api_docs.py --check`** CI gate on **`main`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eab80f94a5133f467a1a8d70c3f024cd53df8b2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->