### PR TITLE
chore: bump version to 0.0.28

### DIFF
--- a/docs-api/meta.json
+++ b/docs-api/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "package": "pluto",
-  "package_version": "0.0.27",
+  "package_version": "0.0.28",
   "public_api": [
     "Artifact",
     "Audio",

--- a/pluto/__init__.py
+++ b/pluto/__init__.py
@@ -44,7 +44,7 @@ __all__ = (
     'agent',
 )
 
-__version__ = '0.0.27'
+__version__ = '0.0.28'
 
 
 # Replaced with the current commit when building the wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pluto-ml"
-version = "0.0.27"
+version = "0.0.28"
 description = "Pluto ML - Machine Learning Operations Framework"
 packages = [
     {include = "pluto"},


### PR DESCRIPTION
Bumps the package version 0.0.27 → 0.0.28 ahead of the next release.

- `pyproject.toml` — published `pluto-ml` version
- `pluto/__init__.py` — runtime `__version__` (re-exported by `mlop`)
- `docs-api/meta.json` — regenerated

**Why the docs regen is in this PR:** `scripts/gen_api_docs.py` derives `package_version` from `pluto.__version__`, and the `api-docs` workflow runs `--check`, which byte-compares the committed manifest. Bumping the version alone leaves `meta.json` stale and fails that job — which is what happened last cycle, where #137 (bump to 0.0.27) needed the follow-up #138 to regenerate the docs. Folding the regen in keeps this to one PR.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh` — ran the pinned `ruff==0.4.10` directly (`ruff check` + `ruff format --check`) rather than the script, since poetry isn't on PATH in this env. Both clean: "All checks passed", 105 files already formatted. `mypy` was not run.
- [x] `python scripts/gen_api_docs.py --check` passes with the pinned `griffe==2.0.2` from the workflow. The regen changed only the `package_version` line, so nothing else in `docs-api/` had drifted.

No test suite run — this touches no runtime behavior beyond the version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.0.28 across project metadata and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->