### PR TITLE
fix(sweep,sync): correct optuna install hint + drop false "0 records" warning

### DIFF
--- a/pluto/op.py
+++ b/pluto/op.py
@@ -1164,12 +1164,18 @@ class Op:
                         wait=True,
                     )
                     if not sync_completed:
+                        # stop() SIGTERMs the sync process on timeout, and its
+                        # unthrottled drain usually empties the queue before we
+                        # read the count here — so only warn when records are
+                        # genuinely still unsent (avoids a contradictory
+                        # "0 records may not have been uploaded").
                         pending = self._sync_manager.get_pending_count()
-                        logger.warning(
-                            f'{tag}: Sync did not complete within timeout, '
-                            f'{pending} records may not have been uploaded. '
-                            f'Data is preserved in {self._sync_manager.db_path}'
-                        )
+                        if pending > 0:
+                            logger.warning(
+                                f'{tag}: Sync did not complete within timeout, '
+                                f'{pending} records may not have been uploaded. '
+                                f'Data is preserved in {self._sync_manager.db_path}'
+                            )
                 self._sync_manager.close()
                 self._sync_manager = None
 

--- a/pluto/sweep.py
+++ b/pluto/sweep.py
@@ -491,7 +491,7 @@ def _run_bayes(
     except ImportError:
         raise ImportError(
             "sweep method='bayes' needs optuna — install it with "
-            '`pip install optuna` (or `pip install pluto[sweep]`).'
+            '`pip install optuna` (or `pip install "pluto-ml[sweep]"`).'
         )
     if count is None:
         raise ValueError("method='bayes' needs count=<n> in pluto.agent(...)")

--- a/tests/test_run_status.py
+++ b/tests/test_run_status.py
@@ -408,6 +408,52 @@ class TestTerminalStatusResilience:
         assert settings._op_status == 0
 
 
+class TestFinishDrainWarning:
+    """finish()'s 'records may not have been uploaded' warning must not fire when
+    the SIGTERM drain already emptied the queue (pending == 0) — otherwise it
+    prints a contradictory '0 records may not have been uploaded' that reads like
+    data loss at the moment nothing was lost.
+    """
+
+    def _noop_op(self):
+        from pluto.op import Op
+        from pluto.sets import Settings
+
+        settings = Settings()
+        settings.mode = 'noop'
+        settings.sync_process_enabled = False  # don't spawn a real sync subprocess
+        op = Op(config={}, settings=settings)
+        op.start()
+        return op
+
+    def _warns(self, op):
+        from unittest.mock import patch
+
+        with patch('pluto.op.logger.warning') as warn:
+            op.finish()
+        return ' '.join(str(c.args[0]) for c in warn.call_args_list if c.args)
+
+    def test_no_warning_when_drain_emptied_queue(self):
+        from unittest.mock import MagicMock
+
+        op = self._noop_op()
+        sm = MagicMock()
+        sm.stop.return_value = False  # 30s wait "timed out"
+        sm.get_pending_count.return_value = 0  # but the drain emptied it
+        op._sync_manager = sm
+        assert 'may not have been uploaded' not in self._warns(op)
+
+    def test_warns_when_records_genuinely_pending(self):
+        from unittest.mock import MagicMock
+
+        op = self._noop_op()
+        sm = MagicMock()
+        sm.stop.return_value = False
+        sm.get_pending_count.return_value = 5  # genuinely unsent
+        op._sync_manager = sm
+        assert '5 records may not have been uploaded' in self._warns(op)
+
+
 class TestExcepthookSubprocess:
     """
     End-to-end test: run a script that raises an unhandled exception

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -307,3 +307,15 @@ class TestBayes:
         )
         with pytest.raises(ValueError, match='needs count'):
             pluto.agent(sid, lambda: None)
+
+
+def test_bayes_missing_optuna_names_the_real_package(monkeypatch):
+    # When optuna isn't installed, the hint must point at the real distribution
+    # name (pluto-ml) — NOT `pluto`, which is an unrelated package on PyPI, so
+    # following the wrong hint silently installs someone else's package.
+    monkeypatch.setitem(sys.modules, 'optuna', None)  # makes `import optuna` raise
+    with pytest.raises(ImportError) as exc:
+        sw._run_bayes('sid', {}, None, lambda: None, 1, [], 'loss')
+    msg = str(exc.value)
+    assert 'pluto-ml[sweep]' in msg
+    assert 'pluto[sweep]' not in msg


### PR DESCRIPTION
Two small SDK bugs surfaced in a docs audit of #131. Both are low-risk and don't change how a normal run uploads *during* a run.

## 1. Wrong package name in the optuna install hint (`pluto/sweep.py`)
A missing-optuna `bayes` sweep raised a hint saying `pip install pluto[sweep]`. But the distribution is **`pluto-ml`**, and **`pluto` is a real, unrelated package on PyPI** — so following the hint silently installs *someone else's* package (with an unknown `[sweep]` extra) instead of failing loudly, leaving the user with a foreign package and still no optuna. Fixed to `pip install "pluto-ml[sweep]"`.

## 2. Contradictory "0 records may not have been uploaded" warning (`pluto/op.py`)
On a large run, `finish()`'s wait can time out (`sync_completed=False`), after which `stop()`'s SIGTERM drain empties the queue. `op.py` then read the pending count **after** that drain — so it literally printed `0 records may not have been uploaded`, a data-loss-looking message at the exact moment nothing was lost. Now it only warns when `pending > 0`.

## Tests
- `test_bayes_missing_optuna_names_the_real_package` — the hint names `pluto-ml[sweep]`, not `pluto[sweep]`.
- `TestFinishDrainWarning` — no warning when the drain emptied the queue; still warns when records genuinely remain.

## Not included (deferred)
This does **not** touch the underlying ~30s finish stall (a throttle-vs-shutdown mismatch that predates #131, from #27). That's a separate, more involved change that mostly affects bulk migration of large runs and warrants its own concurrency/load testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and error-message fixes only; no change to upload behavior during normal runs or sweep optimization logic.
> 
> **Overview**
> Fixes two small SDK messaging bugs from a docs audit.
> 
> **Bayes sweep install hint** (`pluto/sweep.py`): When optuna is missing, the `ImportError` now tells users to install `"pluto-ml[sweep]"` instead of `pluto[sweep]`. The old name pointed at a different PyPI package, so following it could install the wrong project and still leave optuna missing.
> 
> **Finish / sync shutdown** (`pluto/op.py`): If sync shutdown times out but the SIGTERM drain already emptied the queue, `finish()` no longer logs that records *may not have been uploaded* when `get_pending_count()` is **0**. The warning still appears when pending records remain.
> 
> Tests cover the optuna message and both drain-warning cases (`TestFinishDrainWarning`, `test_bayes_missing_optuna_names_the_real_package`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2aee2d9270d9900a2cb402f0f4a3e1f942017ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sync shutdowns no longer show timeout warnings when all records are successfully sent.
  - Missing sweep support now displays the correct installation guidance.

- **Tests**
  - Added coverage for accurate pending-record warnings during shutdown.
  - Added regression coverage for the corrected sweep installation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->